### PR TITLE
Fix Quick Start commands to match current CLI defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Download the latest binary from the [Releases](https://github.com/praetorian-inc
 ### REST API Testing
 
 ```bash
-hadrian test rest --api api.yaml --roles roles.yaml --auth auth.yaml
+hadrian test rest --api api.yaml --roles roles.yaml --auth auth.yaml --category all
 ```
 
 ### GraphQL API Testing
 
 ```bash
-hadrian test graphql --target https://api.example.com --auth auth.yaml --roles roles.yaml
+hadrian test graphql --target https://api.example.com --auth auth.yaml --roles roles.yaml --template-dir templates/graphql
 ```
 
 ### gRPC API Testing
@@ -70,17 +70,17 @@ hadrian test grpc --target localhost:50051 --proto service.proto --auth auth.yam
 
 ```bash
 # Dry run (show what would be tested)
-hadrian test rest --api api.yaml --roles roles.yaml --dry-run
+hadrian test rest --api api.yaml --roles roles.yaml --category all --dry-run
 
 # Output to JSON file
-hadrian test rest --api api.yaml --roles roles.yaml --output json --output-file report.json
+hadrian test rest --api api.yaml --roles roles.yaml --category all --output json --output-file report.json
 
 # With LLM-powered triage
-hadrian test rest --api api.yaml --roles roles.yaml \
+hadrian test rest --api api.yaml --roles roles.yaml --category all \
   --llm-host http://localhost:11434 --llm-model llama3.2:latest
 
 # Route through Burp Suite proxy
-hadrian test rest --api api.yaml --roles roles.yaml --proxy http://localhost:8080 --insecure
+hadrian test rest --api api.yaml --roles roles.yaml --category all --proxy http://localhost:8080 --insecure
 ```
 
 ## Documentation

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -6,16 +6,16 @@ Hadrian supports security testing of GraphQL APIs, including introspection detec
 
 ```bash
 # Basic GraphQL security scan (uses introspection)
-hadrian test graphql --target https://api.example.com
+hadrian test graphql --target https://api.example.com --template-dir templates/graphql
 
 # With custom endpoint path
-hadrian test graphql --target https://api.example.com --endpoint /api/graphql
+hadrian test graphql --target https://api.example.com --endpoint /api/graphql --template-dir templates/graphql
 
 # With SDL schema file (when introspection is disabled)
-hadrian test graphql --target https://api.example.com --schema schema.graphql
+hadrian test graphql --target https://api.example.com --schema schema.graphql --template-dir templates/graphql
 
 # With authentication for authorization testing
-hadrian test graphql --target https://api.example.com --auth auth.yaml --roles roles.yaml
+hadrian test graphql --target https://api.example.com --auth auth.yaml --roles roles.yaml --template-dir templates/graphql
 ```
 
 ## Command Options

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -6,16 +6,16 @@ Hadrian provides comprehensive REST API security testing with 8 built-in templat
 
 ```bash
 # Basic security test
-hadrian test rest --api api.yaml --roles roles.yaml
+hadrian test rest --api api.yaml --roles roles.yaml --category all
 
 # With authentication
-hadrian test rest --api api.yaml --roles roles.yaml --auth auth.yaml
+hadrian test rest --api api.yaml --roles roles.yaml --auth auth.yaml --category all
 
 # Dry run (show what would be tested)
-hadrian test rest --api api.yaml --roles roles.yaml --dry-run
+hadrian test rest --api api.yaml --roles roles.yaml --category all --dry-run
 
 # Verbose output with JSON report
-hadrian test rest --api api.yaml --roles roles.yaml --verbose --output json --output-file report.json
+hadrian test rest --api api.yaml --roles roles.yaml --category all --verbose --output json --output-file report.json
 ```
 
 ## Command Options


### PR DESCRIPTION
## Summary

- Add `--category all` to all REST Quick Start commands — the default `--category owasp` matches no template file paths, silently loading zero templates (LAB-1637)
- Add `--template-dir templates/graphql` to GraphQL Quick Start command — unlike REST and gRPC, GraphQL doesn't auto-default to its template directory (LAB-1638)

## Context

The Quick Start commands in the README looked correct but would silently produce no test results due to two independent bugs:

1. **REST `--category` default**: Defaults to `"owasp"`, but `loadTemplateFiles()` filters by `strings.Contains(path, cat)` and no template path contains `"owasp"`. All 8 REST templates get silently excluded.
2. **GraphQL `--template-dir` missing default**: REST defaults to `./templates/rest/` and gRPC to `./templates/grpc/`, but GraphQL only loads templates when `--template-dir` is explicitly provided.

This PR is a docs-only workaround. The underlying code fixes are tracked in LAB-1637 and LAB-1638.

## Test plan

- [ ] Verify `hadrian test rest --api api.yaml --roles roles.yaml --category all --dry-run` loads templates
- [ ] Verify `hadrian test graphql --target ... --template-dir templates/graphql --dry-run` loads templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)