### PR TITLE
Update GHA workflows to pin version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -27,9 +27,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -37,7 +37,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out
@@ -46,14 +46,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -61,9 +61,9 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean

--- a/pkg/graphql/executor.go
+++ b/pkg/graphql/executor.go
@@ -186,4 +186,3 @@ func (r *ExecuteResult) HasErrors() bool {
 func (r *ExecuteResult) IsSuccess() bool {
 	return r.StatusCode >= 200 && r.StatusCode < 300 && !r.HasErrors()
 }
-

--- a/pkg/orchestrator/tracked_client.go
+++ b/pkg/orchestrator/tracked_client.go
@@ -47,4 +47,3 @@ func (t *TrackedHTTPClient) ClearRequestIDs() {
 	defer t.mu.Unlock()
 	t.requestIDs = make([]string, 0)
 }
-

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -44,9 +44,9 @@ func TestValidate_Success(t *testing.T) {
 
 func TestValidate_MissingAPISpec(t *testing.T) {
 	config := &Config{
-		API:         "/nonexistent/api.yaml",
-		Roles:       "/tmp/roles.yaml",
-		Output:      "terminal",
+		API:    "/nonexistent/api.yaml",
+		Roles:  "/tmp/roles.yaml",
+		Output: "terminal",
 	}
 
 	err := config.Validate()
@@ -64,9 +64,9 @@ func TestValidate_MissingRolesFile(t *testing.T) {
 	}
 
 	config := &Config{
-		API:         apiSpec,
-		Roles:       "/nonexistent/roles.yaml",
-		Output:      "terminal",
+		API:    apiSpec,
+		Roles:  "/nonexistent/roles.yaml",
+		Output: "terminal",
 	}
 
 	err := config.Validate()

--- a/pkg/runner/integration_test.go
+++ b/pkg/runner/integration_test.go
@@ -133,13 +133,13 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 
 	// Create config
 	config := Config{
-		API:         apiSpecPath,
-		Roles:       rolesPath,
-		Auth:        authPath,
-		RateLimit:   10.0,
-		Timeout:     30,
-		Output:      "terminal",
-		Categories:  []string{"owasp"},
+		API:        apiSpecPath,
+		Roles:      rolesPath,
+		Auth:       authPath,
+		RateLimit:  10.0,
+		Timeout:    30,
+		Output:     "terminal",
+		Categories: []string{"owasp"},
 	}
 
 	// Run the test
@@ -190,13 +190,13 @@ func TestIntegration_DryRunMode(t *testing.T) {
 
 	// Create config with DryRun enabled
 	config := Config{
-		API:         apiSpecPath,
-		Roles:       rolesPath,
-		RateLimit:   10.0,
-		Timeout:     30,
-		Output:      "terminal",
-		Categories:  []string{"owasp"},
-		DryRun:      true, // Enable dry-run mode
+		API:        apiSpecPath,
+		Roles:      rolesPath,
+		RateLimit:  10.0,
+		Timeout:    30,
+		Output:     "terminal",
+		Categories: []string{"owasp"},
+		DryRun:     true, // Enable dry-run mode
 	}
 
 	// Run the test
@@ -250,13 +250,13 @@ func TestIntegration_VerboseOutput(t *testing.T) {
 
 	// Create config with Verbose enabled
 	config := Config{
-		API:         apiSpecPath,
-		Roles:       rolesPath,
-		RateLimit:   10.0,
-		Timeout:     30,
-		Output:      "terminal",
-		Categories:  []string{"owasp"},
-		Verbose:     true, // Enable verbose mode
+		API:        apiSpecPath,
+		Roles:      rolesPath,
+		RateLimit:  10.0,
+		Timeout:    30,
+		Output:     "terminal",
+		Categories: []string{"owasp"},
+		Verbose:    true, // Enable verbose mode
 	}
 
 	// Run the test
@@ -313,13 +313,13 @@ func TestIntegration_JSONOutput(t *testing.T) {
 
 	// Create config with JSON output
 	config := Config{
-		API:         apiSpecPath,
-		Roles:       rolesPath,
-		RateLimit:   10.0,
-		Timeout:     30,
-		Output:      "json",
-		OutputFile:  outputFile,
-		Categories:  []string{"owasp"},
+		API:        apiSpecPath,
+		Roles:      rolesPath,
+		RateLimit:  10.0,
+		Timeout:    30,
+		Output:     "json",
+		OutputFile: outputFile,
+		Categories: []string{"owasp"},
 	}
 
 	// Run the test
@@ -375,13 +375,13 @@ func TestIntegration_MarkdownOutput(t *testing.T) {
 
 	// Create config with Markdown output
 	config := Config{
-		API:         apiSpecPath,
-		Roles:       rolesPath,
-		RateLimit:   10.0,
-		Timeout:     30,
-		Output:      "markdown",
-		OutputFile:  outputFile,
-		Categories:  []string{"owasp"},
+		API:        apiSpecPath,
+		Roles:      rolesPath,
+		RateLimit:  10.0,
+		Timeout:    30,
+		Output:     "markdown",
+		OutputFile: outputFile,
+		Categories: []string{"owasp"},
 	}
 
 	// Run the test

--- a/pkg/runner/request_id_e2e_test.go
+++ b/pkg/runner/request_id_e2e_test.go
@@ -140,14 +140,14 @@ http:
 
 	// Create config
 	config := Config{
-		API:         apiSpecPath,
-		Roles:       rolesPath,
-		Auth:        authPath,
-		RateLimit:   10.0,
-		Timeout:     30,
-		Output:      "terminal",
-		Categories:  []string{"owasp"},
-		Verbose:     true,
+		API:        apiSpecPath,
+		Roles:      rolesPath,
+		Auth:       authPath,
+		RateLimit:  10.0,
+		Timeout:    30,
+		Output:     "terminal",
+		Categories: []string{"owasp"},
+		Verbose:    true,
 	}
 
 	// Redirect stdout to capture terminal output

--- a/pkg/templates/parse.go
+++ b/pkg/templates/parse.go
@@ -77,4 +77,3 @@ func validateTemplate(tmpl *Template) error {
 
 	return nil
 }
-


### PR DESCRIPTION
Pinning version tags.

## Description

Our GHA configuration involves authorizing specific workflows by version tag, so unfortunately pinning hashes will result in failing CI workflows. I'm receptive to this in the case of workflows from reputable sources (as we are using here), but we'd need to adopt hash-based pinning if we wanted to use any less common workflows.

## Changes

- Updated ci.yml to use pinned version tags for external workflows
- Updated release.yml to use pinned version tags for external workflows

## Testing

<!-- How was this tested? -->

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manual verification (describe below)

## Checklist

- [ ] Code follows project conventions
- [ ] Tests added/updated for new functionality
- [ ] Documentation updated (if applicable)
