### PR TITLE
feat(runner): add global rate limiting with reactive backoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The CLI (`cmd/hadrian`) delegates to `pkg/runner.Run()` which orchestrates:
 
 ### Key Packages
 
-- **pkg/runner**: CLI commands and main test orchestration loop
+- **pkg/runner**: CLI commands, test orchestration, rate limiting (`ratelimit.go`, `ratelimit_client.go`), and execution logic
 - **pkg/templates**: YAML template parsing (`parse.go`), compilation (`compile.go`), and HTTP execution (`execute.go`)
 - **pkg/owasp**: OWASP-specific test runner, endpoint/role selectors, and mutation testing
 - **pkg/roles**: Permission model with `<action>:<object>:<scope>` format and role-based filtering
@@ -72,10 +72,11 @@ Permissions follow `<action>:<object>:<scope>`:
 
 ### Production Safety
 
-Built-in safeguards in `pkg/runner/production.go`:
+Built-in safeguards in `pkg/runner/production.go` and `pkg/runner/ratelimit_client.go`:
 - Blocks production URLs by default (requires `--allow-production`)
 - Blocks internal/private IPs (requires `--allow-internal`)
-- Rate limiting (default 5 req/s)
+- Proactive rate limiting (default 5 req/s) via `RateLimiter`
+- Reactive backoff on 429/503 responses via `RateLimitingClient`
 - Audit logging to `.hadrian/audit.log`
 
 ## Testing with crAPI

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Hadrian is a security testing framework for REST APIs that tests for OWASP API v
 - **Template-Driven**: YAML templates for customizable security tests
 - **Multiple Output Formats**: Terminal, JSON, and Markdown reports
 - **Production Safety**: Built-in safeguards against testing production systems
+- **Adaptive Rate Limiting**: Proactive request throttling with reactive backoff on 429/503 responses
 - **Proxy Support**: Route traffic through Burp Suite or other proxies
 - **LLM Triage**: Optional AI-powered finding analysis (Anthropic, OpenAI, Ollama)
 
@@ -193,6 +194,10 @@ hadrian test [flags]
 - `--insecure` - Skip TLS verification (use with proxies)
 - `--concurrency <n>` - Concurrent requests (default: 1, max: 10)
 - `--rate-limit <n>` - Global rate limit in req/s (default: 5.0)
+- `--rate-limit-backoff <type>` - Backoff type for rate limit retries: exponential, fixed (default: exponential)
+- `--rate-limit-max-wait <duration>` - Maximum backoff wait time (default: 60s)
+- `--rate-limit-max-retries <n>` - Maximum retry attempts on rate limit response (default: 5)
+- `--rate-limit-status-codes <codes>` - Status codes that trigger rate limit retry (default: 429,503)
 - `--timeout <n>` - Request timeout in seconds (default: 30)
 - `--allow-production` - Allow testing production URLs
 - `--allow-internal` - Allow testing internal/private IP addresses
@@ -363,9 +368,53 @@ go test ./pkg/runner/...
 ## Security Considerations
 
 - **Production Safety**: By default, Hadrian blocks testing against production URLs and internal IPs
-- **Rate Limiting**: Default rate limit of 5 req/s prevents overwhelming target systems
+- **Adaptive Rate Limiting**:
+  - Proactive: Limits outgoing requests to configured rate (default 5 req/s)
+  - Reactive: Automatically backs off when detecting rate limit responses (429/503)
+  - Supports exponential and fixed backoff strategies
+  - Honors server `Retry-After` headers when present
 - **Audit Logging**: All requests are logged for compliance and debugging
 - **Proxy Support**: Use `--proxy` with Burp Suite for manual verification
+
+## Rate Limiting
+
+Hadrian includes comprehensive rate limiting to prevent overwhelming target APIs:
+
+### Proactive Rate Limiting
+
+Limits outgoing requests to a configured rate (default 5 requests/second):
+
+```bash
+# Set custom rate limit
+hadrian test --api api.yaml --roles roles.yaml --rate-limit 10.0
+```
+
+### Reactive Backoff
+
+Automatically detects rate limit responses and implements retry with backoff:
+
+```bash
+# Use fixed backoff (constant 5s wait)
+hadrian test --api api.yaml --roles roles.yaml --rate-limit-backoff fixed
+
+# Configure max retries and wait time
+hadrian test --api api.yaml --roles roles.yaml \
+  --rate-limit-max-retries 10 \
+  --rate-limit-max-wait 120s
+
+# Custom status codes for rate limit detection
+hadrian test --api api.yaml --roles roles.yaml \
+  --rate-limit-status-codes 429,503,529
+```
+
+### Backoff Strategies
+
+| Strategy | Behavior | Use Case |
+|----------|----------|----------|
+| **exponential** (default) | Wait doubles each retry: 1s, 2s, 4s, 8s... | Most APIs |
+| **fixed** | Constant wait time between retries | APIs with fixed rate windows |
+
+The backoff respects the server's `Retry-After` header when present, capping at the configured `--rate-limit-max-wait`.
 
 ## OWASP API Security Top 10 Coverage
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,7 +156,12 @@ Hadrian is a security testing framework designed to identify OWASP API Top 10 vu
 hadrian-api-tester/
 ├── cmd/hadrian/main.go      # CLI entry point
 ├── pkg/
-│   ├── runner/              # Orchestration & test execution loop
+│   ├── runner/              # Orchestration, rate limiting, test execution
+│   │   ├── run.go           # CLI commands and main loop
+│   │   ├── ratelimit.go     # Rate limiter configuration
+│   │   ├── ratelimit_client.go  # HTTP client with reactive backoff
+│   │   ├── execution.go     # Template execution logic
+│   │   └── ...
 │   ├── model/               # Data structures (Operation, Finding)
 │   ├── templates/           # Template parsing, compilation, execution
 │   ├── auth/                # Authentication handling
@@ -252,7 +257,14 @@ Hadrian includes templates for OWASP API Top 10 vulnerabilities:
 
 - **Production URL Blocking**: Requires `--allow-production` flag
 - **Internal IP Blocking**: Requires `--allow-internal` flag
-- **Rate Limiting**: Default 5 req/s, max 10 concurrent requests
+- **Adaptive Rate Limiting**:
+  - Proactive: Limits requests to configured rate (default 5 req/s)
+  - Reactive: Detects 429/503 responses and implements backoff
+  - Exponential backoff: 1s → 2s → 4s → 8s... (capped at max)
+  - Fixed backoff: Constant wait between retries
+  - Honors `Retry-After` header from server
+  - Max retries: 5 (configurable)
+- **Concurrency Control**: Maximum 10 concurrent requests
 - **YAML Bomb Protection**: 1MB size limit, 20-depth limit
 - **TLS 1.3 Enforcement**: No legacy TLS
 - **Credential Validation**: Warns on insecure configurations

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -46,6 +46,28 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid output format: %s (valid: terminal, json, markdown)", c.Output)
 	}
 
