### PR TITLE
fix(ci): pin actions to SHA, add release environment gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
 
@@ -27,9 +27,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
 
@@ -37,7 +37,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: coverage
           path: coverage.out
@@ -46,14 +46,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: latest
 
@@ -61,9 +61,9 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,18 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
## Summary

Addresses Trajan CI/CD security scan findings for pre-OSS-release hardening.

- **Pin all 13 GitHub Actions references to immutable commit SHAs** across `ci.yml` and `release.yml`, mitigating supply chain attacks via mutable version tags (zero-click attack vector)
- **Add `environment: production` gate** to the release workflow, requiring human approval before publishing releases

## Trajan Scan Results

| Severity | Finding | Count | Status |
|----------|---------|-------|--------|
| HIGH | `unpinned_action` (supply chain) | 13 | **Fixed** in this PR |
| HIGH | `environment_bypass` (privilege escalation) | 1 | **Partially fixed** — see blocking step below |

## ⚠️ BLOCKING: Manual Step Required Before Merge

> **This PR is not complete until the `production` environment is created in GitHub repo settings.**
>
> The `environment: production` line in `release.yml` has no effect without a corresponding environment configured in the repo. Without it, releases still run without approval.
>
> **Steps:**
> 1. Go to **Settings → Environments → New environment**
> 2. Name it `production`
> 3. Check **Required reviewers** and add appropriate approvers
> 4. Optionally restrict to the `main` branch under **Deployment branches**
>
> **Do not merge this PR until the environment is configured.** Otherwise the `environment` key is cosmetic only and provides no actual protection.

## Test plan

- [ ] Verify CI workflows pass on this PR (confirms pinned SHAs resolve correctly)
- [ ] Create `production` environment in repo settings with required reviewers
- [ ] After merge, verify a test tag push pauses for approval before releasing