### PR TITLE
feat: Add X-Hadrian-Request-Id tracking for request correlation

### DIFF
--- a/pkg/model/finding.go
+++ b/pkg/model/finding.go
@@ -20,6 +20,7 @@ type Finding struct {
 
 	Evidence    Evidence   `json:"evidence"`
 	LLMAnalysis *LLMTriage `json:"llm_analysis,omitempty"`
+	RequestIDs  []string   `json:"request_ids,omitempty"` // All request IDs from all phases
 
 	Timestamp   time.Time `json:"timestamp"`
 }

--- a/pkg/owasp/mutation.go
+++ b/pkg/owasp/mutation.go
@@ -33,25 +33,36 @@ type HTTPClient interface {
 
 // MutationExecutor runs three-phase mutation tests
 type MutationExecutor struct {
-	httpClient HTTPClient
-	tracker    *Tracker
+	httpClient        HTTPClient
+	trackedHTTPClient *TrackedHTTPClient
+	tracker           *Tracker
+}
+
+// PhaseRequestIDs tracks request IDs from each phase
+type PhaseRequestIDs struct {
+	Setup  []string
+	Attack []string
+	Verify []string
 }
 
 // MutationResult contains results from a three-phase mutation test
 type MutationResult struct {
-	TemplateID    string
-	Matched       bool // true if vulnerability found (attack succeeded)
-	SetupResponse *model.HTTPResponse
+	TemplateID     string
+	Matched        bool // true if vulnerability found (attack succeeded)
+	SetupResponse  *model.HTTPResponse
 	AttackResponse *model.HTTPResponse
 	VerifyResponse *model.HTTPResponse
-	ResourceID    string
+	ResourceID     string
+	RequestIDs     *PhaseRequestIDs // NEW: tracks request IDs per phase
 }
 
 // NewMutationExecutor creates a new mutation executor
 func NewMutationExecutor(client HTTPClient) *MutationExecutor {
+	trackedClient := NewTrackedHTTPClient(client)
 	return &MutationExecutor{
-		httpClient: client,
-		tracker:    NewTracker(),
+		httpClient:        client,
+		trackedHTTPClient: trackedClient,
+		tracker:           NewTracker(),
 	}
 }
 
@@ -67,6 +78,7 @@ func (e *MutationExecutor) ExecuteMutation(
 ) (*MutationResult, error) {
 	result := &MutationResult{
 		TemplateID: tmpl.ID,
+		RequestIDs: &PhaseRequestIDs{},
 	}
 
 	if tmpl.TestPhases == nil {
@@ -75,11 +87,13 @@ func (e *MutationExecutor) ExecuteMutation(
 
 	// Phase 1: Setup (create resource)
 	if tmpl.TestPhases.Setup != nil {
+		e.trackedHTTPClient.ClearRequestIDs()
 		setupResp, err := e.executePhase(ctx, baseURL, tmpl.TestPhases.Setup, tmpl.TestPhases.Setup.Auth, authTokens)
 		if err != nil {
 			return result, fmt.Errorf("setup phase failed: %w", err)
 		}
 		result.SetupResponse = setupResp
+		result.RequestIDs.Setup = e.trackedHTTPClient.GetRequestIDs()
 
 		// Store resource ID if needed - store by field name for later lookup
 		if tmpl.TestPhases.Setup.StoreResponseField != "" && setupResp != nil {
@@ -93,11 +107,13 @@ func (e *MutationExecutor) ExecuteMutation(
 
 	// Phase 2: Attack (try to access with different role)
 	if tmpl.TestPhases.Attack != nil {
+		e.trackedHTTPClient.ClearRequestIDs()
 		attackResp, err := e.executePhase(ctx, baseURL, tmpl.TestPhases.Attack, tmpl.TestPhases.Attack.Auth, authTokens)
 		if err != nil {
 			return result, fmt.Errorf("attack phase failed: %w", err)
 		}
 		result.AttackResponse = attackResp
+		result.RequestIDs.Attack = e.trackedHTTPClient.GetRequestIDs()
 
 		// Check if attack succeeded (vulnerability found)
 		if matchesDetectionConditions(tmpl.TestPhases.Attack, attackResp.StatusCode, attackResp.Body) {
@@ -107,11 +123,13 @@ func (e *MutationExecutor) ExecuteMutation(
 
 	// Phase 3: Verify (confirm resource still accessible by victim)
 	if tmpl.TestPhases.Verify != nil {
+		e.trackedHTTPClient.ClearRequestIDs()
 		verifyResp, err := e.executePhase(ctx, baseURL, tmpl.TestPhases.Verify, tmpl.TestPhases.Verify.Auth, authTokens)
 		if err != nil {
 			return result, fmt.Errorf("verify phase failed: %w", err)
 		}
 		result.VerifyResponse = verifyResp
+		result.RequestIDs.Verify = e.trackedHTTPClient.GetRequestIDs()
 	}
 
 	return result, nil
@@ -182,8 +200,8 @@ func (e *MutationExecutor) executePhase(
 		req.Header.Set("Authorization", token)
 	}
 
-	// Execute request
-	resp, err := e.httpClient.Do(req)
+	// Execute request with tracked client
+	resp, err := e.trackedHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/owasp/request_id_integration_test.go
+++ b/pkg/owasp/request_id_integration_test.go
@@ -1,0 +1,173 @@
+package owasp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/hadrian/pkg/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecuteMutation_TracksRequestIDs verifies that request IDs are tracked per phase
+func TestExecuteMutation_TracksRequestIDs(t *testing.T) {
+	// Setup mock server that captures and verifies request IDs
+	var setupRequestID, attackRequestID, verifyRequestID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := r.Header.Get("X-Hadrian-Request-Id")
+		assert.NotEmpty(t, requestID, "X-Hadrian-Request-Id header should be set")
+
+		// Capture request IDs based on path
+		switch r.URL.Path {
+		case "/api/videos":
+			setupRequestID = requestID
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id": "video123"}`))
+		case "/api/videos/video123":
+			if r.Header.Get("Authorization") == "attacker-token" {
+				attackRequestID = requestID
+				// Attack succeeds (BOLA vulnerability)
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"id": "video123", "title": "Private Video"}`))
+			} else {
+				verifyRequestID = requestID
+				// Verify succeeds
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"id": "video123", "title": "Private Video"}`))
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// Create template with three phases
+	tmpl := &templates.Template{
+		ID: "bola-test",
+		Info: templates.TemplateInfo{
+			Name:     "BOLA Test",
+			Category: "API1",
+			Severity: "HIGH",
+		},
+		TestPhases: &templates.TestPhases{
+			Setup: &templates.Phase{
+				Operation:          "create",
+				Path:               "/api/videos",
+				Auth:               "victim",
+				StoreResponseField: "id",
+			},
+			Attack: &templates.Phase{
+				Operation:      "read",
+				Path:           "/api/videos/{id}",
+				Auth:           "attacker",
+				UseStoredField: "id",
+				ExpectedStatus: http.StatusOK,
+			},
+			Verify: &templates.Phase{
+				Operation:      "read",
+				Path:           "/api/videos/{id}",
+				Auth:           "victim",
+				UseStoredField: "id",
+				ExpectedStatus: http.StatusOK,
+			},
+		},
+	}
+
+	// Create auth tokens
+	authTokens := map[string]string{
+		"victim":   "victim-token",
+		"attacker": "attacker-token",
+	}
+
+	// Execute mutation test
+	executor := NewMutationExecutor(http.DefaultClient)
+	result, err := executor.ExecuteMutation(
+		context.Background(),
+		tmpl,
+		"create",
+		"attacker",
+		"victim",
+		authTokens,
+		server.URL,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify vulnerability was detected
+	assert.True(t, result.Matched, "BOLA vulnerability should be detected")
+
+	// Verify request IDs were tracked for each phase
+	require.NotNil(t, result.RequestIDs, "RequestIDs should not be nil")
+
+	// Verify Setup phase has request IDs
+	require.Len(t, result.RequestIDs.Setup, 1, "Setup phase should have 1 request ID")
+	assert.NotEmpty(t, result.RequestIDs.Setup[0])
+	assert.Equal(t, setupRequestID, result.RequestIDs.Setup[0], "Setup request ID should match")
+
+	// Verify Attack phase has request IDs
+	require.Len(t, result.RequestIDs.Attack, 1, "Attack phase should have 1 request ID")
+	assert.NotEmpty(t, result.RequestIDs.Attack[0])
+	assert.Equal(t, attackRequestID, result.RequestIDs.Attack[0], "Attack request ID should match")
+
+	// Verify Verify phase has request IDs
+	require.Len(t, result.RequestIDs.Verify, 1, "Verify phase should have 1 request ID")
+	assert.NotEmpty(t, result.RequestIDs.Verify[0])
+	assert.Equal(t, verifyRequestID, result.RequestIDs.Verify[0], "Verify request ID should match")
+
+	// Verify all request IDs are unique
+	allIDs := []string{
+		result.RequestIDs.Setup[0],
+		result.RequestIDs.Attack[0],
+		result.RequestIDs.Verify[0],
+	}
+	seen := make(map[string]bool)
+	for _, id := range allIDs {
+		assert.False(t, seen[id], "Request IDs should be unique")
+		seen[id] = true
+	}
+
+	// Verify UUID format for all request IDs
+	for _, id := range allIDs {
+		parts := strings.Split(id, "-")
+		assert.Len(t, parts, 5, "Request ID should have UUID format (8-4-4-4-12)")
+	}
+}
+
+// TestExecuteMutation_NoRequestIDsWhenNoPhases verifies behavior when no phases are executed
+func TestExecuteMutation_NoRequestIDsWhenNoPhases(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Template with no phases
+	tmpl := &templates.Template{
+		ID: "test",
+		Info: templates.TemplateInfo{
+			Name:     "Test",
+			Category: "API1",
+			Severity: "LOW",
+		},
+		TestPhases: nil,
+	}
+
+	executor := NewMutationExecutor(http.DefaultClient)
+	result, err := executor.ExecuteMutation(
+		context.Background(),
+		tmpl,
+		"read",
+		"attacker",
+		"victim",
+		map[string]string{},
+		server.URL,
+	)
+
+	require.Error(t, err, "Should error when template has no phases")
+	require.NotNil(t, result)
+	require.NotNil(t, result.RequestIDs, "RequestIDs struct should be initialized even on error")
+}

--- a/pkg/owasp/tracked_client.go
+++ b/pkg/owasp/tracked_client.go
@@ -1,0 +1,56 @@
+package owasp
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+)
+
+// TrackedHTTPClient wraps an HTTPClient to add request ID tracking
+type TrackedHTTPClient struct {
+	client     HTTPClient
+	requestIDs []string
+}
+
+// NewTrackedHTTPClient creates a new tracked client wrapper
+func NewTrackedHTTPClient(client HTTPClient) *TrackedHTTPClient {
+	return &TrackedHTTPClient{
+		client:     client,
+		requestIDs: make([]string, 0),
+	}
+}
+
+// Do executes the request with a unique request ID header
+func (t *TrackedHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	requestID := generateRequestID()
+	req.Header.Set("X-Hadrian-Request-Id", requestID)
+	t.requestIDs = append(t.requestIDs, requestID)
+	return t.client.Do(req)
+}
+
+// GetRequestIDs returns all tracked request IDs
+func (t *TrackedHTTPClient) GetRequestIDs() []string {
+	return t.requestIDs
+}
+
+// ClearRequestIDs clears the tracked request IDs
+func (t *TrackedHTTPClient) ClearRequestIDs() {
+	t.requestIDs = make([]string, 0)
+}
+
+// generateRequestID creates a random UUID-style request ID
+func generateRequestID() string {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		// Fallback to a simple hex string if crypto/rand fails
+		return hex.EncodeToString(b)
+	}
+
+	// Format as UUID (8-4-4-4-12)
+	return hex.EncodeToString(b[0:4]) + "-" +
+		hex.EncodeToString(b[4:6]) + "-" +
+		hex.EncodeToString(b[6:8]) + "-" +
+		hex.EncodeToString(b[8:10]) + "-" +
+		hex.EncodeToString(b[10:16])
+}

--- a/pkg/owasp/tracked_client_test.go
+++ b/pkg/owasp/tracked_client_test.go
@@ -1,0 +1,112 @@
+package owasp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackedHTTPClient_AddsRequestIDHeader(t *testing.T) {
+	// Setup mock server to capture headers
+	var capturedRequestID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestID = r.Header.Get("X-Hadrian-Request-Id")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create tracked client
+	client := NewTrackedHTTPClient(http.DefaultClient)
+
+	// Make request
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Verify request ID was added
+	assert.NotEmpty(t, capturedRequestID, "X-Hadrian-Request-Id header should be set")
+
+	// Verify UUID format (8-4-4-4-12)
+	parts := strings.Split(capturedRequestID, "-")
+	assert.Len(t, parts, 5, "Request ID should have UUID format")
+	assert.Len(t, parts[0], 8, "First segment should be 8 chars")
+	assert.Len(t, parts[1], 4, "Second segment should be 4 chars")
+	assert.Len(t, parts[2], 4, "Third segment should be 4 chars")
+	assert.Len(t, parts[3], 4, "Fourth segment should be 4 chars")
+	assert.Len(t, parts[4], 12, "Fifth segment should be 12 chars")
+}
+
+func TestTrackedHTTPClient_TracksMultipleRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewTrackedHTTPClient(http.DefaultClient)
+
+	// Make 3 requests
+	for i := 0; i < 3; i++ {
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+
+	// Verify all request IDs tracked
+	requestIDs := client.GetRequestIDs()
+	assert.Len(t, requestIDs, 3, "Should track all 3 requests")
+
+	// Verify all IDs are unique
+	seen := make(map[string]bool)
+	for _, id := range requestIDs {
+		assert.False(t, seen[id], "Request IDs should be unique")
+		seen[id] = true
+	}
+}
+
+func TestTrackedHTTPClient_ClearRequestIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewTrackedHTTPClient(http.DefaultClient)
+
+	// Make request
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Len(t, client.GetRequestIDs(), 1, "Should have 1 request ID")
+
+	// Clear
+	client.ClearRequestIDs()
+	assert.Len(t, client.GetRequestIDs(), 0, "Should have 0 request IDs after clear")
+}
+
+func TestGenerateRequestID_Format(t *testing.T) {
+	// Generate multiple IDs
+	ids := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id := generateRequestID()
+
+		// Verify format
+		parts := strings.Split(id, "-")
+		assert.Len(t, parts, 5, "Request ID should have UUID format")
+
+		// Verify uniqueness
+		assert.False(t, ids[id], "Request IDs should be unique")
+		ids[id] = true
+	}
+}

--- a/pkg/reporter/markdown.go
+++ b/pkg/reporter/markdown.go
@@ -152,6 +152,9 @@ func (r *MarkdownReporter) writeFinding(sb *strings.Builder, finding *model.Find
 	if finding.VictimRole != "" {
 		sb.WriteString(fmt.Sprintf("- **Victim Role:** %s\n", finding.VictimRole))
 	}
+	if len(finding.RequestIDs) > 0 {
+		sb.WriteString(fmt.Sprintf("- **Request IDs:** %s\n", strings.Join(finding.RequestIDs, ", ")))
+	}
 	sb.WriteString("\n")
 
 	// Evidence section

--- a/pkg/reporter/terminal.go
+++ b/pkg/reporter/terminal.go
@@ -65,6 +65,11 @@ func (r *TerminalReporter) ReportFinding(finding *model.Finding) error {
 	// Confidence
 	sb.WriteString(fmt.Sprintf("  Confidence: %.0f%%\n", finding.Confidence*100))
 
+	// Request IDs
+	if len(finding.RequestIDs) > 0 {
+		sb.WriteString(fmt.Sprintf("  Request IDs: %s\n", strings.Join(finding.RequestIDs, ", ")))
+	}
+
 	// Redact and show response body summary if available
 	if finding.Evidence.Response.Body != "" {
 		body := r.redactor.Redact(finding.Evidence.Response.Body)

--- a/pkg/reporter/terminal_test.go
+++ b/pkg/reporter/terminal_test.go
@@ -233,3 +233,37 @@ func TestTerminalReporter_GenerateReport_ShowsOperationsAndTemplates(t *testing.
 	assert.True(t, strings.Contains(output, "30") || strings.Contains(output, "Templates"),
 		"Should mention templates count")
 }
+
+// TestTerminalReporter_ReportFinding_WithRequestIDs verifies that request IDs
+// are displayed in terminal output when present
+func TestTerminalReporter_ReportFinding_WithRequestIDs(t *testing.T) {
+	var buf bytes.Buffer
+	reporter := NewTerminalReporter(&buf, false)
+	
+	finding := createTestFinding(model.SeverityHigh, "API1")
+	finding.RequestIDs = []string{"req-abc123", "req-def456"}
+
+	err := reporter.ReportFinding(finding)
+
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "Request IDs:", "Should label request IDs section")
+	assert.Contains(t, output, "req-abc123", "Should include first request ID")
+	assert.Contains(t, output, "req-def456", "Should include second request ID")
+}
+
+// TestTerminalReporter_ReportFinding_NoRequestIDs verifies that request ID section
+// is omitted when there are no request IDs
+func TestTerminalReporter_ReportFinding_NoRequestIDs(t *testing.T) {
+	var buf bytes.Buffer
+	reporter := NewTerminalReporter(&buf, false)
+	
+	finding := createTestFinding(model.SeverityHigh, "API1")
+	finding.RequestIDs = []string{} // Empty
+
+	err := reporter.ReportFinding(finding)
+
+	require.NoError(t, err)
+	output := buf.String()
+	assert.NotContains(t, output, "Request IDs:", "Should not show request IDs section when empty")
+}

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -76,14 +76,14 @@ type Stats struct {
 }
 
 // createReporter creates appropriate reporter based on output format
-func createReporter(format, outputFile string) (Reporter, error) {
+func createReporter(format, outputFile string, requestIDsLimit int) (Reporter, error) {
 	switch format {
 	case "terminal":
-		return NewTerminalReporter(os.Stdout), nil
+		return NewTerminalReporter(os.Stdout, requestIDsLimit), nil
 	case "json":
-		return NewJSONReporter(outputFile)
+		return NewJSONReporter(outputFile, requestIDsLimit)
 	case "markdown":
-		return NewMarkdownReporter(outputFile)
+		return NewMarkdownReporter(outputFile, requestIDsLimit)
 	default:
 		return nil, fmt.Errorf("unsupported output format: %s", format)
 	}
@@ -180,14 +180,16 @@ func calculateStats(findings []*model.Finding, startTime time.Time) *Stats {
 
 // TerminalReporter outputs findings to terminal with colors
 type TerminalReporter struct {
-	writer   *os.File
-	redactor *reporter.Redactor
+	writer          *os.File
+	redactor        *reporter.Redactor
+	requestIDsLimit int
 }
 
-func NewTerminalReporter(w *os.File) *TerminalReporter {
+func NewTerminalReporter(w *os.File, requestIDsLimit int) *TerminalReporter {
 	return &TerminalReporter{
-		writer:   w,
-		redactor: reporter.NewRedactor(),
+		writer:          w,
+		redactor:        reporter.NewRedactor(),
+		requestIDsLimit: requestIDsLimit,
 	}
 }
 
@@ -209,9 +211,14 @@ func (r *TerminalReporter) ReportFinding(finding *model.Finding) {
 		fmt.Fprintf(r.writer, "  Vulnerability confirmed (confidence: %.0f%%)\n", finding.Confidence*100)
 	}
 
-	// Show request IDs if available
+	// Show request IDs if available (limited by requestIDsLimit)
 	if len(finding.RequestIDs) > 0 {
-		fmt.Fprintf(r.writer, "  Request IDs: %s\n", strings.Join(finding.RequestIDs, ", "))
+		requestIDs := finding.RequestIDs
+		// Apply limit: 0 or negative = show all, positive = limit to last N
+		if r.requestIDsLimit > 0 && len(requestIDs) > r.requestIDsLimit {
+			requestIDs = requestIDs[len(requestIDs)-r.requestIDsLimit:]
+		}
+		fmt.Fprintf(r.writer, "  Request IDs: %s\n", strings.Join(requestIDs, ", "))
 	}
 }
 
@@ -250,16 +257,18 @@ func (r *TerminalReporter) Close() error {
 
 // JSONReporter outputs findings to JSON file
 type JSONReporter struct {
-	outputFile string
-	findings   []*model.Finding
-	redactor   *reporter.Redactor
+	outputFile      string
+	findings        []*model.Finding
+	redactor        *reporter.Redactor
+	requestIDsLimit int
 }
 
-func NewJSONReporter(outputFile string) (*JSONReporter, error) {
+func NewJSONReporter(outputFile string, requestIDsLimit int) (*JSONReporter, error) {
 	return &JSONReporter{
-		outputFile: outputFile,
-		findings:   make([]*model.Finding, 0),
-		redactor:   reporter.NewRedactor(),
+		outputFile:      outputFile,
+		findings:        make([]*model.Finding, 0),
+		redactor:        reporter.NewRedactor(),
+		requestIDsLimit: requestIDsLimit,
 	}, nil
 }
 
@@ -268,9 +277,19 @@ func (r *JSONReporter) ReportFinding(finding *model.Finding) {
 }
 
 func (r *JSONReporter) GenerateReport(findings []*model.Finding, stats *Stats) error {
+	// Limit request IDs in findings
+	limitedFindings := make([]*model.Finding, len(findings))
+	for i, f := range findings {
+		limited := *f // Copy finding
+		if len(limited.RequestIDs) > 0 && r.requestIDsLimit > 0 && len(limited.RequestIDs) > r.requestIDsLimit {
+			limited.RequestIDs = limited.RequestIDs[len(limited.RequestIDs)-r.requestIDsLimit:]
+		}
+		limitedFindings[i] = &limited
+	}
+
 	report := map[string]interface{}{
 		"stats":    stats,
-		"findings": findings,
+		"findings": limitedFindings,
 	}
 
 	var output *os.File
@@ -296,16 +315,18 @@ func (r *JSONReporter) Close() error {
 
 // MarkdownReporter outputs findings to Markdown file
 type MarkdownReporter struct {
-	outputFile string
-	findings   []*model.Finding
-	redactor   *reporter.Redactor
+	outputFile      string
+	findings        []*model.Finding
+	redactor        *reporter.Redactor
+	requestIDsLimit int
 }
 
-func NewMarkdownReporter(outputFile string) (*MarkdownReporter, error) {
+func NewMarkdownReporter(outputFile string, requestIDsLimit int) (*MarkdownReporter, error) {
 	return &MarkdownReporter{
-		outputFile: outputFile,
-		findings:   make([]*model.Finding, 0),
-		redactor:   reporter.NewRedactor(),
+		outputFile:      outputFile,
+		findings:        make([]*model.Finding, 0),
+		redactor:        reporter.NewRedactor(),
+		requestIDsLimit: requestIDsLimit,
 	}, nil
 }
 
@@ -354,6 +375,15 @@ func (r *MarkdownReporter) GenerateReport(findings []*model.Finding, stats *Stat
 		}
 		if f.VictimRole != "" {
 			fmt.Fprintf(output, "**Victim Role:** %s\n\n", f.VictimRole)
+		}
+
+		// Show limited request IDs if available
+		if len(f.RequestIDs) > 0 {
+			requestIDs := f.RequestIDs
+			if r.requestIDsLimit > 0 && len(requestIDs) > r.requestIDsLimit {
+				requestIDs = requestIDs[len(requestIDs)-r.requestIDsLimit:]
+			}
+			fmt.Fprintf(output, "**Request IDs:** %s\n\n", strings.Join(requestIDs, ", "))
 		}
 
 		if f.LLMAnalysis != nil {

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	http "github.com/praetorian-inc/hadrian/internal/http"
@@ -206,6 +207,11 @@ func (r *TerminalReporter) ReportFinding(finding *model.Finding) {
 
 	if finding.IsVulnerability {
 		fmt.Fprintf(r.writer, "  Vulnerability confirmed (confidence: %.0f%%)\n", finding.Confidence*100)
+	}
+
+	// Show request IDs if available
+	if len(finding.RequestIDs) > 0 {
+		fmt.Fprintf(r.writer, "  Request IDs: %s\n", strings.Join(finding.RequestIDs, ", "))
 	}
 }
 

--- a/pkg/runner/helpers_test.go
+++ b/pkg/runner/helpers_test.go
@@ -118,28 +118,28 @@ func TestCreateHTTPClient_WithInsecure(t *testing.T) {
 // =============================================================================
 
 func TestCreateReporter_Terminal(t *testing.T) {
-	rep, err := createReporter("terminal", "")
+	rep, err := createReporter("terminal", "", 1)
 	require.NoError(t, err)
 	assert.NotNil(t, rep)
 	assert.NoError(t, rep.Close())
 }
 
 func TestCreateReporter_JSON(t *testing.T) {
-	rep, err := createReporter("json", "")
+	rep, err := createReporter("json", "", 1)
 	require.NoError(t, err)
 	assert.NotNil(t, rep)
 	assert.NoError(t, rep.Close())
 }
 
 func TestCreateReporter_Markdown(t *testing.T) {
-	rep, err := createReporter("markdown", "")
+	rep, err := createReporter("markdown", "", 1)
 	require.NoError(t, err)
 	assert.NotNil(t, rep)
 	assert.NoError(t, rep.Close())
 }
 
 func TestCreateReporter_InvalidFormat(t *testing.T) {
-	_, err := createReporter("invalid", "")
+	_, err := createReporter("invalid", "", 1)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported output format")
 }
@@ -196,7 +196,7 @@ func TestTerminalReporter_ReportFinding(t *testing.T) {
 	require.NoError(t, err)
 	defer tmpFile.Close()
 
-	rep := NewTerminalReporter(tmpFile)
+	rep := NewTerminalReporter(tmpFile, 1)
 	finding := &model.Finding{
 		Severity:        model.SeverityHigh,
 		Category:        "API1",
@@ -223,7 +223,7 @@ func TestTerminalReporter_GenerateReport(t *testing.T) {
 	require.NoError(t, err)
 	defer tmpFile.Close()
 
-	rep := NewTerminalReporter(tmpFile)
+	rep := NewTerminalReporter(tmpFile, 1)
 	stats := &Stats{
 		Findings:        5,
 		Critical:        1,
@@ -256,7 +256,7 @@ func TestTerminalReporter_GenerateReport(t *testing.T) {
 func TestJSONReporter_GenerateReport(t *testing.T) {
 	outputFile := filepath.Join(t.TempDir(), "report.json")
 
-	rep, err := NewJSONReporter(outputFile)
+	rep, err := NewJSONReporter(outputFile, 1)
 	require.NoError(t, err)
 
 	findings := []*model.Finding{
@@ -291,7 +291,7 @@ func TestJSONReporter_GenerateReport(t *testing.T) {
 func TestMarkdownReporter_GenerateReport(t *testing.T) {
 	outputFile := filepath.Join(t.TempDir(), "report.md")
 
-	rep, err := NewMarkdownReporter(outputFile)
+	rep, err := NewMarkdownReporter(outputFile, 1)
 	require.NoError(t, err)
 
 	findings := []*model.Finding{

--- a/pkg/runner/request_id_test.go
+++ b/pkg/runner/request_id_test.go
@@ -1,0 +1,47 @@
+package runner
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/reporter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFinding_RequestIDsFlowToTerminalOutput verifies that request IDs
+// in a Finding are displayed by the terminal reporter
+func TestFinding_RequestIDsFlowToTerminalOutput(t *testing.T) {
+	// Create a finding with request IDs (simulating what runner creates)
+	finding := &model.Finding{
+		ID:          "test-finding",
+		Category:    "API1",
+		Name:        "Test Vulnerability",
+		Severity:    model.SeverityHigh,
+		Endpoint:    "/api/users/123",
+		Method:      "GET",
+		Confidence:  0.95,
+		RequestIDs:  []string{"req-abc123", "req-def456"},
+		Evidence: model.Evidence{
+			Response: model.HTTPResponse{
+				StatusCode: 200,
+				Body:       `{"user": "admin"}`,
+			},
+		},
+	}
+
+	// Create terminal reporter
+	var buf bytes.Buffer
+	terminalReporter := reporter.NewTerminalReporter(&buf, false)
+
+	// Report the finding
+	err := terminalReporter.ReportFinding(finding)
+	require.NoError(t, err)
+
+	// Verify output contains request IDs
+	output := buf.String()
+	assert.Contains(t, output, "Request IDs:", "output should label request IDs section")
+	assert.Contains(t, output, "req-abc123", "output should contain first request ID")
+	assert.Contains(t, output, "req-def456", "output should contain second request ID")
+}

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -439,7 +439,8 @@ func executeTemplate(
 				Evidence: model.Evidence{
 					Response: result.Response,
 				},
-				Timestamp: time.Now(),
+				RequestIDs: result.RequestIDs,
+				Timestamp:  time.Now(),
 			}
 			findings = append(findings, finding)
 		}
@@ -507,7 +508,8 @@ func executeTemplate(
 					Evidence: model.Evidence{
 						Response: result.Response,
 					},
-					Timestamp: time.Now(),
+					RequestIDs: result.RequestIDs,
+					Timestamp:  time.Now(),
 				}
 
 				if victimRole != nil {
@@ -590,6 +592,16 @@ func executeMutationTemplate(
 						Response: *result.AttackResponse,
 					}
 				}
+
+				// Collect all request IDs from all phases
+				if result.RequestIDs != nil {
+					var allRequestIDs []string
+					allRequestIDs = append(allRequestIDs, result.RequestIDs.Setup...)
+					allRequestIDs = append(allRequestIDs, result.RequestIDs.Attack...)
+					allRequestIDs = append(allRequestIDs, result.RequestIDs.Verify...)
+					finding.RequestIDs = allRequestIDs
+				}
+
 				findings = append(findings, finding)
 			}
 		}

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -41,6 +41,7 @@ type Config struct {
 	OWASPCategories  []string
 	Verbose          bool
 	DryRun           bool
+	RequestIDsLimit  int      // Number of request IDs to display per finding (0 = all)
 }
 
 // Run is the main entry point for the Hadrian CLI
@@ -96,6 +97,7 @@ func newTestCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&config.OWASPCategories, "owasp", []string{}, "OWASP API categories to test (e.g., API1,API2,API5,API9)")
 	cmd.Flags().BoolVarP(&config.Verbose, "verbose", "v", false, "Enable verbose logging output")
 	cmd.Flags().BoolVar(&config.DryRun, "dry-run", false, "Show what would be tested without making requests")
+	cmd.Flags().IntVar(&config.RequestIDsLimit, "request-ids", 1, "Number of request IDs to display per finding (0 = all)")
 
 	return cmd
 }
@@ -176,7 +178,7 @@ func runTest(ctx context.Context, config Config) error {
 	}
 
 	// 7. Create reporter based on output format
-	rep, err := createReporter(config.Output, config.OutputFile)
+	rep, err := createReporter(config.Output, config.OutputFile, config.RequestIDsLimit)
 	if err != nil {
 		return fmt.Errorf("failed to create reporter: %w", err)
 	}

--- a/pkg/templates/execute.go
+++ b/pkg/templates/execute.go
@@ -3,7 +3,9 @@ package templates
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +15,23 @@ import (
 	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/log"
 )
+
+// generateRequestID creates a random UUID-style request ID
+func generateRequestID() string {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		// Fallback to a simple hex string if crypto/rand fails
+		return hex.EncodeToString(b)
+	}
+
+	// Format as UUID (8-4-4-4-12)
+	return hex.EncodeToString(b[0:4]) + "-" +
+		hex.EncodeToString(b[4:6]) + "-" +
+		hex.EncodeToString(b[6:8]) + "-" +
+		hex.EncodeToString(b[8:10]) + "-" +
+		hex.EncodeToString(b[10:16])
+}
 
 // hasUnresolvedPlaceholders checks if a path contains unresolved {placeholder} patterns.
 // Returns the first unresolved placeholder name if found, or empty string if all resolved.
@@ -37,12 +56,14 @@ type HTTPClient interface {
 type Executor struct {
 	httpClient HTTPClient
 	cache      *Cache
+	requestIDs []string
 }
 
 func NewExecutor(client HTTPClient) *Executor {
 	return &Executor{
 		httpClient: client,
 		cache:      NewCache(1000), // Cache 1000 compiled templates
+		requestIDs: make([]string, 0),
 	}
 }
 
@@ -54,6 +75,9 @@ func (e *Executor) Execute(
 	authHeader string,
 	variables map[string]string,
 ) (*ExecutionResult, error) {
+	// Clear request IDs for this execution
+	e.requestIDs = make([]string, 0)
+
 	result := &ExecutionResult{
 		TemplateID: tmpl.ID,
 		Operation:  operation,
@@ -132,6 +156,11 @@ func (e *Executor) Execute(
 				if err != nil {
 					return nil, fmt.Errorf("failed to build request: %w", err)
 				}
+
+				// Add request ID header and track it
+				requestID := generateRequestID()
+				req.Header.Set("X-Hadrian-Request-Id", requestID)
+				e.requestIDs = append(e.requestIDs, requestID)
 
 				// Execute HTTP request
 				resp, err = e.httpClient.Do(req)
@@ -293,6 +322,9 @@ func (e *Executor) Execute(
 			}
 		}
 	}
+
+	// Add tracked request IDs to result
+	result.RequestIDs = e.requestIDs
 
 	return result, nil
 }
@@ -483,6 +515,7 @@ type ExecutionResult struct {
 	Response      model.HTTPResponse
 	Findings      []model.Finding
 	RateLimitInfo *RateLimitInfo
+	RequestIDs    []string // X-Hadrian-Request-Id values from all requests
 }
 
 // RateLimitInfo contains results from rate limit testing

--- a/pkg/templates/execute_test.go
+++ b/pkg/templates/execute_test.go
@@ -492,3 +492,72 @@ func TestExecute_Integration_WithHTTPTest(t *testing.T) {
 		t.Errorf("StatusCode = %d, want 200", result.Response.StatusCode)
 	}
 }
+
+// TestExecute_RequestIDsTracked verifies that X-Hadrian-Request-Id header is added
+// to all requests and tracked in the ExecutionResult
+func TestExecute_RequestIDsTracked(t *testing.T) {
+	var capturedRequestID string
+
+	// Create test server that captures the request ID
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestID = r.Header.Get("X-Hadrian-Request-Id")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"status": "ok"}`))
+	}))
+	defer server.Close()
+
+	executor := NewExecutor(&http.Client{})
+
+	tmpl := &CompiledTemplate{
+		Template: &Template{
+			ID: "request-id-test",
+			HTTP: []HTTPTest{
+				{
+					Method: "GET",
+					Path:   server.URL + "/api/test",
+					Matchers: []Matcher{
+						{
+							Type:   "status",
+							Status: []int{200},
+						},
+					},
+				},
+			},
+		},
+		CompiledMatchers: []*CompiledMatcher{
+			{
+				Type:   "status",
+				Status: []int{200},
+			},
+		},
+	}
+
+	operation := &model.Operation{
+		Method: "GET",
+		Path:   "/api/test",
+	}
+
+	result, err := executor.Execute(context.Background(), tmpl, operation, "", nil)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	// Verify request ID was sent in header
+	if capturedRequestID == "" {
+		t.Error("X-Hadrian-Request-Id header was not set")
+	}
+
+	// Verify request ID was tracked in result
+	if len(result.RequestIDs) != 1 {
+		t.Errorf("Expected 1 request ID, got %d", len(result.RequestIDs))
+	}
+
+	if len(result.RequestIDs) > 0 && result.RequestIDs[0] != capturedRequestID {
+		t.Errorf("Tracked request ID %q doesn't match sent ID %q", result.RequestIDs[0], capturedRequestID)
+	}
+
+	// Verify request ID format (should be UUID-like)
+	if len(capturedRequestID) < 32 {
+		t.Errorf("Request ID %q seems too short for a UUID", capturedRequestID)
+	}
+}

--- a/pkg/templates/executor_reuse_test.go
+++ b/pkg/templates/executor_reuse_test.go
@@ -1,0 +1,99 @@
+package templates
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecutor_ReuseDoesNotClearRequestIDs tests that reusing an executor
+// for multiple Execute() calls doesn't cause request IDs from previous calls
+// to be cleared/lost due to slice sharing
+func TestExecutor_ReuseDoesNotClearRequestIDs(t *testing.T) {
+	// Create a single executor (mimicking real usage)
+	client := &mockHTTPClient{
+		response: &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"status": "ok"}`)),
+		},
+	}
+	executor := NewExecutor(client)
+
+	// Create two templates
+	tmpl1 := &CompiledTemplate{
+		Template: &Template{
+			ID: "template-1",
+			HTTP: []HTTPTest{
+				{
+					Method: "GET",
+					Path:   "/api/test1",
+					Matchers: []Matcher{
+						{Type: "status", Status: []int{200}},
+					},
+				},
+			},
+		},
+		CompiledMatchers: []*CompiledMatcher{
+			{Type: "status", Status: []int{200}},
+		},
+	}
+
+	tmpl2 := &CompiledTemplate{
+		Template: &Template{
+			ID: "template-2",
+			HTTP: []HTTPTest{
+				{
+					Method: "GET",
+					Path:   "/api/test2",
+					Matchers: []Matcher{
+						{Type: "status", Status: []int{200}},
+					},
+				},
+			},
+		},
+		CompiledMatchers: []*CompiledMatcher{
+			{Type: "status", Status: []int{200}},
+		},
+	}
+
+	operation := &model.Operation{
+		Method: "GET",
+		Path:   "/api/test",
+	}
+
+	// Execute first template
+	result1, err := executor.Execute(context.Background(), tmpl1, operation, "", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, result1.RequestIDs, "first execution should have request IDs")
+
+	// Capture request IDs from first execution
+	firstRequestIDs := make([]string, len(result1.RequestIDs))
+	copy(firstRequestIDs, result1.RequestIDs)
+	t.Logf("First execution request IDs: %v (ptr: %p)", result1.RequestIDs, &result1.RequestIDs[0])
+
+	// Execute second template with SAME executor
+	result2, err := executor.Execute(context.Background(), tmpl2, operation, "", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, result2.RequestIDs, "second execution should have request IDs")
+	t.Logf("Second execution request IDs: %v (ptr: %p)", result2.RequestIDs, &result2.RequestIDs[0])
+	t.Logf("First execution request IDs AFTER second call: %v", result1.RequestIDs)
+
+	// CRITICAL TEST: First result should STILL have its request IDs
+	// (they should not have been cleared when second Execute() was called)
+	assert.NotEmpty(t, result1.RequestIDs,
+		"first result's request IDs should not be cleared by second Execute() call")
+
+	assert.Equal(t, firstRequestIDs, result1.RequestIDs,
+		"first result's request IDs should match original captured values")
+
+	// Second result should have DIFFERENT request IDs
+	assert.NotEqual(t, result1.RequestIDs, result2.RequestIDs,
+		"each execution should have unique request IDs")
+}


### PR DESCRIPTION
## Linear Ticket
[ENG-1169](https://linear.app/praetorianlabs/issue/ENG-1169/comprehensive-testing-and-validation-of-api-security-testing-tool-mvp)

## Summary

This PR adds unique request ID tracking to all HTTP requests made by Hadrian, enabling correlation between findings and server-side logs or proxy captures (e.g., Burp Suite).

### Features

- **X-Hadrian-Request-Id header**: Every HTTP request includes a unique UUID-format request ID
- **Request IDs in output**: All output formats (terminal, JSON, markdown) display associated request IDs
- **`--request-ids` flag**: Control how many request IDs to display per finding
  - Default (1): Show only the most recent request ID
  - Positive N (e.g., `--request-ids 30`): Show up to N most recent IDs
  - 0: Show all request IDs

### Use Cases

- Correlate Hadrian findings with Burp Suite request history
- Match findings to server-side access logs
- Debug which specific requests triggered a vulnerability detection

## Test Commands

### Run All Tests
```bash
cd modules/hadrian
GOWORK=off go test ./... -v
```

### Run Request ID Tests Only
```bash
cd modules/hadrian
GOWORK=off go test ./pkg/runner/... -v -run "RequestID"
```

### Build Hadrian
```bash
cd modules/hadrian
GOWORK=off go build -o hadrian ./cmd/hadrian
```

### Verify Request ID Flag
```bash
cd modules/hadrian
./hadrian test --help | grep -A2 "request-ids"
```

### Test with Proxy (Burp Suite)
```bash
# Configure Burp Suite to listen on 127.0.0.1:8080

cd modules/hadrian
./hadrian test \
  --api testdata/crapi/openapi.yaml \
  --roles testdata/crapi/roles.yaml \
  --template-dir testdata/crapi/templates/owasp \
  --proxy http://127.0.0.1:8080 \
  --allow-internal \
  --verbose

# Check Burp Suite history for X-Hadrian-Request-Id headers
```

### Test Request ID Display Options
```bash
cd modules/hadrian

# Default: Show 1 request ID per finding
./hadrian test \
  --api testdata/crapi/openapi.yaml \
  --roles testdata/crapi/roles.yaml \
  --template-dir testdata/crapi/templates/owasp \
  --allow-internal

# Show up to 5 request IDs per finding
./hadrian test \
  --api testdata/crapi/openapi.yaml \
  --roles testdata/crapi/roles.yaml \
  --template-dir testdata/crapi/templates/owasp \
  --allow-internal \
  --request-ids 5

# Show all request IDs
./hadrian test \
  --api testdata/crapi/openapi.yaml \
  --roles testdata/crapi/roles.yaml \
  --template-dir testdata/crapi/templates/owasp \
  --allow-internal \
  --request-ids 0
```

### Race Condition Test
```bash
cd modules/hadrian
GOWORK=off go test -race ./...
```

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (11 request ID tests + all existing tests)
- [x] `go test -race ./...` passes (no race conditions)
- [x] `./hadrian test --help` shows `--request-ids` flag
- [x] Request IDs appear in Burp Suite when proxying requests
- [x] Request IDs appear in terminal output for findings