### PR TITLE
Update README with expected e2e test results

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -190,3 +190,19 @@ test/
   grpc-server/             # gRPC server source + templates
   crapi/                   # crAPI test config + templates
 ```
+
+## Expected result
+
+After running the e2e test shell script, you will see a table similar to the following.
+
+```
+TARGET                    STATUS     FINDINGS     DURATION
+------------------------- ---------- ------------ ----------
+vulnerable-api-bearer     PASS       61           21s
+vulnerable-api-apikey     PASS       61           20s
+vulnerable-api-basic      PASS       61           20s
+vulnerable-api-cookie     PASS       61           20s
+dvga                      PASS       6            3s
+grpc                      PASS       8            1s
+crapi                     PASS       26           37s
+```


### PR DESCRIPTION
## Description

Adds an "Expected result" section to the e2e test README showing the expected output table after running the e2e test shell script. This gives developers a quick reference to verify their test runs are producing the correct results.

## Changes

- Added expected result section to `test/README.md` with a sample output table showing target names, pass/fail status, finding counts, and durations for all 7 e2e test targets (vulnerable-api variants, dvga, grpc, crapi)

## Testing

- [x] Manual verification — documentation-only change, no code affected

## Checklist

- [x] Code follows project conventions
- [ ] Tests added/updated for new functionality
- [x] Documentation updated (if applicable)