+	// Validate rate limit configuration
+	if c.RateLimit <= 0 {
+		return fmt.Errorf("rate limit must be > 0")
+	}
+
+	validBackoffTypes := map[string]bool{"exponential": true, "fixed": true}
+	if !validBackoffTypes[c.RateLimitBackoff] {
+		return fmt.Errorf("invalid rate limit backoff type: %s (valid: exponential, fixed)", c.RateLimitBackoff)
+	}
+
+	if c.RateLimitMaxWait <= 0 {
+		return fmt.Errorf("rate limit max wait must be > 0")
+	}
+
+	if c.RateLimitMaxRetries < 0 {
+		return fmt.Errorf("rate limit max retries must be >= 0")
+	}
+
+	if len(c.RateLimitStatusCodes) == 0 {
+		return fmt.Errorf("rate limit status codes must not be empty")
+	}
+
 	return nil
 }
 

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -4,7 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+// validRateLimitDefaults returns valid rate limit configuration for tests
+func validRateLimitDefaults() (float64, string, time.Duration, int, []int) {
+	return 5.0, "exponential", 60 * time.Second, 5, []int{429, 503}
+}
 
 func TestValidate_Success(t *testing.T) {
 	// Create temporary test files
@@ -20,10 +26,15 @@ func TestValidate_Success(t *testing.T) {
 	}
 
 	config := &Config{
-		API:         apiSpec,
-		Roles:       rolesFile,
-		Concurrency: 5,
-		Output:      "terminal",
+		API:                  apiSpec,
+		Roles:                rolesFile,
+		Concurrency:          5,
+		Output:               "terminal",
+		RateLimit:            5.0,
+		RateLimitBackoff:     "exponential",
+		RateLimitMaxWait:     60 * time.Second,
+		RateLimitMaxRetries:  5,
+		RateLimitStatusCodes: []int{429, 503},
 	}
 
 	err := config.Validate()
@@ -80,11 +91,17 @@ func TestValidate_ConcurrencyTooLow(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rate, backoff, maxWait, maxRetries, statusCodes := validRateLimitDefaults()
 	config := &Config{
-		API:          apiSpec,
-		Roles:        rolesFile,
-		Concurrency:  0,
-		Output: "terminal",
+		API:                  apiSpec,
+		Roles:                rolesFile,
+		Concurrency:          0,
+		Output:               "terminal",
+		RateLimit:            rate,
+		RateLimitBackoff:     backoff,
+		RateLimitMaxWait:     maxWait,
+		RateLimitMaxRetries:  maxRetries,
+		RateLimitStatusCodes: statusCodes,
 	}
 
 	err := config.Validate()
@@ -106,11 +123,17 @@ func TestValidate_ConcurrencyTooHigh(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rate, backoff, maxWait, maxRetries, statusCodes := validRateLimitDefaults()
 	config := &Config{
-		API:          apiSpec,
-		Roles:        rolesFile,
-		Concurrency:  11, // DoS check: max is 10
-		Output: "terminal",
+		API:                  apiSpec,
+		Roles:                rolesFile,
+		Concurrency:          11, // DoS check: max is 10
+		Output:               "terminal",
+		RateLimit:            rate,
+		RateLimitBackoff:     backoff,
+		RateLimitMaxWait:     maxWait,
+		RateLimitMaxRetries:  maxRetries,
+		RateLimitStatusCodes: statusCodes,
 	}
 
 	err := config.Validate()
@@ -132,12 +155,18 @@ func TestValidate_InvalidProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rate, backoff, maxWait, maxRetries, statusCodes := validRateLimitDefaults()
 	config := &Config{
-		API:          apiSpec,
-		Roles:        rolesFile,
-		Proxy:        "not-a-valid-url",
-		Concurrency:  5,
-		Output: "terminal",
+		API:                  apiSpec,
+		Roles:                rolesFile,
+		Proxy:                "not-a-valid-url",
+		Concurrency:          5,
+		Output:               "terminal",
+		RateLimit:            rate,
+		RateLimitBackoff:     backoff,
+		RateLimitMaxWait:     maxWait,
+		RateLimitMaxRetries:  maxRetries,
+		RateLimitStatusCodes: statusCodes,
 	}
 
 	err := config.Validate()
@@ -159,11 +188,17 @@ func TestValidate_InvalidOutputFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rate, backoff, maxWait, maxRetries, statusCodes := validRateLimitDefaults()
 	config := &Config{
-		API:         apiSpec,
-		Roles:       rolesFile,
-		Concurrency: 5,
-		Output:      "xml", // Invalid format
+		API:                  apiSpec,
+		Roles:                rolesFile,
+		Concurrency:          5,
+		Output:               "xml", // Invalid format
+		RateLimit:            rate,
+		RateLimitBackoff:     backoff,
+		RateLimitMaxWait:     maxWait,
+		RateLimitMaxRetries:  maxRetries,
+		RateLimitStatusCodes: statusCodes,
 	}
 
 	err := config.Validate()

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -45,10 +45,10 @@ func TestValidate_Success(t *testing.T) {
 
 func TestValidate_MissingAPISpec(t *testing.T) {
 	config := &Config{
-		API:          "/nonexistent/api.yaml",
-		Roles:        "/tmp/roles.yaml",
-		Concurrency:  5,
-		Output: "terminal",
+		API:         "/nonexistent/api.yaml",
+		Roles:       "/tmp/roles.yaml",
+		Concurrency: 5,
+		Output:      "terminal",
 	}
 
 	err := config.Validate()
@@ -66,10 +66,10 @@ func TestValidate_MissingRolesFile(t *testing.T) {
 	}
 
 	config := &Config{
-		API:          apiSpec,
-		Roles:        "/nonexistent/roles.yaml",
-		Concurrency:  5,
-		Output: "terminal",
+		API:         apiSpec,
+		Roles:       "/nonexistent/roles.yaml",
+		Concurrency: 5,
+		Output:      "terminal",
 	}
 
 	err := config.Validate()

--- a/pkg/runner/execution.go
+++ b/pkg/runner/execution.go
@@ -1,0 +1,242 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/praetorian-inc/hadrian/pkg/auth"
+	"github.com/praetorian-inc/hadrian/pkg/log"
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/owasp"
+	"github.com/praetorian-inc/hadrian/pkg/roles"
+	"github.com/praetorian-inc/hadrian/pkg/templates"
+)
+
+// executeTemplate runs template against operation with role combinations
+func executeTemplate(
+	ctx context.Context,
+	executor *templates.Executor,
+	mutationExecutor *owasp.MutationExecutor,
+	tmpl *templates.CompiledTemplate,
+	op *model.Operation,
+	rolesCfg *roles.RoleConfig,
+	authCfg *auth.AuthConfig,
+	baseURL string,
+) ([]*model.Finding, error) {
+	// Check if this is a mutation template - route to MutationExecutor
+	if tmpl.Template != nil && tmpl.Template.Info.TestPattern == "mutation" {
+		return executeMutationTemplate(ctx, mutationExecutor, tmpl, op, rolesCfg, authCfg, baseURL)
+	}
+
+	var findings []*model.Finding
+
+	// For unauthenticated endpoints, run test only once without roles
+	if !tmpl.EndpointSelector.RequiresAuth {
+		variables := map[string]string{
+			"baseURL": baseURL,
+		}
+		for _, p := range op.PathParams {
+			if p.Example != nil {
+				variables[p.Name] = fmt.Sprintf("%v", p.Example)
+			} else {
+				variables[p.Name] = "1"
+			}
+		}
+
+		result, err := executor.Execute(ctx, tmpl, op, nil, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		if result.Matched {
+			finding := &model.Finding{
+				ID:              fmt.Sprintf("%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-")),
+				Category:        tmpl.Info.Category,
+				Name:            tmpl.Info.Name,
+				Severity:        model.Severity(tmpl.Info.Severity),
+				Endpoint:        op.Path,
+				Method:          op.Method,
+				AttackerRole:    "anonymous",
+				IsVulnerability: true,
+				Evidence: model.Evidence{
+					Response: result.Response,
+				},
+				RequestIDs: result.RequestIDs,
+				Timestamp:  time.Now(),
+			}
+			findings = append(findings, finding)
+		}
+		return findings, nil
+	}
+
+	// Get roles based on selector
+	attackerRoles := rolesCfg.GetRolesByPermissionLevel(tmpl.RoleSelector.AttackerPermissionLevel)
+	victimRoles := rolesCfg.GetRolesByPermissionLevel(tmpl.RoleSelector.VictimPermissionLevel)
+
+	// If no victim roles needed, use single-role tests
+	if tmpl.RoleSelector.VictimPermissionLevel == "" {
+		victimRoles = []*roles.Role{nil}
+	}
+
+	for _, attackerRole := range attackerRoles {
+		for _, victimRole := range victimRoles {
+			// Skip same-role if testing cross-role
+			if victimRole != nil && attackerRole.Name == victimRole.Name {
+				continue
+			}
+
+			// Build auth info for attacker
+			var authInfo *templates.AuthInfo
+			if authCfg != nil {
+				authValue, err := authCfg.GetAuth(attackerRole.Name)
+				if err != nil {
+					// Role may not have auth configured
+					continue
+				}
+
+				// Create AuthInfo from auth config
+				authInfo = &templates.AuthInfo{
+					Method:   authCfg.Method,
+					Location: authCfg.Location,
+					KeyName:  authCfg.KeyName,
+					Value:    authValue,
+				}
+			}
+
+			// Build variables for template substitution
+			variables := map[string]string{
+				"baseURL": baseURL,
+			}
+
+			// Add path parameter values
+			for _, p := range op.PathParams {
+				if p.Example != nil {
+					variables[p.Name] = fmt.Sprintf("%v", p.Example)
+				} else {
+					variables[p.Name] = "1" // Default value
+				}
+			}
+
+			// Execute template
+			result, err := executor.Execute(ctx, tmpl, op, authInfo, variables)
+			if err != nil {
+				return nil, err
+			}
+
+			// Check if vulnerability detected
+			if result.Matched {
+				finding := &model.Finding{
+					ID:              fmt.Sprintf("%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-")),
+					Category:        tmpl.Info.Category,
+					Name:            tmpl.Info.Name,
+					Severity:        model.Severity(tmpl.Info.Severity),
+					Endpoint:        op.Path,
+					Method:          op.Method,
+					AttackerRole:    attackerRole.Name,
+					IsVulnerability: true,
+					Evidence: model.Evidence{
+						Response: result.Response,
+					},
+					RequestIDs: result.RequestIDs,
+					Timestamp:  time.Now(),
+				}
+
+				if victimRole != nil {
+					finding.VictimRole = victimRole.Name
+				}
+
+				findings = append(findings, finding)
+			}
+		}
+	}
+
+	return findings, nil
+}
+
+// executeMutationTemplate runs a three-phase mutation test
+func executeMutationTemplate(
+	ctx context.Context,
+	executor *owasp.MutationExecutor,
+	tmpl *templates.CompiledTemplate,
+	op *model.Operation,
+	rolesCfg *roles.RoleConfig,
+	authCfg *auth.AuthConfig,
+	baseURL string,
+) ([]*model.Finding, error) {
+	var findings []*model.Finding
+
+	attackerRoles := rolesCfg.GetRolesByPermissionLevel(tmpl.RoleSelector.AttackerPermissionLevel)
+	victimRoles := rolesCfg.GetRolesByPermissionLevel(tmpl.RoleSelector.VictimPermissionLevel)
+
+	for _, attackerRole := range attackerRoles {
+		for _, victimRole := range victimRoles {
+			if victimRole == nil || attackerRole.Name == victimRole.Name {
+				continue
+			}
+
+			// Build auth info map for both roles
+			authInfos := make(map[string]*auth.AuthInfo)
+			if authCfg != nil {
+				if info, err := authCfg.GetAuthInfo(attackerRole.Name); err == nil {
+					authInfos["attacker"] = info
+				}
+				if info, err := authCfg.GetAuthInfo(victimRole.Name); err == nil {
+					authInfos["victim"] = info
+				}
+			}
+
+			// Clear tracker between tests
+			executor.ClearTracker()
+
+			// Execute three-phase mutation test
+			result, err := executor.ExecuteMutation(
+				ctx,
+				tmpl.Template,
+				op.Method,
+				attackerRole.Name,
+				victimRole.Name,
+				authInfos,
+				baseURL,
+			)
+			if err != nil {
+				log.Warn("Mutation test failed: %v", err)
+				continue
+			}
+
+			if result.Matched {
+				finding := &model.Finding{
+					ID:              fmt.Sprintf("%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-")),
+					Category:        tmpl.Info.Category,
+					Name:            tmpl.Info.Name,
+					Severity:        model.Severity(tmpl.Info.Severity),
+					Endpoint:        op.Path,
+					Method:          op.Method,
+					AttackerRole:    attackerRole.Name,
+					VictimRole:      victimRole.Name,
+					IsVulnerability: true,
+					Timestamp:       time.Now(),
+				}
+				if result.AttackResponse != nil {
+					finding.Evidence = model.Evidence{
+						Response: *result.AttackResponse,
+					}
+				}
+
+				// Collect all request IDs from all phases
+				if result.RequestIDs != nil {
+					var allRequestIDs []string
+					allRequestIDs = append(allRequestIDs, result.RequestIDs.Setup...)
+					allRequestIDs = append(allRequestIDs, result.RequestIDs.Attack...)
+					allRequestIDs = append(allRequestIDs, result.RequestIDs.Verify...)
+					finding.RequestIDs = allRequestIDs
+				}
+
+				findings = append(findings, finding)
+			}
+		}
+	}
+
+	return findings, nil
+}

--- a/pkg/runner/ratelimit.go
+++ b/pkg/runner/ratelimit.go
@@ -10,14 +10,14 @@ import (
 
 // RateLimitConfig configures rate limiting behavior including reactive backoff
 type RateLimitConfig struct {
-	Rate            float64       // Requests per second (default 5.0)
-	Enabled         bool          // Whether rate limiting is active (default true)
-	BackoffType     string        // "exponential" or "fixed" (default "exponential")
-	BackoffInitial  time.Duration // Initial backoff duration (default 1s)
-	BackoffMax      time.Duration // Maximum backoff duration (default 60s)
-	MaxRetries      int           // Maximum retry attempts on rate limit (default 5)
-	StatusCodes     []int         // HTTP status codes that trigger rate limiting (default [429, 503])
-	BodyPatterns    []string      // Optional body patterns to detect rate limiting
+	Rate           float64       // Requests per second (default 5.0)
+	Enabled        bool          // Whether rate limiting is active (default true)
+	BackoffType    string        // "exponential" or "fixed" (default "exponential")
+	BackoffInitial time.Duration // Initial backoff duration (default 1s)
+	BackoffMax     time.Duration // Maximum backoff duration (default 60s)
+	MaxRetries     int           // Maximum retry attempts on rate limit (default 5)
+	StatusCodes    []int         // HTTP status codes that trigger rate limiting (default [429, 503])
+	BodyPatterns   []string      // Optional body patterns to detect rate limiting
 }
 
 // DefaultRateLimitConfig returns the default rate limiting configuration

--- a/pkg/runner/ratelimit.go
+++ b/pkg/runner/ratelimit.go
@@ -3,9 +3,36 @@ package runner
 import (
 	"context"
 	"sync"
+	"time"
 
 	"golang.org/x/time/rate"
 )
+
+// RateLimitConfig configures rate limiting behavior including reactive backoff
+type RateLimitConfig struct {
+	Rate            float64       // Requests per second (default 5.0)
+	Enabled         bool          // Whether rate limiting is active (default true)
+	BackoffType     string        // "exponential" or "fixed" (default "exponential")
+	BackoffInitial  time.Duration // Initial backoff duration (default 1s)
+	BackoffMax      time.Duration // Maximum backoff duration (default 60s)
+	MaxRetries      int           // Maximum retry attempts on rate limit (default 5)
+	StatusCodes     []int         // HTTP status codes that trigger rate limiting (default [429, 503])
+	BodyPatterns    []string      // Optional body patterns to detect rate limiting
+}
+
+// DefaultRateLimitConfig returns the default rate limiting configuration
+func DefaultRateLimitConfig() *RateLimitConfig {
+	return &RateLimitConfig{
+		Rate:           5.0,
+		Enabled:        true,
+		BackoffType:    "exponential",
+		BackoffInitial: 1 * time.Second,
+		BackoffMax:     60 * time.Second,
+		MaxRetries:     5,
+		StatusCodes:    []int{429, 503},
+		BodyPatterns:   []string{},
+	}
+}
 
 // RateLimiter controls request rate to prevent DoS (HR-1)
 // Provides both global rate limiting and per-endpoint rate limiting

--- a/pkg/runner/ratelimit_client.go
+++ b/pkg/runner/ratelimit_client.go
@@ -1,0 +1,155 @@
+package runner
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/praetorian-inc/hadrian/pkg/log"
+	"github.com/praetorian-inc/hadrian/pkg/templates"
+)
+
+// RateLimitingClient wraps an HTTPClient with rate limiting and reactive backoff
+type RateLimitingClient struct {
+	client  templates.HTTPClient
+	limiter *RateLimiter
+	config  *RateLimitConfig
+}
+
+// NewRateLimitingClient creates a new rate-limiting HTTP client wrapper
+func NewRateLimitingClient(client templates.HTTPClient, limiter *RateLimiter, config *RateLimitConfig) *RateLimitingClient {
+	if config == nil {
+		config = DefaultRateLimitConfig()
+	}
+	return &RateLimitingClient{
+		client:  client,
+		limiter: limiter,
+		config:  config,
+	}
+}
+
+// Do executes an HTTP request with proactive rate limiting and reactive backoff
+func (c *RateLimitingClient) Do(req *http.Request) (*http.Response, error) {
+	if !c.config.Enabled {
+		return c.client.Do(req)
+	}
+
+	endpoint := req.Method + " " + req.URL.Path
+
+	if err := c.limiter.Wait(req.Context(), endpoint); err != nil {
+		return nil, fmt.Errorf("rate limit wait failed: %w", err)
+	}
+
+	return c.retryWithBackoff(req, endpoint)
+}
+
+// retryWithBackoff executes a request with retry logic for rate limit responses
+func (c *RateLimitingClient) retryWithBackoff(req *http.Request, endpoint string) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt <= c.config.MaxRetries; attempt++ {
+		resp, err = c.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if c.isRateLimited(resp) {
+			resp.Body.Close()
+
+			if attempt < c.config.MaxRetries {
+				backoff := c.calculateBackoff(attempt, resp)
+				log.Debug("Rate limited on %s (attempt %d/%d), backing off for %v",
+					endpoint, attempt+1, c.config.MaxRetries, backoff)
+
+				select {
+				case <-time.After(backoff):
+					continue
+				case <-req.Context().Done():
+					return nil, req.Context().Err()
+				}
+			}
+
+			// Defensive cleanup before returning error
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+			return nil, fmt.Errorf("max retries (%d) exceeded for rate-limited endpoint: %s", c.config.MaxRetries, endpoint)
+		}
+
+		return resp, nil
+	}
+
+	return resp, nil
+}
+
+// isRateLimited checks if the response indicates rate limiting
+func (c *RateLimitingClient) isRateLimited(resp *http.Response) bool {
+	// Check status code
+	for _, code := range c.config.StatusCodes {
+		if resp.StatusCode == code {
+			log.Debug("Rate limit detected: status code %d", resp.StatusCode)
+			return true
+		}
+	}
+
+	// TODO: Implement body pattern matching if needed
+	// This would require reading the response body, which we want to avoid
+	// unless absolutely necessary to preserve the body for caller
+
+	return false
+}
+
+// calculateBackoff determines the wait time before retry
+func (c *RateLimitingClient) calculateBackoff(attempt int, resp *http.Response) time.Duration {
+	// Check for Retry-After header first
+	if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+		// Try parsing as seconds (integer)
+		if seconds, err := strconv.Atoi(retryAfter); err == nil {
+			duration := time.Duration(seconds) * time.Second
+			// Cap at BackoffMax
+			if duration > c.config.BackoffMax {
+				return c.config.BackoffMax
+			}
+			log.Debug("Using Retry-After header: %v", duration)
+			return duration
+		}
+
+		// Try parsing as HTTP date (RFC1123)
+		if retryTime, err := time.Parse(time.RFC1123, retryAfter); err == nil {
+			duration := time.Until(retryTime)
+			if duration < 0 {
+				duration = c.config.BackoffInitial
+			}
+			// Cap at BackoffMax
+			if duration > c.config.BackoffMax {
+				return c.config.BackoffMax
+			}
+			log.Debug("Using Retry-After header (date): %v", duration)
+			return duration
+		}
+	}
+
+	// Calculate backoff based on configuration
+	var backoff time.Duration
+	switch strings.ToLower(c.config.BackoffType) {
+	case "fixed":
+		backoff = c.config.BackoffInitial
+	case "exponential":
+		// Exponential: initial * 2^attempt
+		backoff = time.Duration(float64(c.config.BackoffInitial) * math.Pow(2, float64(attempt)))
+	default:
+		// Default to exponential
+		backoff = time.Duration(float64(c.config.BackoffInitial) * math.Pow(2, float64(attempt)))
+	}
+
+	// Cap at maximum
+	if backoff > c.config.BackoffMax {
+		backoff = c.config.BackoffMax
+	}
+
+	return backoff
+}

