### PR TITLE
Added banner for Hadrian

### DIFF
--- a/pkg/runner/display.go
+++ b/pkg/runner/display.go
@@ -1,0 +1,26 @@
+package runner
+
+import "fmt"
+
+const (
+	bannerColorCyan  = "\033[36m"
+	bannerColorBold  = "\033[1m"
+	bannerColorGray  = "\033[90m"
+	bannerColorReset = "\033[0m"
+)
+
+// Version can be overridden via ldflags in a future ticket.
+var Version = "1.0.0"
+
+const banner = `
+ _   _    _    ____  ____  ___    _    _   _
+| | | |  / \  |  _ \|  _ \|_ _|  / \  | \ | |
+| |_| | / _ \ | | | | |_) || |  / _ \ |  \| |
+|  _  |/ ___ \| |_| |  _ < | | / ___ \| |\  |
+|_| |_/_/   \_\____/|_| \_\___/_/   \_\_| \_|
+`
+
+func printBanner() {
+	fmt.Printf("%s%s%s", bannerColorBold, bannerColorCyan, banner)
+	fmt.Printf("%s  Praetorian Security — v%s%s\n\n", bannerColorGray, Version, bannerColorReset)
+}

--- a/pkg/runner/display.go
+++ b/pkg/runner/display.go
@@ -1,6 +1,9 @@
 package runner
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 const (
 	bannerColorRed   = "\033[31m"
@@ -23,6 +26,6 @@ const banner = `
 `
 
 func printBanner() {
-	fmt.Printf("%s%s%s%s\n", bannerColorBold, bannerColorRed, banner, bannerColorReset)
-	fmt.Printf("%s  v%s%s\n\n", bannerColorGray, Version, bannerColorReset)
+	fmt.Fprintf(os.Stderr, "%s%s%s%s\n", bannerColorBold, bannerColorRed, banner, bannerColorReset)
+	fmt.Fprintf(os.Stderr, "%s  v%s%s\n\n", bannerColorGray, Version, bannerColorReset)
 }

--- a/pkg/runner/display.go
+++ b/pkg/runner/display.go
@@ -3,7 +3,7 @@ package runner
 import "fmt"
 
 const (
-	bannerColorCyan  = "\033[36m"
+	bannerColorRed   = "\033[31m"
 	bannerColorBold  = "\033[1m"
 	bannerColorGray  = "\033[90m"
 	bannerColorReset = "\033[0m"
@@ -13,14 +13,16 @@ const (
 var Version = "1.0.0"
 
 const banner = `
- _   _    _    ____  ____  ___    _    _   _
-| | | |  / \  |  _ \|  _ \|_ _|  / \  | \ | |
-| |_| | / _ \ | | | | |_) || |  / _ \ |  \| |
-|  _  |/ ___ \| |_| |  _ < | | / ___ \| |\  |
-|_| |_/_/   \_\____/|_| \_\___/_/   \_\_| \_|
+    __  _____    ____  ____  _______    _   __
+   / / / /   |  / __ \/ __ \/  _/   |  / | / /
+  / /_/ / /| | / / / / /_/ // // /| | /  |/ /
+ / __  / ___ |/ /_/ / _, _// // ___ |/ /|  /
+/_/ /_/_/  |_/_____/_/ |_/___/_/  |_/_/ |_/
+
+ Praetorian Security, Inc.
 `
 
 func printBanner() {
-	fmt.Printf("%s%s%s", bannerColorBold, bannerColorCyan, banner)
-	fmt.Printf("%s  Praetorian Security — v%s%s\n\n", bannerColorGray, Version, bannerColorReset)
+	fmt.Printf("%s%s%s%s\n", bannerColorBold, bannerColorRed, banner, bannerColorReset)
+	fmt.Printf("%s  v%s%s\n\n", bannerColorGray, Version, bannerColorReset)
 }

--- a/pkg/runner/display_test.go
+++ b/pkg/runner/display_test.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout redirects os.Stdout to a buffer, calls f, then restores stdout
+// and returns whatever was written.
+func captureStdout(f func()) string {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+	return buf.String()
+}
+
+func TestPrintBanner(t *testing.T) {
+	output := captureStdout(func() {
+		printBanner()
+	})
+
+	// The ASCII art banner spells out HADRIAN visually; the tagline is always present.
+	assert.Contains(t, output, "Praetorian Security", "banner should contain tagline")
+	assert.Contains(t, output, fmt.Sprintf("v%s", Version), "banner should contain version string")
+}
+
+func TestNoBannerFlag(t *testing.T) {
+	rootCmd := &cobra.Command{
+		Use: "hadrian",
+	}
+	rootCmd.PersistentFlags().Bool("no-banner", false, "Suppress the startup banner")
+
+	flag := rootCmd.PersistentFlags().Lookup("no-banner")
+	require.NotNil(t, flag, "--no-banner flag should exist")
+	assert.Equal(t, "false", flag.DefValue, "--no-banner should default to false")
+}
+
+func TestBannerSuppression(t *testing.T) {
+	rootCmd := &cobra.Command{
+		Use: "hadrian",
+	}
+	rootCmd.PersistentFlags().Bool("no-banner", false, "Suppress the startup banner")
+
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		noBanner, _ := cmd.Root().PersistentFlags().GetBool("no-banner")
+		if !noBanner {
+			printBanner()
+		}
+	}
+
+	noopCmd := &cobra.Command{
+		Use:  "noop",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	rootCmd.AddCommand(noopCmd)
+
+	output := captureStdout(func() {
+		rootCmd.SetArgs([]string{"--no-banner", "noop"})
+		err := rootCmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	assert.NotContains(t, output, "Praetorian Security", "banner should be suppressed with --no-banner")
+	assert.True(t, strings.TrimSpace(output) == "" || !strings.Contains(output, "Praetorian Security"),
+		"no banner output expected when --no-banner is set")
+}

--- a/pkg/runner/display_test.go
+++ b/pkg/runner/display_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -33,8 +32,26 @@ func captureStdout(f func()) string {
 	return buf.String()
 }
 
+func captureStderr(f func()) string {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+
+	f()
+
+	_ = w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+	return buf.String()
+}
+
 func TestPrintBanner(t *testing.T) {
-	output := captureStdout(func() {
+	output := captureStderr(func() {
 		printBanner()
 	})
 
@@ -55,31 +72,20 @@ func TestNoBannerFlag(t *testing.T) {
 }
 
 func TestBannerSuppression(t *testing.T) {
+	// Replicate the Run() banner logic: parse flags before Execute() and
+	// conditionally call printBanner(). The banner is written to stderr.
 	rootCmd := &cobra.Command{
 		Use: "hadrian",
 	}
 	rootCmd.PersistentFlags().Bool("no-banner", false, "Suppress the startup banner")
 
-	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		noBanner, _ := cmd.Root().PersistentFlags().GetBool("no-banner")
+	output := captureStderr(func() {
+		rootCmd.ParseFlags([]string{"--no-banner"}) //nolint:errcheck
+		noBanner, _ := rootCmd.Flags().GetBool("no-banner")
 		if !noBanner {
 			printBanner()
 		}
-	}
-
-	noopCmd := &cobra.Command{
-		Use:  "noop",
-		RunE: func(cmd *cobra.Command, args []string) error { return nil },
-	}
-	rootCmd.AddCommand(noopCmd)
-
-	output := captureStdout(func() {
-		rootCmd.SetArgs([]string{"--no-banner", "noop"})
-		err := rootCmd.Execute()
-		assert.NoError(t, err)
 	})
 
 	assert.NotContains(t, output, "Praetorian Security", "banner should be suppressed with --no-banner")
-	assert.True(t, strings.TrimSpace(output) == "" || !strings.Contains(output, "Praetorian Security"),
-		"no banner output expected when --no-banner is set")
 }

--- a/pkg/runner/display_test.go
+++ b/pkg/runner/display_test.go
@@ -12,26 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// captureStdout redirects os.Stdout to a buffer, calls f, then restores stdout
-// and returns whatever was written.
-func captureStdout(f func()) string {
-	r, w, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-	old := os.Stdout
-	os.Stdout = w
-
-	f()
-
-	_ = w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r) //nolint:errcheck
-	return buf.String()
-}
-
 func captureStderr(f func()) string {
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/pkg/runner/display_test.go
+++ b/pkg/runner/display_test.go
@@ -25,7 +25,7 @@ func captureStdout(f func()) string {
 
 	f()
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 
 	var buf bytes.Buffer

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -16,6 +16,15 @@ func Run() error {
 		Long:  `Hadrian is a security testing framework for REST, GraphQL, and gRPC APIs that tests for OWASP vulnerabilities and custom security issues.`,
 	}
 
+	rootCmd.PersistentFlags().Bool("no-banner", false, "Suppress the startup banner")
+
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		noBanner, _ := cmd.Root().PersistentFlags().GetBool("no-banner")
+		if !noBanner {
+			printBanner()
+		}
+	}
+
 	rootCmd.AddCommand(newTestCmd())
 	rootCmd.AddCommand(newParseCmd())
 	rootCmd.AddCommand(newVersionCmd())
@@ -59,12 +68,15 @@ func newVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show Hadrian version",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Hadrian v1.0.0")
-		},
+		RunE:  runVersion,
 	}
 
 	return cmd
+}
+
+func runVersion(cmd *cobra.Command, args []string) error {
+	fmt.Printf("Hadrian v%s\n", Version)
+	return nil
 }
 
 // parseCmdHandler parses and displays API specification details

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -18,16 +18,18 @@ func Run() error {
 
 	rootCmd.PersistentFlags().Bool("no-banner", false, "Suppress the startup banner")
 
-	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		noBanner, _ := cmd.Root().PersistentFlags().GetBool("no-banner")
-		if !noBanner {
-			printBanner()
-		}
-	}
-
 	rootCmd.AddCommand(newTestCmd())
 	rootCmd.AddCommand(newParseCmd())
 	rootCmd.AddCommand(newVersionCmd())
+
+	// Parse flags early so --no-banner is available before Execute().
+	// Cobra's PersistentPreRun doesn't chain, so calling printBanner here
+	// avoids being silently overridden by subcommand PersistentPreRun hooks.
+	rootCmd.ParseFlags(os.Args[1:]) //nolint:errcheck
+	noBanner, _ := rootCmd.Flags().GetBool("no-banner")
+	if !noBanner {
+		printBanner()
+	}
 
 	return rootCmd.Execute()
 }


### PR DESCRIPTION
## Description

Added the ASCII art banner. 

## Changes

Modified display, display_test, and run files in the runner to introduce the ASCII banner on module load. 

**NOTE:** The banner does not print when there is an error (for e.g., using a wrong flag value)

## Testing

<!-- How was this tested? -->

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Manual verification (describe below)

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated for new functionality
- [x] Documentation updated (if applicable)


## Evidence

<img width="435" height="169" alt="image" src="https://github.com/user-attachments/assets/eb51502e-3825-45cb-a486-d6f3506bf9cb" />

