### PR TITLE
refactor(util): consolidate duplicate hasUnresolvedPlaceholders function

### DIFF
--- a/pkg/owasp/mutation.go
+++ b/pkg/owasp/mutation.go
@@ -10,21 +10,9 @@ import (
 
 	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/templates"
+	"github.com/praetorian-inc/hadrian/pkg/util"
 )
 
-// hasUnresolvedPlaceholders checks if a path contains unresolved {placeholder} patterns.
-// Returns the first unresolved placeholder name if found, or empty string if all resolved.
-func hasUnresolvedPlaceholders(path string) string {
-	start := strings.Index(path, "{")
-	if start == -1 {
-		return ""
-	}
-	end := strings.Index(path[start:], "}")
-	if end == -1 {
-		return ""
-	}
-	return path[start+1 : start+end]
-}
 
 // HTTPClient interface for making HTTP requests
 type HTTPClient interface {
@@ -180,7 +168,7 @@ func (e *MutationExecutor) executePhase(
 	}
 
 	// Check for unresolved placeholders - error if any remain
-	if placeholder := hasUnresolvedPlaceholders(path); placeholder != "" {
+	if placeholder := util.HasUnresolvedPlaceholders(path); placeholder != "" {
 		return nil, fmt.Errorf("unresolved placeholder {%s} in path %q - required value not stored from setup phase", placeholder, phase.Path)
 	}
 

--- a/pkg/owasp/mutation_test.go
+++ b/pkg/owasp/mutation_test.go
@@ -523,56 +523,8 @@ func TestExecutePhase_ReturnsErrorForMissingPath(t *testing.T) {
 	assert.Contains(t, err.Error(), "path is required")
 }
 
-func TestHasUnresolvedPlaceholders(t *testing.T) {
-	tests := []struct {
-		name     string
-		path     string
-		expected string
-	}{
-		{
-			name:     "no placeholders",
-			path:     "/api/v1/resources",
-			expected: "",
-		},
-		{
-			name:     "single placeholder",
-			path:     "/api/v1/resources/{id}",
-			expected: "id",
-		},
-		{
-			name:     "multiple placeholders returns first",
-			path:     "/api/v1/resources/{id}/items/{item_id}",
-			expected: "id",
-		},
-		{
-			name:     "placeholder at start",
-			path:     "{version}/resources",
-			expected: "version",
-		},
-		{
-			name:     "unclosed brace",
-			path:     "/api/v1/resources/{id",
-			expected: "",
-		},
-		{
-			name:     "empty string",
-			path:     "",
-			expected: "",
-		},
-		{
-			name:     "resolved placeholder",
-			path:     "/api/v1/resources/resource123",
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasUnresolvedPlaceholders(tt.path)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
+// NOTE: TestHasUnresolvedPlaceholders moved to pkg/util/placeholder_test.go
+// since hasUnresolvedPlaceholders is now util.HasUnresolvedPlaceholders
 
 func TestExecutePhase_ReturnsErrorForUnresolvedPlaceholder(t *testing.T) {
 	client := &MockHTTPClient{}

--- a/pkg/templates/execute.go
+++ b/pkg/templates/execute.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/log"
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/util"
 )
 
 // generateRequestID creates a random UUID-style request ID
@@ -33,19 +34,6 @@ func generateRequestID() string {
 		hex.EncodeToString(b[10:16])
 }
 
-// hasUnresolvedPlaceholders checks if a path contains unresolved {placeholder} patterns.
-// Returns the first unresolved placeholder name if found, or empty string if all resolved.
-func hasUnresolvedPlaceholders(path string) string {
-	start := strings.Index(path, "{")
-	if start == -1 {
-		return ""
-	}
-	end := strings.Index(path[start:], "}")
-	if end == -1 {
-		return ""
-	}
-	return path[start+1 : start+end]
-}
 
 // HTTPClient interface for dependency injection
 type HTTPClient interface {
@@ -353,7 +341,7 @@ func buildRequest(
 	}
 
 	// Check for unresolved placeholders - error if any remain
-	if placeholder := hasUnresolvedPlaceholders(path); placeholder != "" {
+	if placeholder := util.HasUnresolvedPlaceholders(path); placeholder != "" {
 		return nil, fmt.Errorf("unresolved placeholder {%s} in path %q - no variable provided", placeholder, test.Path)
 	}
 

--- a/pkg/util/placeholder.go
+++ b/pkg/util/placeholder.go
@@ -1,0 +1,17 @@
+package util
+
+import "strings"
+
+// HasUnresolvedPlaceholders checks if a path contains unresolved {placeholder} patterns.
+// Returns the first unresolved placeholder name if found, or empty string if all resolved.
+func HasUnresolvedPlaceholders(path string) string {
+	start := strings.Index(path, "{")
+	if start == -1 {
+		return ""
+	}
+	end := strings.Index(path[start:], "}")
+	if end == -1 {
+		return ""
+	}
+	return path[start+1 : start+end]
+}

--- a/pkg/util/placeholder_test.go
+++ b/pkg/util/placeholder_test.go
@@ -1,0 +1,78 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasUnresolvedPlaceholders(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "no placeholders",
+			path:     "/api/v1/resources",
+			expected: "",
+		},
+		{
+			name:     "single placeholder",
+			path:     "/api/v1/resources/{id}",
+			expected: "id",
+		},
+		{
+			name:     "multiple placeholders returns first",
+			path:     "/api/v1/resources/{id}/items/{item_id}",
+			expected: "id",
+		},
+		{
+			name:     "placeholder at start",
+			path:     "{version}/resources",
+			expected: "version",
+		},
+		{
+			name:     "unclosed brace",
+			path:     "/api/v1/resources/{id",
+			expected: "",
+		},
+		{
+			name:     "empty string",
+			path:     "",
+			expected: "",
+		},
+		{
+			name:     "resolved placeholder",
+			path:     "/api/v1/resources/resource123",
+			expected: "",
+		},
+		{
+			name:     "nested braces",
+			path:     "/api/v1/{outer{inner}}",
+			expected: "outer{inner",
+		},
+		{
+			name:     "empty placeholder",
+			path:     "/api/v1/resources/{}",
+			expected: "",
+		},
+		{
+			name:     "placeholder with underscore",
+			path:     "/api/v1/resources/{video_id}",
+			expected: "video_id",
+		},
+		{
+			name:     "placeholder with hyphen",
+			path:     "/api/v1/resources/{user-id}",
+			expected: "user-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HasUnresolvedPlaceholders(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Ticket
[ENG-1275](https://linear.app/praetorianlabs/issue/ENG-1275/refactortemplates-extract-duplicated-hasunresolvedplaceholders)

## Summary

Consolidate duplicate `hasUnresolvedPlaceholders` function into a shared utility package:

- **Created `pkg/util/placeholder.go`** - Single source of truth for placeholder detection
- **Eliminated code duplication** - 79 lines of duplicate code removed
- **Comprehensive test coverage** - 11 test cases covering all edge cases
- **Context-specific error messages preserved** - Each call site maintains appropriate error context

## Problem

The `hasUnresolvedPlaceholders` function was duplicated in two locations with identical implementations:
- `pkg/templates/execute.go:38-48` (used by `Executor` for simple HTTP tests)
- `pkg/owasp/mutation.go:18-28` (used by `MutationExecutor` for mutation tests)

This created maintenance burden and risk of divergent implementations.

## Files Changed

### Added
- `pkg/util/placeholder.go` - Shared utility with exported `HasUnresolvedPlaceholders(path string) string`
- `pkg/util/placeholder_test.go` - Comprehensive test suite (11 test cases)

### Modified
- `pkg/templates/execute.go` - Removed duplicate function, imports `pkg/util`
- `pkg/owasp/mutation.go` - Removed duplicate function, imports `pkg/util`
- `pkg/owasp/mutation_test.go` - Removed redundant test (now in `pkg/util/`)

## Test Commands

### Run Unit Tests
```bash
cd modules/hadrian
GOWORK=off go test ./pkg/util/... -v
GOWORK=off go test ./pkg/templates/... -v
GOWORK=off go test ./pkg/owasp/... -run "Mutation|Placeholder" -v
```

### Build Hadrian
```bash
cd modules/hadrian
GOWORK=off go build -o hadrian ./cmd/hadrian
```

## Test Plan

- [x] Unit tests pass for pkg/util (11 test cases, 100% coverage)
- [x] Unit tests pass for pkg/templates
- [x] Unit tests pass for pkg/owasp (mutation tests)
- [x] Build succeeds
- [x] Error messages remain contextually appropriate at each call site