--- a/pkg/runner/ratelimit_client_test.go
+++ b/pkg/runner/ratelimit_client_test.go
@@ -1,0 +1,358 @@
+package runner
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockHTTPClient simulates an HTTP client for testing
+type mockHTTPClient struct {
+	responses []*http.Response
+	errors    []error
+	callCount int
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if m.callCount >= len(m.responses) {
+		return nil, io.EOF
+	}
+
+	resp := m.responses[m.callCount]
+	var err error
+	if m.callCount < len(m.errors) {
+		err = m.errors[m.callCount]
+	}
+	m.callCount++
+
+	return resp, err
+}
+
+// makeResponse creates a test HTTP response
+func makeResponse(statusCode int, body string, headers map[string]string) *http.Response {
+	resp := &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+	for k, v := range headers {
+		resp.Header.Set(k, v)
+	}
+	return resp
+}
+
+func TestRateLimitingClient_ProactiveRateLimiting(t *testing.T) {
+	// Test that proactive rate limiting respects configured rate
+	config := &RateLimitConfig{
+		Rate:           10.0, // 10 req/s
+		Enabled:        true,
+		BackoffType:    "exponential",
+		BackoffInitial: 100 * time.Millisecond,
+		BackoffMax:     1 * time.Second,
+		MaxRetries:     3,
+		StatusCodes:    []int{429, 503},
+	}
+
+	limiter := NewRateLimiter(config.Rate, config.Rate)
+	mockClient := &mockHTTPClient{
+		responses: []*http.Response{
+			makeResponse(200, "OK", nil),
+			makeResponse(200, "OK", nil),
+			makeResponse(200, "OK", nil),
+		},
+	}
+
+	client := NewRateLimitingClient(mockClient, limiter, config)
+
+	// Make requests and measure timing
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		resp.Body.Close()
+	}
+	elapsed := time.Since(start)
+
+	// With 10 req/s, 3 requests should take at least 200ms (spacing between requests)
+	// Allow some tolerance for timing precision
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(150), "Rate limiting should delay requests")
+}
+
+func TestRateLimitingClient_ExponentialBackoff(t *testing.T) {
+	config := &RateLimitConfig{
+		Rate:           10.0,
+		Enabled:        true,
+		BackoffType:    "exponential",
+		BackoffInitial: 100 * time.Millisecond,
+		BackoffMax:     1 * time.Second,
+		MaxRetries:     3,
+		StatusCodes:    []int{429},
+	}
+
+	limiter := NewRateLimiter(config.Rate, config.Rate)
+	mockClient := &mockHTTPClient{
+		responses: []*http.Response{
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(200, "OK", nil),
+		},
+	}
+
+	client := NewRateLimitingClient(mockClient, limiter, config)
+
+	start := time.Now()
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	resp, err := client.Do(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	resp.Body.Close()
+
+	// Exponential backoff: 100ms (attempt 0) + 200ms (attempt 1) = 300ms minimum
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(250), "Exponential backoff should double wait time")
+	assert.Equal(t, 3, mockClient.callCount, "Should make 3 attempts")
+}
+
+func TestRateLimitingClient_FixedBackoff(t *testing.T) {
+	config := &RateLimitConfig{
+		Rate:           10.0,
+		Enabled:        true,
+		BackoffType:    "fixed",
+		BackoffInitial: 100 * time.Millisecond,
+		BackoffMax:     1 * time.Second,
+		MaxRetries:     3,
+		StatusCodes:    []int{429},
+	}
+
+	limiter := NewRateLimiter(config.Rate, config.Rate)
+	mockClient := &mockHTTPClient{
+		responses: []*http.Response{
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(200, "OK", nil),
+		},
+	}
+
+	client := NewRateLimitingClient(mockClient, limiter, config)
+
+	start := time.Now()
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	resp, err := client.Do(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	resp.Body.Close()
+
+	// Fixed backoff: 100ms * 2 retries = 200ms minimum
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(150), "Fixed backoff should use constant wait time")
+	assert.Equal(t, 3, mockClient.callCount, "Should make 3 attempts")
+}
+
+func TestRateLimitingClient_MaxRetriesExceeded(t *testing.T) {
+	config := &RateLimitConfig{
+		Rate:           10.0,
+		Enabled:        true,
+		BackoffType:    "exponential",
+		BackoffInitial: 10 * time.Millisecond, // Short for fast test
+		BackoffMax:     100 * time.Millisecond,
+		MaxRetries:     2,
+		StatusCodes:    []int{429},
+	}
+
+	limiter := NewRateLimiter(config.Rate, config.Rate)
+	mockClient := &mockHTTPClient{
+		responses: []*http.Response{
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(200, "OK", nil), // Should not reach this
+		},
+	}
+
+	client := NewRateLimitingClient(mockClient, limiter, config)
+
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	resp, err := client.Do(req)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "max retries")
+	assert.Equal(t, 3, mockClient.callCount, "Should make MaxRetries+1 attempts")
+}
+
+func TestRateLimitingClient_RetryAfterHeader(t *testing.T) {
+	config := &RateLimitConfig{
+		Rate:           10.0,
+		Enabled:        true,
+		BackoffType:    "exponential",
+		BackoffInitial: 100 * time.Millisecond,
+		BackoffMax:     5 * time.Second,
+		MaxRetries:     2,
+		StatusCodes:    []int{429},
+	}
+
+	limiter := NewRateLimiter(config.Rate, config.Rate)
+
+	t.Run("Retry-After as seconds", func(t *testing.T) {
+		mockClient := &mockHTTPClient{
+			responses: []*http.Response{
+				makeResponse(429, "Rate limited", map[string]string{"Retry-After": "1"}),
+				makeResponse(200, "OK", nil),
+			},
+		}
+
+		client := NewRateLimitingClient(mockClient, limiter, config)
+
+		start := time.Now()
+		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+		resp, err := client.Do(req)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, 200, resp.StatusCode)
+		resp.Body.Close()
+
+		// Should respect Retry-After: 1 second
+		assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(900), "Should honor Retry-After header")
+	})
+}
+
+func TestRateLimitingClient_ContextCancellation(t *testing.T) {
+	config := &RateLimitConfig{
+		Rate:           10.0,
+		Enabled:        true,
+		BackoffType:    "exponential",
+		BackoffInitial: 500 * time.Millisecond,
+		BackoffMax:     5 * time.Second,
+		MaxRetries:     5,
+		StatusCodes:    []int{429},
+	}
+
+	limiter := NewRateLimiter(config.Rate, config.Rate)
+	mockClient := &mockHTTPClient{
+		responses: []*http.Response{
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(429, "Rate limited", nil),
+			makeResponse(200, "OK", nil),
+		},
+	}
+
+	client := NewRateLimitingClient(mockClient, limiter, config)
+
+	// Create context with short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com/test", nil)
+	resp, err := client.Do(req)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRateLimitingClient_MultipleStatusCodes(t *testing.T) {
+	config := &RateLimitConfig{
+		Rate:           10.0,
+		Enabled:        true,
+		BackoffType:    "fixed",
+		BackoffInitial: 50 * time.Millisecond,
+		BackoffMax:     1 * time.Second,
+		MaxRetries:     3,
+		StatusCodes:    []int{429, 503}, // Both 429 and 503 should trigger retry
+	}
+
+	limiter := NewRateLimiter(config.Rate, config.Rate)
+
+	t.Run("Status 429", func(t *testing.T) {
+		mockClient := &mockHTTPClient{
+			responses: []*http.Response{
+				makeResponse(429, "Too Many Requests", nil),
+				makeResponse(200, "OK", nil),
+			},
+		}
+
+		client := NewRateLimitingClient(mockClient, limiter, config)
+		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+		resp, err := client.Do(req)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, 200, resp.StatusCode)
+		resp.Body.Close()
+	})
+
+	t.Run("Status 503", func(t *testing.T) {
+		mockClient := &mockHTTPClient{
+			responses: []*http.Response{
+				makeResponse(503, "Service Unavailable", nil),
+				makeResponse(200, "OK", nil),
+			},
+		}
+
+		client := NewRateLimitingClient(mockClient, limiter, config)
+		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+		resp, err := client.Do(req)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, 200, resp.StatusCode)
+		resp.Body.Close()
+	})
+}
+
+func TestRateLimitingClient_DisabledRateLimiting(t *testing.T) {
+	config := &RateLimitConfig{
+		Rate:           10.0,
+		Enabled:        false, // Rate limiting disabled
+		BackoffType:    "exponential",
+		BackoffInitial: 100 * time.Millisecond,
+		BackoffMax:     1 * time.Second,
+		MaxRetries:     3,
+		StatusCodes:    []int{429},
+	}
+
+	limiter := NewRateLimiter(config.Rate, config.Rate)
+	mockClient := &mockHTTPClient{
+		responses: []*http.Response{
+			makeResponse(429, "Rate limited", nil), // Should not retry when disabled
+		},
+	}
+
+	client := NewRateLimitingClient(mockClient, limiter, config)
+
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	resp, err := client.Do(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 429, resp.StatusCode) // Should return 429 without retrying
+	resp.Body.Close()
+	assert.Equal(t, 1, mockClient.callCount, "Should only make 1 attempt when disabled")
+}
+
+func TestDefaultRateLimitConfig(t *testing.T) {
+	config := DefaultRateLimitConfig()
+
+	assert.Equal(t, 5.0, config.Rate)
+	assert.True(t, config.Enabled)
+	assert.Equal(t, "exponential", config.BackoffType)
+	assert.Equal(t, 1*time.Second, config.BackoffInitial)
+	assert.Equal(t, 60*time.Second, config.BackoffMax)
+	assert.Equal(t, 5, config.MaxRetries)
+	assert.Equal(t, []int{429, 503}, config.StatusCodes)
+	assert.Empty(t, config.BodyPatterns)
+}

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -22,27 +22,31 @@ import (
 
 // Config holds the test command configuration
 type Config struct {
-	API             string
-	Roles           string
-	Auth            string
-	Proxy           string
-	CACert          string
-	Insecure        bool
-	Concurrency     int
-	RateLimit       float64
-	Timeout         int
-	AllowProduction bool
-	AllowInternal   bool
-	Output          string
-	OutputFile      string
-	Categories      []string
-	TemplateDir     string   // Directory containing templates
-	Templates       []string // Filter templates by ID or name
-	AuditLog        string
-	OWASPCategories []string
-	Verbose         bool
-	DryRun          bool
-	RequestIDsLimit int // Number of request IDs to display per finding (0 = all)
+	API                  string
+	Roles                string
+	Auth                 string
+	Proxy                string
+	CACert               string
+	Insecure             bool
+	Concurrency          int
+	RateLimit            float64
+	RateLimitBackoff     string        // Backoff type: exponential or fixed
+	RateLimitMaxWait     time.Duration // Maximum backoff wait time
+	RateLimitMaxRetries  int           // Maximum retry attempts on rate limit
+	RateLimitStatusCodes []int         // Status codes that trigger rate limit retry
+	Timeout              int
+	AllowProduction      bool
+	AllowInternal        bool
+	Output               string
+	OutputFile           string
+	Categories           []string
+	TemplateDir          string   // Directory containing templates
+	Templates            []string // Filter templates by ID or name
+	AuditLog             string
+	OWASPCategories      []string
+	Verbose              bool
+	DryRun               bool
+	RequestIDsLimit      int // Number of request IDs to display per finding (0 = all)
 }
 
 // Run is the main entry point for the Hadrian CLI
@@ -86,6 +90,10 @@ func newTestCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&config.Insecure, "insecure", false, "Skip TLS verification (use with proxies)")
 	cmd.Flags().IntVar(&config.Concurrency, "concurrency", 1, "Concurrent requests (max: 10)")
 	cmd.Flags().Float64Var(&config.RateLimit, "rate-limit", 5.0, "Global rate limit (req/s)")
+	cmd.Flags().StringVar(&config.RateLimitBackoff, "rate-limit-backoff", "exponential", "Backoff type for rate limit retries: exponential, fixed")
+	cmd.Flags().DurationVar(&config.RateLimitMaxWait, "rate-limit-max-wait", 60*time.Second, "Maximum backoff wait time on rate limit")
+	cmd.Flags().IntVar(&config.RateLimitMaxRetries, "rate-limit-max-retries", 5, "Maximum retry attempts on rate limit response")
+	cmd.Flags().IntSliceVar(&config.RateLimitStatusCodes, "rate-limit-status-codes", []int{429, 503}, "Status codes that trigger rate limit retry")
 	cmd.Flags().IntVar(&config.Timeout, "timeout", 30, "Request timeout (seconds)")
 	cmd.Flags().BoolVar(&config.AllowProduction, "allow-production", false, "Allow testing production URLs")
 	cmd.Flags().BoolVar(&config.AllowInternal, "allow-internal", false, "Allow testing internal/private IP addresses")
@@ -178,6 +186,20 @@ func runTest(ctx context.Context, config Config) error {
 		return fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
+	// 6a. Wrap HTTP client with rate limiting
+	rateLimitConfig := &RateLimitConfig{
+		Rate:           config.RateLimit,
+		Enabled:        true,
+		BackoffType:    config.RateLimitBackoff,
+		BackoffInitial: 1 * time.Second,
+		BackoffMax:     config.RateLimitMaxWait,
+		MaxRetries:     config.RateLimitMaxRetries,
+		StatusCodes:    config.RateLimitStatusCodes,
+		BodyPatterns:   []string{},
+	}
+	rateLimiter := NewRateLimiter(config.RateLimit, config.RateLimit)
+	rateLimitingClient := NewRateLimitingClient(httpClient, rateLimiter, rateLimitConfig)
+
 	// 7. Create reporter based on output format
 	rep, err := createReporter(config.Output, config.OutputFile, config.RequestIDsLimit)
 	if err != nil {
@@ -213,11 +235,11 @@ func runTest(ctx context.Context, config Config) error {
 	fmt.Printf("[INFO] Loaded %d templates\n", len(tmplFiles))
 	fmt.Printf("[INFO] Testing %d operations against %d roles\n", len(spec.Operations), len(rolesCfg.Roles))
 
-	// 9. Create template executor
-	executor := templates.NewExecutor(httpClient)
+	// 9. Create template executor with rate-limiting client
+	executor := templates.NewExecutor(rateLimitingClient)
 
-	// 10. Create mutation executor for mutation templates
-	mutationExecutor := owasp.NewMutationExecutor(httpClient)
+	// 10. Create mutation executor for mutation templates with rate-limiting client
+	mutationExecutor := owasp.NewMutationExecutor(rateLimitingClient)
 
 	// 11. Run tests for each operation
 	var allFindings []*model.Finding
@@ -396,233 +418,6 @@ func templateApplies(tmpl *templates.CompiledTemplate, op *model.Operation) bool
 	}
 
 	return true
-}
-
-// executeTemplate runs template against operation with role combinations
-func executeTemplate(
-	ctx context.Context,
-	executor *templates.Executor,
-	mutationExecutor *owasp.MutationExecutor,
-	tmpl *templates.CompiledTemplate,
-	op *model.Operation,
-	rolesCfg *roles.RoleConfig,
-	authCfg *auth.AuthConfig,
-	baseURL string,
-) ([]*model.Finding, error) {
-	// Check if this is a mutation template - route to MutationExecutor
-	if tmpl.Template != nil && tmpl.Template.Info.TestPattern == "mutation" {
-		return executeMutationTemplate(ctx, mutationExecutor, tmpl, op, rolesCfg, authCfg, baseURL)
-	}
-
-	var findings []*model.Finding
-
-	// For unauthenticated endpoints, run test only once without roles
-	if !tmpl.EndpointSelector.RequiresAuth {
-		variables := map[string]string{
-			"baseURL": baseURL,
-		}
-		for _, p := range op.PathParams {
-			if p.Example != nil {
-				variables[p.Name] = fmt.Sprintf("%v", p.Example)
-			} else {
-				variables[p.Name] = "1"
-			}
-		}
-
-		result, err := executor.Execute(ctx, tmpl, op, nil, variables)
-		if err != nil {
-			return nil, err
-		}
-
-		if result.Matched {
-			finding := &model.Finding{
-				ID:              fmt.Sprintf("%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-")),
-				Category:        tmpl.Info.Category,
-				Name:            tmpl.Info.Name,
-				Severity:        model.Severity(tmpl.Info.Severity),
-				Endpoint:        op.Path,
-				Method:          op.Method,
-				AttackerRole:    "anonymous",
-				IsVulnerability: true,
-				Evidence: model.Evidence{
-					Response: result.Response,
-				},
-				RequestIDs: result.RequestIDs,
-				Timestamp:  time.Now(),
-			}
-			findings = append(findings, finding)
-		}
-		return findings, nil
-	}
-
-	// Get roles based on selector
-	attackerRoles := rolesCfg.GetRolesByPermissionLevel(tmpl.RoleSelector.AttackerPermissionLevel)
-	victimRoles := rolesCfg.GetRolesByPermissionLevel(tmpl.RoleSelector.VictimPermissionLevel)
-
-	// If no victim roles needed, use single-role tests
-	if tmpl.RoleSelector.VictimPermissionLevel == "" {
-		victimRoles = []*roles.Role{nil}
-	}
-
-	for _, attackerRole := range attackerRoles {
-		for _, victimRole := range victimRoles {
-			// Skip same-role if testing cross-role
-			if victimRole != nil && attackerRole.Name == victimRole.Name {
-				continue
-			}
-
-			// Build auth info for attacker
-			var authInfo *templates.AuthInfo
-			if authCfg != nil {
-				authValue, err := authCfg.GetAuth(attackerRole.Name)
-				if err != nil {
-					// Role may not have auth configured
-					continue
-				}
-
-				// Create AuthInfo from auth config
-				authInfo = &templates.AuthInfo{
-					Method:   authCfg.Method,
-					Location: authCfg.Location,
-					KeyName:  authCfg.KeyName,
-					Value:    authValue,
-				}
-			}
-
-			// Build variables for template substitution
-			variables := map[string]string{
-				"baseURL": baseURL,
-			}
-
-			// Add path parameter values
-			for _, p := range op.PathParams {
-				if p.Example != nil {
-					variables[p.Name] = fmt.Sprintf("%v", p.Example)
-				} else {
-					variables[p.Name] = "1" // Default value
-				}
-			}
-
-			// Execute template
-			result, err := executor.Execute(ctx, tmpl, op, authInfo, variables)
-			if err != nil {
-				return nil, err
-			}
-
-			// Check if vulnerability detected
-			if result.Matched {
-				finding := &model.Finding{
-					ID:              fmt.Sprintf("%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-")),
-					Category:        tmpl.Info.Category,
-					Name:            tmpl.Info.Name,
-					Severity:        model.Severity(tmpl.Info.Severity),
-					Endpoint:        op.Path,
-					Method:          op.Method,
-					AttackerRole:    attackerRole.Name,
-					IsVulnerability: true,
-					Evidence: model.Evidence{
-						Response: result.Response,
-					},
-					RequestIDs: result.RequestIDs,
-					Timestamp:  time.Now(),
-				}
-
-				if victimRole != nil {
-					finding.VictimRole = victimRole.Name
-				}
-
-				findings = append(findings, finding)
-			}
-		}
-	}
-
-	return findings, nil
-}
-
-// executeMutationTemplate runs a three-phase mutation test
-func executeMutationTemplate(
-	ctx context.Context,
-	executor *owasp.MutationExecutor,
-	tmpl *templates.CompiledTemplate,
-	op *model.Operation,
-	rolesCfg *roles.RoleConfig,
-	authCfg *auth.AuthConfig,
-	baseURL string,
-) ([]*model.Finding, error) {
-	var findings []*model.Finding
-
-	attackerRoles := rolesCfg.GetRolesByPermissionLevel(tmpl.RoleSelector.AttackerPermissionLevel)
-	victimRoles := rolesCfg.GetRolesByPermissionLevel(tmpl.RoleSelector.VictimPermissionLevel)
-
-	for _, attackerRole := range attackerRoles {
-		for _, victimRole := range victimRoles {
-			if victimRole == nil || attackerRole.Name == victimRole.Name {
-				continue
-			}
-
-			// Build auth info map for both roles
-			authInfos := make(map[string]*auth.AuthInfo)
-			if authCfg != nil {
-				if info, err := authCfg.GetAuthInfo(attackerRole.Name); err == nil {
-					authInfos["attacker"] = info
-				}
-				if info, err := authCfg.GetAuthInfo(victimRole.Name); err == nil {
-					authInfos["victim"] = info
-				}
-			}
-
-			// Clear tracker between tests
-			executor.ClearTracker()
-
-			// Execute three-phase mutation test
-			result, err := executor.ExecuteMutation(
-				ctx,
-				tmpl.Template,
-				op.Method,
-				attackerRole.Name,
-				victimRole.Name,
-				authInfos,
-				baseURL,
-			)
-			if err != nil {
-				log.Warn("Mutation test failed: %v", err)
-				continue
-			}
-
-			if result.Matched {
-				finding := &model.Finding{
-					ID:              fmt.Sprintf("%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-")),
-					Category:        tmpl.Info.Category,
-					Name:            tmpl.Info.Name,
-					Severity:        model.Severity(tmpl.Info.Severity),
-					Endpoint:        op.Path,
-					Method:          op.Method,
-					AttackerRole:    attackerRole.Name,
-					VictimRole:      victimRole.Name,
-					IsVulnerability: true,
-					Timestamp:       time.Now(),
-				}
-				if result.AttackResponse != nil {
-					finding.Evidence = model.Evidence{
-						Response: *result.AttackResponse,
-					}
-				}
-
-				// Collect all request IDs from all phases
-				if result.RequestIDs != nil {
-					var allRequestIDs []string
-					allRequestIDs = append(allRequestIDs, result.RequestIDs.Setup...)
-					allRequestIDs = append(allRequestIDs, result.RequestIDs.Attack...)
-					allRequestIDs = append(allRequestIDs, result.RequestIDs.Verify...)
-					finding.RequestIDs = allRequestIDs
-				}
-
-				findings = append(findings, finding)
-			}
-		}
-	}
-
-	return findings, nil
 }
 
 // hasLLMConfig checks if LLM provider is configured

--- a/testdata/ratelimit-demo/.gitignore
+++ b/testdata/ratelimit-demo/.gitignore
@@ -1,0 +1,19 @@
+# Binaries
+ratelimit-demo
+ratelimit-demo-test
+
+# Go build artifacts
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Dependency directories
+vendor/

--- a/testdata/ratelimit-demo/README.md
+++ b/testdata/ratelimit-demo/README.md
@@ -1,0 +1,399 @@
+# Rate Limit Demo Server
+
+A Go web application demonstrating various rate limiting patterns for testing Hadrian's rate limit detection capabilities.
+
+## Quick Start
+
+```bash
+# Build the server
+cd /workspaces/praetorian-dev/modules/hadrian/testdata/ratelimit-demo
+go build -o ratelimit-demo .
+
+# Start the server
+./ratelimit-demo
+
+# In another terminal, test an endpoint
+curl http://localhost:8080/api/v1/status-429/resource
+
+# Run 6 times to see rate limiting
+for i in {1..6}; do curl http://localhost:8080/api/v1/status-429/resource; echo; done
+```
+
+## Server Options
+
+```bash
+./ratelimit-demo [flags]
+
+Flags:
+  -port int              Server port (default 8080)
+  -default-limit int     Default rate limit (default 5)
+  -default-window duration Default time window (default 60s)
+```
+
+## Endpoints
+
+### Baseline (No Rate Limit)
+
+| Endpoint | Description | Rate Limit |
+|----------|-------------|------------|
+| `GET /api/v1/basic/resource` | Baseline endpoint | **None** (always 200) |
+
+**Example:**
+```bash
+# Make 100 requests - all succeed
+for i in {1..100}; do curl -s http://localhost:8080/api/v1/basic/resource | jq -r .status; done
+```
+
+### Status Code Patterns
+
+| Endpoint | Description | Response When Limited |
+|----------|-------------|----------------------|
+| `GET /api/v1/status-429/resource` | Returns 429 after limit | `429 Too Many Requests` |
+| `GET /api/v1/status-503/resource` | Returns 503 after limit | `503 Service Unavailable` |
+
+**Example:**
+```bash
+# Exhaust limit (5 requests), then get 429
+for i in {1..6}; do
+  curl -s -w "\nHTTP Status: %{http_code}\n" http://localhost:8080/api/v1/status-429/resource
+done
+```
+
+### Retry-After Patterns
+
+| Endpoint | Description | Retry-After Format |
+|----------|-------------|-------------------|
+| `GET /api/v1/retry-seconds/resource` | Returns Retry-After in seconds | `Retry-After: 5` |
+| `GET /api/v1/retry-date/resource` | Returns Retry-After as HTTP-date | `Retry-After: Fri, 31 Jan 2026 12:00:05 GMT` |
+
+**Example:**
+```bash
+# Exhaust limit, see Retry-After header
+for i in {1..6}; do
+  curl -i http://localhost:8080/api/v1/retry-seconds/resource 2>&1 | grep -E "(HTTP/|Retry-After:)"
+done
+```
+
+### X-RateLimit Headers
+
+| Endpoint | Description | Headers Included |
+|----------|-------------|-----------------|
+| `GET /api/v1/ratelimit-headers/resource` | Returns standard rate limit headers | `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` |
+
+**Example:**
+```bash
+# See rate limit headers on each request
+for i in {1..6}; do
+  echo "Request $i:"
+  curl -i http://localhost:8080/api/v1/ratelimit-headers/resource 2>&1 | \
+    grep -E "(X-RateLimit-|HTTP/)"
+done
+```
+
+### Response Body Patterns
+
+| Endpoint | Description | Content-Type | Body Format |
+|----------|-------------|--------------|-------------|
+| `GET /api/v1/body-plain/resource` | Plain text error | `text/plain` | `Too Many Requests` |
+| `GET /api/v1/body-json/resource` | JSON error | `application/json` | `{"error": "rate_limit_exceeded"}` |
+| `GET /api/v1/body-json-retry/resource` | JSON with retry info | `application/json` | `{"error": "...", "retry_after": 5, "message": "..."}` |
+
+**Example:**
+```bash
+# See JSON error response
+for i in {1..6}; do
+  curl -s http://localhost:8080/api/v1/body-json-retry/resource | jq .
+done
+```
+
+### Scoping Patterns
+
+| Endpoint | Description | Counter Scope |
+|----------|-------------|--------------|
+| `GET /api/v1/global/resource` | Shared counter | All `/global/*` endpoints share one counter |
+| `GET /api/v1/global/other` | Shared counter | Same counter as `/global/resource` |
+| `GET /api/v1/per-endpoint/one` | Independent counter | Each endpoint has its own counter |
+| `GET /api/v1/per-endpoint/two` | Independent counter | Separate from `/per-endpoint/one` |
+| `GET /api/v1/per-ip/resource` | Per-IP counter | Each client IP has independent counter |
+
+**Example (Global Shared Counter):**
+```bash
+# Make 3 requests to /global/resource and 3 to /global/other
+# The 6th request (to either) will be rate limited
+for i in {1..3}; do curl -s http://localhost:8080/api/v1/global/resource?limit=5 | jq -r .status; done
+for i in {1..3}; do curl -s http://localhost:8080/api/v1/global/other?limit=5 | jq -r .status; done
+```
+
+**Example (Per-Endpoint Independent):**
+```bash
+# Exhaust /per-endpoint/one (5 requests)
+for i in {1..5}; do curl -s http://localhost:8080/api/v1/per-endpoint/one | jq -r .status; done
+
+# /per-endpoint/two still works (independent counter)
+curl -s http://localhost:8080/api/v1/per-endpoint/two | jq -r .status  # Returns "ok"
+```
+
+## Query Parameters
+
+All rate-limited endpoints support:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | int | 5 | Number of requests allowed before rate limiting |
+| `window` | int | 60 | Time window in seconds before counter resets |
+
+**Example:**
+```bash
+# Custom limit of 3 requests with 10-second window
+curl "http://localhost:8080/api/v1/status-429/resource?limit=3&window=10"
+
+# After 3 requests, wait 10 seconds for reset
+for i in {1..4}; do
+  curl -s "http://localhost:8080/api/v1/status-429/resource?limit=3&window=10"
+  echo
+done
+sleep 10
+curl -s "http://localhost:8080/api/v1/status-429/resource?limit=3&window=10"  # Works again
+```
+
+## Testing with Hadrian
+
+### Run Hadrian Against Demo Server
+
+```bash
+# Start the demo server
+cd /workspaces/praetorian-dev/modules/hadrian/testdata/ratelimit-demo
+./ratelimit-demo &
+
+# Run Hadrian with rate limit templates
+cd /workspaces/praetorian-dev/modules/hadrian
+HADRIAN_TEMPLATES=testdata/ratelimit-demo/templates ./hadrian test \
+  --api testdata/ratelimit-demo/openapi.yaml \
+  --roles testdata/ratelimit-demo/roles.yaml \
+  --allow-internal \
+  --verbose
+
+# Stop the server
+kill %1
+```
+
+### Expected Hadrian Findings
+
+| Template | Endpoint Pattern | Expected Result |
+|----------|-----------------|----------------|
+| `detect-429.yaml` | `/status-429/*` | ✅ Detects 429 rate limiting |
+| `detect-503.yaml` | `/status-503/*` | ✅ Detects 503 rate limiting |
+| `detect-no-limit.yaml` | `/basic/*` | ⚠️ **Vulnerability**: No rate limit detected |
+| `detect-retry-after.yaml` | `/retry-*/*` | ℹ️ Info: Retry-After header present |
+
+### Hadrian --rate-limit Flag Interaction
+
+Hadrian's `--rate-limit` flag controls **client-side request pacing** to avoid overwhelming the target:
+
+```bash
+# Hadrian sends requests at 10 req/s (prevents client from being rate limited)
+./hadrian test --api openapi.yaml --rate-limit 10
+
+# Server-side rate limiting (what we're testing) is independent
+# The demo server still enforces its own limits (default: 5 req/60s per endpoint)
+```
+
+**Key difference:**
+- **Hadrian `--rate-limit`**: Client-side throttling (how fast Hadrian sends requests)
+- **Demo server limits**: Server-side enforcement (what the server allows)
+
+## Implementation Details
+
+### Rate Limiter Algorithm
+
+The server uses a **fixed window counter** algorithm:
+
+```go
+type Counter struct {
+    count     int           // Current request count
+    windowEnd time.Time     // When counter resets
+    limit     int           // Maximum requests allowed
+    window    time.Duration // Window duration
+}
+```
+
+**Behavior:**
+1. First request creates a counter with `windowEnd = now + window`
+2. Subsequent requests increment the counter
+3. When `count >= limit`, requests are denied (429/503)
+4. When `now > windowEnd`, counter resets
+
+### Thread Safety
+
+All rate limiter operations are protected by `sync.RWMutex` for concurrent access.
+
+### Key Generation
+
+Rate limit keys determine counter scope:
+
+```go
+// Endpoint-specific
+key := "status-429:" + r.URL.Path  // Independent per endpoint
+
+// Global shared
+key := "global-shared"  // All /global/* share one counter
+
+// Per-IP
+key := "per-ip:" + clientIP  // Independent per client
+```
+
+## Testing the Implementation
+
+```bash
+# Run unit tests
+cd /workspaces/praetorian-dev/modules/hadrian/testdata/ratelimit-demo
+GOWORK=off go test -v
+
+# Run specific test
+GOWORK=off go test -v -run TestStatus429Handler
+
+# Run with race detection
+GOWORK=off go test -race -v
+```
+
+## Files
+
+```
+ratelimit-demo/
+├── main.go                          # Server entry point, CLI flags
+├── handlers.go                      # HTTP handlers for all endpoints
+├── limiter.go                       # In-memory rate limiter
+├── limiter_test.go                  # Rate limiter unit tests
+├── handlers_test.go                 # HTTP handler tests
+├── openapi.yaml                     # OpenAPI 3.0 spec
+├── roles.yaml                       # Minimal roles config
+├── templates/ratelimit/             # Hadrian test templates
+│   ├── detect-429.yaml              # Detect 429 rate limiting
+│   ├── detect-503.yaml              # Detect 503 rate limiting
+│   ├── detect-no-limit.yaml         # Detect missing rate limits
+│   └── detect-retry-after.yaml      # Detect Retry-After headers
+└── README.md                        # This file
+```
+
+## Common Scenarios
+
+### Scenario 1: Testing Rate Limit Detection
+
+**Goal:** Verify Hadrian detects rate limits correctly
+
+```bash
+# Start server
+./ratelimit-demo &
+
+# Test with Hadrian
+HADRIAN_TEMPLATES=templates ./hadrian test \
+  --api openapi.yaml \
+  --roles roles.yaml \
+  --allow-internal
+
+# Should find:
+# - LOW severity: Rate limits detected on /status-429/* and /status-503/*
+# - MEDIUM severity: No rate limit on /basic/* (vulnerability)
+```
+
+### Scenario 2: Testing Custom Limits
+
+**Goal:** Test with different rate limit thresholds
+
+```bash
+# Start server with custom defaults
+./ratelimit-demo --default-limit 10 --default-window 30s &
+
+# Manual testing with custom limits
+curl "http://localhost:8080/api/v1/status-429/resource?limit=2&window=5"
+```
+
+### Scenario 3: Testing Per-IP Limits
+
+**Goal:** Verify IP-based rate limiting
+
+```bash
+# Simulate different IPs using X-Forwarded-For header
+for i in {1..6}; do
+  curl -H "X-Forwarded-For: 192.168.1.1" \
+    http://localhost:8080/api/v1/per-ip/resource
+done  # IP 192.168.1.1 gets rate limited
+
+curl -H "X-Forwarded-For: 192.168.1.2" \
+  http://localhost:8080/api/v1/per-ip/resource  # IP 192.168.1.2 works
+```
+
+## Troubleshooting
+
+### Server Won't Start
+
+```bash
+# Check if port is already in use
+lsof -i :8080
+
+# Use different port
+./ratelimit-demo --port 9090
+```
+
+### Rate Limits Not Working
+
+```bash
+# Check server logs - they show each request
+./ratelimit-demo
+# Output: [15:04:05] GET /api/v1/status-429/resource -> 200 (1.23ms)
+
+# Verify query parameters are being passed
+curl -v "http://localhost:8080/api/v1/status-429/resource?limit=3"
+```
+
+### Hadrian Not Detecting Limits
+
+```bash
+# Ensure --allow-internal flag is set (localhost is internal IP)
+./hadrian test --api openapi.yaml --allow-internal
+
+# Check template directory is correct
+ls templates/ratelimit/  # Should show *.yaml files
+```
+
+## Architecture Notes
+
+### Why Fixed Window?
+
+Fixed window counters are simple and performant but have edge cases:
+
+**Burst at window boundary:**
+```
+Window 1: [55s] 5 requests → Reset at 60s
+Window 2: [1s]  5 requests → 10 requests in 6 seconds
+```
+
+For production, consider:
+- **Sliding window**: More accurate but more complex
+- **Token bucket**: Allows bursts with gradual refill
+- **Leaky bucket**: Smooth rate limiting
+
+This demo uses fixed window for **simplicity and clarity** in testing.
+
+### Rate Limit Key Design
+
+The key structure determines counter scope:
+
+```go
+// Pattern: <type>:<identifier>
+"status-429:/api/v1/status-429/resource"  // Per-endpoint
+"global-shared"                            // Global shared
+"per-ip:192.168.1.1"                       // Per-IP
+```
+
+This allows flexible rate limiting strategies in a single implementation.
+
+## Future Enhancements
+
+- [ ] Add sliding window algorithm
+- [ ] Add token bucket algorithm
+- [ ] Persist counters to Redis
+- [ ] Add distributed rate limiting
+- [ ] Add rate limit analytics endpoint
+- [ ] Add WebSocket support
+- [ ] Add GraphQL endpoint examples

--- a/testdata/ratelimit-demo/go.mod
+++ b/testdata/ratelimit-demo/go.mod
@@ -1,0 +1,3 @@
+module github.com/praetorian-inc/hadrian/testdata/ratelimit-demo
+
+go 1.25.3

--- a/testdata/ratelimit-demo/handlers.go
+++ b/testdata/ratelimit-demo/handlers.go
@@ -1,0 +1,382 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// basicResourceHandler always returns 200 (no rate limiting)
+func basicResourceHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// status429Handler returns 429 after limit exceeded
+func status429Handler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "status-429:" + r.URL.Path
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rate_limit_exceeded",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// status503Handler returns 503 after limit exceeded
+func status503Handler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "status-503:" + r.URL.Path
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "service_temporarily_unavailable",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// retryAfterSecondsHandler returns 429 with Retry-After header (seconds)
+func retryAfterSecondsHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "retry-seconds:" + r.URL.Path
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rate_limit_exceeded",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// retryAfterDateHandler returns 429 with Retry-After header (HTTP-date)
+func retryAfterDateHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "retry-date:" + r.URL.Path
+
+	if !limiter.Allow(key, limit, window) {
+		retryTime := time.Now().Add(5 * time.Second)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", retryTime.Format(http.TimeFormat))
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rate_limit_exceeded",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// rateLimitHeadersHandler returns 429 with X-RateLimit-* headers
+func rateLimitHeadersHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "ratelimit-headers:" + r.URL.Path
+
+	allowed := limiter.Allow(key, limit, window)
+	remaining := limiter.Remaining(key)
+	resetTime := limiter.ResetTime(key)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit))
+	w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+	w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetTime.Unix(), 10))
+
+	if !allowed {
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rate_limit_exceeded",
+		})
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// bodyPlainHandler returns plain text error
+func bodyPlainHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "body-plain:" + r.URL.Path
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte("Too Many Requests"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// bodyJSONHandler returns JSON error body
+func bodyJSONHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "body-json:" + r.URL.Path
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rate_limit_exceeded",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// bodyJSONRetryHandler returns JSON error with retry_after field
+func bodyJSONRetryHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "body-json-retry:" + r.URL.Path
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":       "rate_limit_exceeded",
+			"retry_after": 5,
+			"message":     "Try again in 5 seconds",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// globalHandler uses shared counter across all /global/* endpoints
+func globalHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "global-shared" // Same key for all global endpoints
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rate_limit_exceeded",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// perEndpointHandler uses independent counters per endpoint
+func perEndpointHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	key := "per-endpoint:" + r.URL.Path // Unique key per endpoint
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rate_limit_exceeded",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+	})
+}
+
+// perIPHandler rate limits per client IP
+func perIPHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) {
+	limit, window := parseLimitParams(r)
+	clientIP := getClientIP(r)
+	key := "per-ip:" + clientIP
+
+	if !limiter.Allow(key, limit, window) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rate_limit_exceeded",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":   "ok",
+		"endpoint": r.URL.Path,
+		"client_ip": clientIP,
+	})
+}
+
+// parseLimitParams extracts limit and window from query parameters
+func parseLimitParams(r *http.Request) (int, time.Duration) {
+	limit := 5 // default
+	window := 60 * time.Second // default
+
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+			limit = l
+		}
+	}
+
+	if windowStr := r.URL.Query().Get("window"); windowStr != "" {
+		if w, err := strconv.Atoi(windowStr); err == nil && w > 0 {
+			window = time.Duration(w) * time.Second
+		}
+	}
+
+	return limit, window
+}
+
+// getClientIP extracts client IP from request
+func getClientIP(r *http.Request) string {
+	// Check X-Forwarded-For header first
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		ips := strings.Split(xff, ",")
+		if len(ips) > 0 {
+			return strings.TrimSpace(ips[0])
+		}
+	}
+
+	// Check X-Real-IP header
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+
+	// Fall back to RemoteAddr
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+// registerHandlers sets up all HTTP routes
+func registerHandlers(mux *http.ServeMux, limiter *RateLimiter) {
+	// No rate limit endpoints
+	mux.HandleFunc("/api/v1/basic/resource", func(w http.ResponseWriter, r *http.Request) {
+		basicResourceHandler(w, r, limiter)
+	})
+
+	// Status code endpoints
+	mux.HandleFunc("/api/v1/status-429/resource", func(w http.ResponseWriter, r *http.Request) {
+		status429Handler(w, r, limiter)
+	})
+	mux.HandleFunc("/api/v1/status-503/resource", func(w http.ResponseWriter, r *http.Request) {
+		status503Handler(w, r, limiter)
+	})
+
+	// Retry-After endpoints
+	mux.HandleFunc("/api/v1/retry-seconds/resource", func(w http.ResponseWriter, r *http.Request) {
+		retryAfterSecondsHandler(w, r, limiter)
+	})
+	mux.HandleFunc("/api/v1/retry-date/resource", func(w http.ResponseWriter, r *http.Request) {
+		retryAfterDateHandler(w, r, limiter)
+	})
+
+	// X-RateLimit headers endpoint
+	mux.HandleFunc("/api/v1/ratelimit-headers/resource", func(w http.ResponseWriter, r *http.Request) {
+		rateLimitHeadersHandler(w, r, limiter)
+	})
+
+	// Body format endpoints
+	mux.HandleFunc("/api/v1/body-plain/resource", func(w http.ResponseWriter, r *http.Request) {
+		bodyPlainHandler(w, r, limiter)
+	})
+	mux.HandleFunc("/api/v1/body-json/resource", func(w http.ResponseWriter, r *http.Request) {
+		bodyJSONHandler(w, r, limiter)
+	})
+	mux.HandleFunc("/api/v1/body-json-retry/resource", func(w http.ResponseWriter, r *http.Request) {
+		bodyJSONRetryHandler(w, r, limiter)
+	})
+
+	// Scoping endpoints
+	mux.HandleFunc("/api/v1/global/", func(w http.ResponseWriter, r *http.Request) {
+		globalHandler(w, r, limiter)
+	})
+	mux.HandleFunc("/api/v1/per-endpoint/", func(w http.ResponseWriter, r *http.Request) {
+		perEndpointHandler(w, r, limiter)
+	})
+	mux.HandleFunc("/api/v1/per-ip/resource", func(w http.ResponseWriter, r *http.Request) {
+		perIPHandler(w, r, limiter)
+	})
+}
+
+// loggingMiddleware logs all HTTP requests
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		fmt.Printf("[%s] %s %s", start.Format("15:04:05"), r.Method, r.URL.Path)
+
+		// Wrap ResponseWriter to capture status code
+		wrapped := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(wrapped, r)
+
+		fmt.Printf(" -> %d (%v)\n", wrapped.status, time.Since(start))
+	})
+}
+
+// statusWriter wraps http.ResponseWriter to capture status code
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (sw *statusWriter) WriteHeader(status int) {
+	sw.status = status
+	sw.ResponseWriter.WriteHeader(status)
+}

--- a/testdata/ratelimit-demo/handlers.go
+++ b/testdata/ratelimit-demo/handlers.go
@@ -256,15 +256,15 @@ func perIPHandler(w http.ResponseWriter, r *http.Request, limiter *RateLimiter) 
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
-		"status":   "ok",
-		"endpoint": r.URL.Path,
+		"status":    "ok",
+		"endpoint":  r.URL.Path,
 		"client_ip": clientIP,
 	})
 }
 
 // parseLimitParams extracts limit and window from query parameters
 func parseLimitParams(r *http.Request) (int, time.Duration) {
-	limit := 5 // default
+	limit := 5                 // default
 	window := 60 * time.Second // default
 
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {

--- a/testdata/ratelimit-demo/handlers_test.go
+++ b/testdata/ratelimit-demo/handlers_test.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestBasicResourceHandler_NoRateLimit verifies baseline endpoint never rate limits
+func TestBasicResourceHandler_NoRateLimit(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		basicResourceHandler(w, r, limiter)
+	})
+
+	// Make 10 requests - all should succeed
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/basic/resource", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i+1, w.Code)
+		}
+	}
+}
+
+// TestStatus429Handler_ReturnsRateLimitAfterN verifies 429 after limit exceeded
+func TestStatus429Handler_ReturnsRateLimitAfterN(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		status429Handler(w, r, limiter)
+	})
+
+	// First 5 should succeed (default limit)
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/status-429/resource", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i+1, w.Code)
+		}
+	}
+
+	// 6th should return 429
+	req := httptest.NewRequest("GET", "/api/v1/status-429/resource", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", w.Code)
+	}
+}
+
+// TestStatus429Handler_CustomLimit verifies custom limit via query param
+func TestStatus429Handler_CustomLimit(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		status429Handler(w, r, limiter)
+	})
+
+	// First 3 should succeed (custom limit=3)
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/status-429/resource?limit=3", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i+1, w.Code)
+		}
+	}
+
+	// 4th should return 429
+	req := httptest.NewRequest("GET", "/api/v1/status-429/resource?limit=3", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", w.Code)
+	}
+}
+
+// TestRetryAfterSecondsHandler_IncludesHeader verifies Retry-After header
+func TestRetryAfterSecondsHandler_IncludesHeader(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		retryAfterSecondsHandler(w, r, limiter)
+	})
+
+	// Exhaust limit
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/retry-seconds/resource", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	// Rate limited request
+	req := httptest.NewRequest("GET", "/api/v1/retry-seconds/resource", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", w.Code)
+	}
+
+	retryAfter := w.Header().Get("Retry-After")
+	if retryAfter == "" {
+		t.Error("expected Retry-After header")
+	}
+	if retryAfter != "5" {
+		t.Errorf("expected Retry-After=5, got %s", retryAfter)
+	}
+}
+
+// TestRateLimitHeadersHandler_IncludesXRateLimitHeaders verifies X-RateLimit-* headers
+func TestRateLimitHeadersHandler_IncludesXRateLimitHeaders(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rateLimitHeadersHandler(w, r, limiter)
+	})
+
+	// Exhaust limit
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/ratelimit-headers/resource", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	// Rate limited request
+	req := httptest.NewRequest("GET", "/api/v1/ratelimit-headers/resource", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", w.Code)
+	}
+
+	limit := w.Header().Get("X-RateLimit-Limit")
+	if limit != "5" {
+		t.Errorf("expected X-RateLimit-Limit=5, got %s", limit)
+	}
+
+	remaining := w.Header().Get("X-RateLimit-Remaining")
+	if remaining != "0" {
+		t.Errorf("expected X-RateLimit-Remaining=0, got %s", remaining)
+	}
+
+	reset := w.Header().Get("X-RateLimit-Reset")
+	if reset == "" {
+		t.Error("expected X-RateLimit-Reset header")
+	}
+}
+
+// TestBodyJSONHandler_ReturnsJSONError verifies JSON error response
+func TestBodyJSONHandler_ReturnsJSONError(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyJSONHandler(w, r, limiter)
+	})
+
+	// Exhaust limit
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/body-json/resource", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	// Rate limited request
+	req := httptest.NewRequest("GET", "/api/v1/body-json/resource", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("expected Content-Type=application/json, got %s", contentType)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	if response["error"] != "rate_limit_exceeded" {
+		t.Errorf("expected error=rate_limit_exceeded, got %v", response["error"])
+	}
+}
+
+// TestPerIPHandler_IndependentPerIP verifies per-IP rate limiting
+func TestPerIPHandler_IndependentPerIP(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		perIPHandler(w, r, limiter)
+	})
+
+	// Exhaust limit for IP1
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/per-ip/resource", nil)
+		req.RemoteAddr = "192.168.1.1:1234"
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	// IP1 should be rate limited
+	req1 := httptest.NewRequest("GET", "/api/v1/per-ip/resource", nil)
+	req1.RemoteAddr = "192.168.1.1:1234"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusTooManyRequests {
+		t.Errorf("IP1: expected 429, got %d", w1.Code)
+	}
+
+	// IP2 should still be allowed
+	req2 := httptest.NewRequest("GET", "/api/v1/per-ip/resource", nil)
+	req2.RemoteAddr = "192.168.1.2:5678"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Errorf("IP2: expected 200, got %d", w2.Code)
+	}
+}
+
+// TestGlobalHandler_SharedCounter verifies global shared counter
+func TestGlobalHandler_SharedCounter(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		globalHandler(w, r, limiter)
+	})
+
+	// Make 3 requests to /global/resource
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/global/resource?limit=5", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	// Make 2 requests to /global/other (same counter)
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/global/other?limit=5", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	// 6th request should be rate limited (shared counter exhausted)
+	req := httptest.NewRequest("GET", "/api/v1/global/resource?limit=5", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429 (shared counter), got %d", w.Code)
+	}
+}
+
+// TestWindowExpiration verifies counter resets after window
+func TestWindowExpiration(t *testing.T) {
+	limiter := NewRateLimiter()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		status429Handler(w, r, limiter)
+	})
+
+	// Exhaust limit with 1-second window
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/api/v1/status-429/resource?limit=5&window=1", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	// Wait for window to expire
+	time.Sleep(1100 * time.Millisecond)
+
+	// Next request should succeed
+	req := httptest.NewRequest("GET", "/api/v1/status-429/resource?limit=5&window=1", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 after window expiration, got %d", w.Code)
+	}
+}

--- a/testdata/ratelimit-demo/limiter.go
+++ b/testdata/ratelimit-demo/limiter.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimiter provides in-memory rate limiting with sliding windows
+type RateLimiter struct {
+	counters map[string]*Counter
+	mu       sync.RWMutex
+}
+
+// Counter tracks request count and window expiration for a single key
+type Counter struct {
+	count     int
+	windowEnd time.Time
+	limit     int
+	window    time.Duration
+}
+
+// NewRateLimiter creates a new rate limiter
+func NewRateLimiter() *RateLimiter {
+	return &RateLimiter{
+		counters: make(map[string]*Counter),
+	}
+}
+
+// Allow checks if a request should be allowed under the rate limit
+// Returns true if allowed, false if rate limited
+func (rl *RateLimiter) Allow(key string, limit int, window time.Duration) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	counter, exists := rl.counters[key]
+
+	// Initialize counter if it doesn't exist or window has expired
+	if !exists || now.After(counter.windowEnd) {
+		rl.counters[key] = &Counter{
+			count:     1,
+			windowEnd: now.Add(window),
+			limit:     limit,
+			window:    window,
+		}
+		return true
+	}
+
+	// Check if limit exceeded
+	if counter.count >= limit {
+		return false
+	}
+
+	// Increment counter
+	counter.count++
+	return true
+}
+
+// Remaining returns the number of remaining requests before rate limit
+func (rl *RateLimiter) Remaining(key string) int {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	counter, exists := rl.counters[key]
+	if !exists {
+		return 0
+	}
+
+	remaining := counter.limit - counter.count
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// ResetTime returns when the rate limit window will reset
+func (rl *RateLimiter) ResetTime(key string) time.Time {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	counter, exists := rl.counters[key]
+	if !exists {
+		return time.Time{}
+	}
+
+	return counter.windowEnd
+}
+
+// Reset manually resets the rate limit counter for a key
+func (rl *RateLimiter) Reset(key string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	delete(rl.counters, key)
+}

--- a/testdata/ratelimit-demo/limiter_test.go
+++ b/testdata/ratelimit-demo/limiter_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNewRateLimiter verifies rate limiter initialization
+func TestNewRateLimiter(t *testing.T) {
+	rl := NewRateLimiter()
+	if rl == nil {
+		t.Fatal("NewRateLimiter returned nil")
+	}
+	if rl.counters == nil {
+		t.Error("counters map not initialized")
+	}
+}
+
+// TestAllow_FirstRequest verifies first request is always allowed
+func TestAllow_FirstRequest(t *testing.T) {
+	rl := NewRateLimiter()
+	key := "test-endpoint"
+	limit := 5
+	window := 60 * time.Second
+
+	allowed := rl.Allow(key, limit, window)
+	if !allowed {
+		t.Error("first request should be allowed")
+	}
+}
+
+// TestAllow_WithinLimit verifies requests within limit are allowed
+func TestAllow_WithinLimit(t *testing.T) {
+	rl := NewRateLimiter()
+	key := "test-endpoint"
+	limit := 3
+	window := 60 * time.Second
+
+	// Make 3 requests (within limit)
+	for i := 0; i < 3; i++ {
+		if !rl.Allow(key, limit, window) {
+			t.Errorf("request %d should be allowed (within limit of %d)", i+1, limit)
+		}
+	}
+}
+
+// TestAllow_ExceedsLimit verifies requests exceeding limit are denied
+func TestAllow_ExceedsLimit(t *testing.T) {
+	rl := NewRateLimiter()
+	key := "test-endpoint"
+	limit := 3
+	window := 60 * time.Second
+
+	// Make 3 requests (within limit)
+	for i := 0; i < 3; i++ {
+		rl.Allow(key, limit, window)
+	}
+
+	// 4th request should be denied
+	allowed := rl.Allow(key, limit, window)
+	if allowed {
+		t.Error("request exceeding limit should be denied")
+	}
+}
+
+// TestAllow_WindowExpires verifies counter resets after window expiration
+func TestAllow_WindowExpires(t *testing.T) {
+	rl := NewRateLimiter()
+	key := "test-endpoint"
+	limit := 2
+	window := 100 * time.Millisecond
+
+	// Exhaust limit
+	rl.Allow(key, limit, window)
+	rl.Allow(key, limit, window)
+
+	// Wait for window to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Next request should be allowed (window reset)
+	allowed := rl.Allow(key, limit, window)
+	if !allowed {
+		t.Error("request after window expiration should be allowed")
+	}
+}
+
+// TestAllow_IndependentKeys verifies different keys have independent counters
+func TestAllow_IndependentKeys(t *testing.T) {
+	rl := NewRateLimiter()
+	limit := 2
+	window := 60 * time.Second
+
+	// Exhaust limit for key1
+	rl.Allow("key1", limit, window)
+	rl.Allow("key1", limit, window)
+
+	// key2 should still be allowed
+	allowed := rl.Allow("key2", limit, window)
+	if !allowed {
+		t.Error("different key should have independent counter")
+	}
+}
+
+// TestRemaining_ZeroWhenExhausted verifies remaining returns 0 when limit exhausted
+func TestRemaining_ZeroWhenExhausted(t *testing.T) {
+	rl := NewRateLimiter()
+	key := "test-endpoint"
+	limit := 3
+	window := 60 * time.Second
+
+	// Exhaust limit
+	for i := 0; i < 3; i++ {
+		rl.Allow(key, limit, window)
+	}
+
+	remaining := rl.Remaining(key)
+	if remaining != 0 {
+		t.Errorf("expected remaining=0, got %d", remaining)
+	}
+}
+
+// TestRemaining_DecreasesWithUse verifies remaining counter decreases
+func TestRemaining_DecreasesWithUse(t *testing.T) {
+	rl := NewRateLimiter()
+	key := "test-endpoint"
+	limit := 5
+	window := 60 * time.Second
+
+	// Make 2 requests
+	rl.Allow(key, limit, window)
+	rl.Allow(key, limit, window)
+
+	remaining := rl.Remaining(key)
+	if remaining != 3 {
+		t.Errorf("expected remaining=3, got %d", remaining)
+	}
+}
+
+// TestResetTime_ReturnsWindowEnd verifies reset time calculation
+func TestResetTime_ReturnsWindowEnd(t *testing.T) {
+	rl := NewRateLimiter()
+	key := "test-endpoint"
+	limit := 5
+	window := 60 * time.Second
+
+	before := time.Now()
+	rl.Allow(key, limit, window)
+	resetTime := rl.ResetTime(key)
+	after := time.Now()
+
+	// Reset time should be approximately now + window
+	expectedMin := before.Add(window)
+	expectedMax := after.Add(window)
+
+	if resetTime.Before(expectedMin) || resetTime.After(expectedMax) {
+		t.Errorf("reset time %v outside expected range [%v, %v]", resetTime, expectedMin, expectedMax)
+	}
+}
+
+// TestReset_ClearsCounter verifies manual counter reset
+func TestReset_ClearsCounter(t *testing.T) {
+	rl := NewRateLimiter()
+	key := "test-endpoint"
+	limit := 2
+	window := 60 * time.Second
+
+	// Exhaust limit
+	rl.Allow(key, limit, window)
+	rl.Allow(key, limit, window)
+
+	// Reset counter
+	rl.Reset(key)
+
+	// Next request should be allowed
+	allowed := rl.Allow(key, limit, window)
+	if !allowed {
+		t.Error("request after reset should be allowed")
+	}
+}

--- a/testdata/ratelimit-demo/main.go
+++ b/testdata/ratelimit-demo/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+var (
+	port          = flag.Int("port", 8080, "Server port")
+	defaultLimit  = flag.Int("default-limit", 5, "Default rate limit")
+	defaultWindow = flag.Duration("default-window", 60*time.Second, "Default time window")
+)
+
+func main() {
+	flag.Parse()
+
+	limiter := NewRateLimiter()
+	mux := http.NewServeMux()
+	registerHandlers(mux, limiter)
+
+	handler := loggingMiddleware(mux)
+
+	addr := fmt.Sprintf(":%d", *port)
+	fmt.Printf("Starting Rate Limit Demo Server on %s\n", addr)
+	fmt.Printf("Default settings: limit=%d, window=%v\n", *defaultLimit, *defaultWindow)
+	fmt.Println("\nEndpoints:")
+	fmt.Println("  GET /api/v1/basic/resource           - No rate limit (baseline)")
+	fmt.Println("  GET /api/v1/status-429/resource      - Returns 429 after limit")
+	fmt.Println("  GET /api/v1/status-503/resource      - Returns 503 after limit")
+	fmt.Println("  GET /api/v1/retry-seconds/resource   - 429 + Retry-After: 5")
+	fmt.Println("  GET /api/v1/retry-date/resource      - 429 + Retry-After: <HTTP-date>")
+	fmt.Println("  GET /api/v1/ratelimit-headers/resource - 429 + X-RateLimit-* headers")
+	fmt.Println("  GET /api/v1/body-plain/resource      - 429 + plain text body")
+	fmt.Println("  GET /api/v1/body-json/resource       - 429 + JSON error")
+	fmt.Println("  GET /api/v1/body-json-retry/resource - 429 + JSON with retry_after")
+	fmt.Println("  GET /api/v1/global/*                 - Shared counter")
+	fmt.Println("  GET /api/v1/per-endpoint/*           - Independent counters")
+	fmt.Println("  GET /api/v1/per-ip/resource          - Rate limit per IP")
+	fmt.Println("\nQuery parameters:")
+	fmt.Println("  ?limit=N   - Set rate limit (default: 5)")
+	fmt.Println("  ?window=N  - Set window in seconds (default: 60)")
+	fmt.Println()
+
+	if err := http.ListenAndServe(addr, handler); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/testdata/ratelimit-demo/openapi.yaml
+++ b/testdata/ratelimit-demo/openapi.yaml
@@ -1,0 +1,391 @@
+openapi: 3.0.0
+info:
+  title: Rate Limit Demo API
+  description: Demonstrates various rate limiting patterns for Hadrian testing
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+paths:
+  /api/v1/basic/resource:
+    get:
+      summary: Baseline endpoint (no rate limit)
+      operationId: getBasicResource
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+
+  /api/v1/status-429/resource:
+    get:
+      summary: Returns 429 after limit exceeded
+      operationId: getStatus429Resource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/status-503/resource:
+    get:
+      summary: Returns 503 after limit exceeded
+      operationId: getStatus503Resource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '503':
+          description: Service temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/retry-seconds/resource:
+    get:
+      summary: Returns 429 with Retry-After header (seconds)
+      operationId: getRetrySecondsResource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+                example: 5
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/retry-date/resource:
+    get:
+      summary: Returns 429 with Retry-After header (HTTP-date)
+      operationId: getRetryDateResource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              description: HTTP-date format (RFC 1123)
+              schema:
+                type: string
+                example: "Fri, 31 Jan 2026 12:00:05 GMT"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/ratelimit-headers/resource:
+    get:
+      summary: Returns X-RateLimit-* headers
+      operationId: getRateLimitHeadersResource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+                format: int64
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/body-plain/resource:
+    get:
+      summary: Returns plain text error
+      operationId: getBodyPlainResource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Too Many Requests"
+
+  /api/v1/body-json/resource:
+    get:
+      summary: Returns JSON error body
+      operationId: getBodyJsonResource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/body-json-retry/resource:
+    get:
+      summary: Returns JSON error with retry_after field
+      operationId: getBodyJsonRetryResource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseWithRetry'
+
+  /api/v1/global/resource:
+    get:
+      summary: Global shared counter
+      operationId: getGlobalResource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/global/other:
+    get:
+      summary: Global shared counter (same as /global/resource)
+      operationId: getGlobalOther
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/per-endpoint/one:
+    get:
+      summary: Per-endpoint counter (independent)
+      operationId: getPerEndpointOne
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/per-endpoint/two:
+    get:
+      summary: Per-endpoint counter (independent)
+      operationId: getPerEndpointTwo
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/per-ip/resource:
+    get:
+      summary: Rate limit per client IP
+      operationId: getPerIpResource
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/WindowParam'
+      responses:
+        '200':
+          description: Success (within limit)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponseWithIP'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  parameters:
+    LimitParam:
+      name: limit
+      in: query
+      description: Maximum requests allowed
+      schema:
+        type: integer
+        default: 5
+        minimum: 1
+    WindowParam:
+      name: window
+      in: query
+      description: Time window in seconds
+      schema:
+        type: integer
+        default: 60
+        minimum: 1
+
+  schemas:
+    SuccessResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: "ok"
+        endpoint:
+          type: string
+          example: "/api/v1/status-429/resource"
+
+    SuccessResponseWithIP:
+      type: object
+      properties:
+        status:
+          type: string
+          example: "ok"
+        endpoint:
+          type: string
+          example: "/api/v1/per-ip/resource"
+        client_ip:
+          type: string
+          example: "192.168.1.1"
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          example: "rate_limit_exceeded"
+
+    ErrorResponseWithRetry:
+      type: object
+      properties:
+        error:
+          type: string
+          example: "rate_limit_exceeded"
+        retry_after:
+          type: integer
+          example: 5
+        message:
+          type: string
+          example: "Try again in 5 seconds"

--- a/testdata/ratelimit-demo/roles.yaml
+++ b/testdata/ratelimit-demo/roles.yaml
@@ -1,0 +1,6 @@
+objects: []
+
+roles:
+  - name: anonymous
+    level: 0
+    permissions: []

--- a/testdata/ratelimit-demo/templates/ratelimit/detect-429.yaml
+++ b/testdata/ratelimit-demo/templates/ratelimit/detect-429.yaml
@@ -1,0 +1,33 @@
+id: ratelimit-detect-429
+
+info:
+  name: "Rate Limit Detection - 429 Status"
+  category: "API4:2023"
+  severity: "LOW"
+  requires_llm_triage: false
+  test_pattern: "rate_limit"
+
+endpoint_selector:
+  requires_auth: false
+  methods: ["GET"]
+  path_pattern: ".*/status-429/.*"
+
+role_selector:
+  attacker_permission_level: "all"
+  victim_permission_level: ""
+
+http:
+  - method: "GET"
+    path: "{{operation.path}}"
+    repeat: 10
+    rate_limit:
+      threshold: 1
+      status_codes: [429]
+    matchers:
+      - type: status
+        status: [200]
+
+detection:
+  success_indicators: []
+  vulnerability_pattern: "rate_limit"
+  conditions: []

--- a/testdata/ratelimit-demo/templates/ratelimit/detect-503.yaml
+++ b/testdata/ratelimit-demo/templates/ratelimit/detect-503.yaml
@@ -1,0 +1,33 @@
+id: ratelimit-detect-503
+
+info:
+  name: "Rate Limit Detection - 503 Status"
+  category: "API4:2023"
+  severity: "LOW"
+  requires_llm_triage: false
+  test_pattern: "rate_limit"
+
+endpoint_selector:
+  requires_auth: false
+  methods: ["GET"]
+  path_pattern: ".*/status-503/.*"
+
+role_selector:
+  attacker_permission_level: "all"
+  victim_permission_level: ""
+
+http:
+  - method: "GET"
+    path: "{{operation.path}}"
+    repeat: 10
+    rate_limit:
+      threshold: 1
+      status_codes: [503]
+    matchers:
+      - type: status
+        status: [200]
+
+detection:
+  success_indicators: []
+  vulnerability_pattern: "rate_limit"
+  conditions: []

--- a/testdata/ratelimit-demo/templates/ratelimit/detect-no-limit.yaml
+++ b/testdata/ratelimit-demo/templates/ratelimit/detect-no-limit.yaml
@@ -1,0 +1,33 @@
+id: ratelimit-detect-no-limit
+
+info:
+  name: "Missing Rate Limit - Unprotected Endpoint"
+  category: "API4:2023"
+  severity: "MEDIUM"
+  requires_llm_triage: false
+  test_pattern: "rate_limit"
+
+endpoint_selector:
+  requires_auth: false
+  methods: ["GET"]
+  path_pattern: ".*/basic/.*"
+
+role_selector:
+  attacker_permission_level: "all"
+  victim_permission_level: ""
+
+http:
+  - method: "GET"
+    path: "{{operation.path}}"
+    repeat: 10
+    rate_limit:
+      threshold: 1
+      status_codes: [429, 503]
+    matchers:
+      - type: status
+        status: [200]
+
+detection:
+  success_indicators: []
+  vulnerability_pattern: "rate_limit"
+  conditions: []

--- a/testdata/ratelimit-demo/templates/ratelimit/detect-retry-after.yaml
+++ b/testdata/ratelimit-demo/templates/ratelimit/detect-retry-after.yaml
@@ -1,0 +1,33 @@
+id: ratelimit-detect-retry-after
+
+info:
+  name: "Rate Limit Detection - Retry-After Header"
+  category: "API4:2023"
+  severity: "LOW"
+  requires_llm_triage: false
+  test_pattern: "rate_limit"
+
+endpoint_selector:
+  requires_auth: false
+  methods: ["GET"]
+  path_pattern: ".*/retry-seconds/.*"
+
+role_selector:
+  attacker_permission_level: "all"
+  victim_permission_level: ""
+
+http:
+  - method: "GET"
+    path: "{{operation.path}}"
+    repeat: 10
+    rate_limit:
+      threshold: 1
+      status_codes: [429]
+    matchers:
+      - type: status
+        status: [200]
+
+detection:
+  success_indicators: []
+  vulnerability_pattern: "rate_limit"
+  conditions: []


### PR DESCRIPTION
## Linear Ticket
[ENG-1169](https://linear.app/praetorianlabs/issue/ENG-1169/comprehensive-testing-and-validation-of-api-security-testing-tool-mvp)

## Summary

Add comprehensive global rate limiting to Hadrian with:

- **Proactive rate limiting** - Limits outgoing requests to configured rate (default 5 req/s)
- **Reactive backoff** - Automatically backs off when detecting rate limit responses (429/503)
- **Exponential and fixed backoff strategies** - Configurable via CLI
- **Retry-After header support** - Honors server-provided timing
- **Rate limit demo server** - Test target demonstrating various rate limiting patterns

## New CLI Flags

| Flag | Default | Description |
|------|---------|-------------|
| `--rate-limit` | 5.0 | Requests per second |
| `--rate-limit-backoff` | exponential | Backoff type: exponential or fixed |
| `--rate-limit-max-wait` | 60s | Maximum backoff duration |
| `--rate-limit-max-retries` | 5 | Maximum retry attempts |
| `--rate-limit-status-codes` | 429,503 | Status codes that trigger retry |

## Files Changed

### Rate Limiting Implementation
- `pkg/runner/ratelimit.go` - RateLimitConfig struct
- `pkg/runner/ratelimit_client.go` - HTTP client wrapper with backoff
- `pkg/runner/ratelimit_client_test.go` - Comprehensive tests
- `pkg/runner/execution.go` - Extracted execution functions
- `pkg/runner/run.go` - CLI flags and integration

### Demo Server
- `testdata/ratelimit-demo/` - Go server demonstrating 13 rate limiting patterns
- Includes OpenAPI spec, Hadrian templates, and documentation

## Test Commands

### Run Unit Tests
```bash
cd modules/hadrian
GOWORK=off go test ./pkg/runner/... -v -run "RateLimit"
```

### Build Hadrian
```bash
cd modules/hadrian
GOWORK=off go build -o hadrian ./cmd/hadrian
```

### Test with Demo Server

**Terminal 1 - Start demo server:**
```bash
cd modules/hadrian/testdata/ratelimit-demo
go run .
```

**Terminal 2 - Run Hadrian:**
```bash
cd modules/hadrian/testdata/ratelimit-demo
../../hadrian test \
  --api openapi.yaml \
  --roles roles.yaml \
  --template-dir templates/ratelimit \
  --category all \
  --allow-internal \
  --verbose
```

### Test Rate Limiting Manually
```bash
# Start demo server
cd modules/hadrian/testdata/ratelimit-demo
go run . &

# Send requests to trigger rate limit (default: 5 requests per 60s)
for i in {1..6}; do
  curl -s http://localhost:8080/api/v1/status-429/resource
  echo ""
done

# Expected: First 5 return 200, 6th returns 429
```

### Test Hadrian Backoff Behavior
```bash
# Run with verbose to see backoff in action
cd modules/hadrian
./hadrian test \
  --api testdata/ratelimit-demo/openapi.yaml \
  --roles testdata/ratelimit-demo/roles.yaml \
  --template-dir testdata/ratelimit-demo/templates/ratelimit \
  --category all \
  --allow-internal \
  --verbose

# Look for DEBUG messages like:
# [DEBUG] Rate limit detected: status code 429
# [DEBUG] Rate limited on GET /api/v1/status-429/resource (attempt 1/5), backing off for 1s
```

## Test Plan

- [x] All rate limit tests pass (16 tests)
- [x] Demo server tests pass (14 tests)
- [x] Build succeeds
- [x] Manual testing with demo server shows backoff working
- [x] Documentation updated (README.md, CLAUDE.md, docs/architecture.md)
