### PR TITLE
fix(graphql): default --template-dir to ./templates/graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ hadrian test rest --api api.yaml --roles roles.yaml --auth auth.yaml --category 
 ### GraphQL API Testing
 
 ```bash
-hadrian test graphql --target https://api.example.com --auth auth.yaml --roles roles.yaml --template-dir templates/graphql
+hadrian test graphql --target https://api.example.com --auth auth.yaml --roles roles.yaml
 ```
 
 ### gRPC API Testing

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -6,16 +6,16 @@ Hadrian supports security testing of GraphQL APIs, including introspection detec
 
 ```bash
 # Basic GraphQL security scan (uses introspection)
-hadrian test graphql --target https://api.example.com --template-dir templates/graphql
+hadrian test graphql --target https://api.example.com
 
 # With custom endpoint path
-hadrian test graphql --target https://api.example.com --endpoint /api/graphql --template-dir templates/graphql
+hadrian test graphql --target https://api.example.com --endpoint /api/graphql
 
 # With SDL schema file (when introspection is disabled)
-hadrian test graphql --target https://api.example.com --schema schema.graphql --template-dir templates/graphql
+hadrian test graphql --target https://api.example.com --schema schema.graphql
 
 # With authentication for authorization testing
-hadrian test graphql --target https://api.example.com --auth auth.yaml --roles roles.yaml --template-dir templates/graphql
+hadrian test graphql --target https://api.example.com --auth auth.yaml --roles roles.yaml
 ```
 
 ## Command Options
@@ -29,7 +29,7 @@ Flags:
       --schema string          GraphQL SDL schema file (optional, uses introspection if not provided)
       --roles string           Roles and permissions YAML file
       --auth string            Authentication configuration YAML file
-      --template-dir string    GraphQL templates directory
+      --template-dir string    GraphQL templates directory (default: $HADRIAN_TEMPLATES or ./templates/graphql)
       --depth-limit int        Maximum query depth for DoS testing (default 10)
       --complexity-limit int   Maximum complexity score for DoS testing (default 1000)
       --batch-size int         Number of queries in batch attack tests (default 100)

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -99,7 +99,7 @@ func newTestGraphQLCmd() *cobra.Command {
 	cmd.Flags().StringVar(&config.Auth, "auth", "", "Authentication configuration YAML file")
 
 	// Template configuration
-	cmd.Flags().StringVar(&config.TemplateDir, "template-dir", "", "GraphQL templates directory (e.g., templates/graphql)")
+	cmd.Flags().StringVar(&config.TemplateDir, "template-dir", "", "GraphQL templates directory (default: $HADRIAN_TEMPLATES or ./templates/graphql)")
 	cmd.Flags().BoolVar(&config.SkipBuiltinChecks, "skip-builtin-checks", false, "Skip built-in security checks (introspection, depth limit, batching)")
 
 	// Security limits

--- a/pkg/runner/graphql_helpers.go
+++ b/pkg/runner/graphql_helpers.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"time"
 
 	internalhttp "github.com/praetorian-inc/hadrian/internal/http"
@@ -225,8 +226,19 @@ func runSecurityChecks(ctx context.Context, schema *graphql.Schema, httpClient t
 	}
 
 	templateCount := 0
-	// Execute GraphQL templates if provided
-	if config.TemplateDir != "" {
+	// Execute GraphQL templates if template directory exists
+	templateDir := config.TemplateDir
+	if templateDir == "" {
+		templateDir = getTemplateDir("./templates/graphql")
+	}
+	if _, err := os.Stat(templateDir); err != nil {
+		if os.IsNotExist(err) {
+			graphqlVerboseLog(config.Verbose, "\n=== Skipping GraphQL Templates (directory not found: %s) ===", templateDir)
+		} else {
+			graphqlVerboseLog(config.Verbose, "\n=== Skipping GraphQL Templates (error accessing %s: %v) ===", templateDir, err)
+		}
+	} else {
+		config.TemplateDir = templateDir
 		templateFindings, count := runTemplateTests(ctx, config, endpoint, httpClient, authConfigs, reporter, customHeaders)
 		findings = append(findings, templateFindings...)
 		templateCount = count

--- a/pkg/runner/grpc.go
+++ b/pkg/runner/grpc.go
@@ -108,7 +108,7 @@ func newTestGRPCCmd() *cobra.Command {
 	cmd.Flags().StringVar(&config.Auth, "auth", "", "Authentication configuration YAML file")
 
 	// Template configuration
-	cmd.Flags().StringVar(&config.TemplateDir, "template-dir", "", "gRPC templates directory (e.g., templates/grpc)")
+	cmd.Flags().StringVar(&config.TemplateDir, "template-dir", "", "gRPC templates directory (default: $HADRIAN_TEMPLATES or ./templates/grpc)")
 	cmd.Flags().StringSliceVar(&config.Templates, "template", []string{}, "Filter templates by ID or name (can specify multiple)")
 
 	// TLS options

--- a/pkg/runner/grpc.go
+++ b/pkg/runner/grpc.go
@@ -246,7 +246,7 @@ func runGRPCTest(ctx context.Context, config GRPCConfig) error {
 	// 3. Load templates from template directory
 	templateDir := config.TemplateDir
 	if templateDir == "" {
-		templateDir = "./templates/grpc"
+		templateDir = getTemplateDir("./templates/grpc")
 	}
 
 	var templateFiles []*templates.CompiledTemplate

--- a/pkg/runner/helpers_test.go
+++ b/pkg/runner/helpers_test.go
@@ -498,15 +498,23 @@ func TestGetTemplateDir_Default(t *testing.T) {
 	// Unset env var
 	_ = os.Unsetenv("HADRIAN_TEMPLATES")
 
-	dir := getTemplateDir()
+	dir := getTemplateDir("./templates/rest")
 	assert.Equal(t, "./templates/rest", dir)
+}
+
+func TestGetTemplateDir_DefaultGraphQL(t *testing.T) {
+	// Unset env var
+	_ = os.Unsetenv("HADRIAN_TEMPLATES")
+
+	dir := getTemplateDir("./templates/graphql")
+	assert.Equal(t, "./templates/graphql", dir)
 }
 
 func TestGetTemplateDir_EnvOverride(t *testing.T) {
 	_ = os.Setenv("HADRIAN_TEMPLATES", "/custom/templates")
 	defer func() { _ = os.Unsetenv("HADRIAN_TEMPLATES") }()
 
-	dir := getTemplateDir()
+	dir := getTemplateDir("./templates/rest")
 	assert.Equal(t, "/custom/templates", dir)
 }
 

--- a/pkg/runner/helpers_test.go
+++ b/pkg/runner/helpers_test.go
@@ -516,6 +516,9 @@ func TestGetTemplateDir_EnvOverride(t *testing.T) {
 
 	dir := getTemplateDir("./templates/rest")
 	assert.Equal(t, "/custom/templates", dir)
+
+	dir = getTemplateDir("./templates/graphql")
+	assert.Equal(t, "/custom/templates", dir)
 }
 
 func TestHasLLMConfig_NoConfig(t *testing.T) {

--- a/pkg/runner/library.go
+++ b/pkg/runner/library.go
@@ -67,7 +67,7 @@ func RunTest(ctx context.Context, config Config) ([]*model.Finding, error) {
 
 	templateDir := config.TemplateDir
 	if templateDir == "" {
-		templateDir = getTemplateDir()
+		templateDir = getTemplateDir("./templates/rest")
 	}
 
 	tmplFiles, err := loadTemplateFiles(templateDir, config.Categories)

--- a/pkg/runner/rest.go
+++ b/pkg/runner/rest.go
@@ -133,7 +133,7 @@ func runTest(ctx context.Context, config Config) error {
 
 	templateDir := config.TemplateDir
 	if templateDir == "" {
-		templateDir = getTemplateDir()
+		templateDir = getTemplateDir("./templates/rest")
 	}
 	tmplFiles, err := loadTemplateFiles(templateDir, config.Categories)
 	if err != nil {
@@ -200,15 +200,15 @@ func runTest(ctx context.Context, config Config) error {
 // HELPER FUNCTIONS
 // =============================================================================
 
-// getTemplateDir returns the template directory path
-func getTemplateDir() string {
+// getTemplateDir returns the template directory path, using defaultPath if no
+// environment variable override is set.
+func getTemplateDir(defaultPath string) string {
 	// Check for environment variable override
 	if dir := os.Getenv("HADRIAN_TEMPLATES"); dir != "" {
 		return dir
 	}
 
-	// Default to ./templates/rest/ relative to current directory
-	return "./templates/rest"
+	return defaultPath
 }
 
 // loadTemplateFiles loads and compiles templates from directory

--- a/test/dvga/README.md
+++ b/test/dvga/README.md
@@ -141,7 +141,7 @@ set -a && source test/dvga/.env && set +a && \
 **Option C: With Generic GraphQL Templates**
 
 ```bash
-# Run all GraphQL attack templates (--template-dir templates/graphql is now optional, this is the default)
+# Run all GraphQL attack templates (uses default template directory)
 ./hadrian test graphql \
   --target http://localhost:5013 \
   --verbose

--- a/test/dvga/README.md
+++ b/test/dvga/README.md
@@ -141,10 +141,9 @@ set -a && source test/dvga/.env && set +a && \
 **Option C: With Generic GraphQL Templates**
 
 ```bash
-# Run all GraphQL attack templates
+# Run all GraphQL attack templates (--template-dir templates/graphql is now optional, this is the default)
 ./hadrian test graphql \
   --target http://localhost:5013 \
-  --template-dir templates/graphql \
   --verbose
 ```
 


### PR DESCRIPTION
## Summary

Fixes **LAB-1638**: The GraphQL runner's `--template-dir` flag had no default, so the 13 built-in GraphQL security templates (OWASP API1–API8) were silently skipped unless users explicitly passed `--template-dir ./templates/graphql`. REST and gRPC runners already had proper defaults.

## Problem

In `pkg/runner/graphql_helpers.go`, `runSecurityChecks()` guarded template execution with `if config.TemplateDir != ""`. Since `--template-dir` defaulted to an empty string in `graphql.go`, templates never loaded without the explicit flag — contradicting the Quick Start documentation.

## Solution

### Parameterized `getTemplateDir(defaultPath)` + `os.Stat` guard

1. **`getTemplateDir(defaultPath string)`** — Refactored from hardcoded `./templates/rest` to accept a default path parameter, shared by REST and GraphQL runners. Resolution order: `HADRIAN_TEMPLATES` env var → `defaultPath` argument.

2. **GraphQL template loading** — Defaults to `./templates/graphql/` when no `--template-dir` is provided. Uses `os.Stat` with `os.IsNotExist` discrimination to gracefully skip when the directory doesn't exist (e.g., running from a different working directory) vs logging errors for permission issues.

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `pkg/runner/rest.go` | +5, -5 | Parameterized `getTemplateDir(defaultPath string)` |
| `pkg/runner/graphql_helpers.go` | +13, -2 | Default to `./templates/graphql`, `os.Stat` guard with verbose logging |
| `pkg/runner/library.go` | +1, -1 | Updated caller to `getTemplateDir("./templates/rest")` |
| `pkg/runner/helpers_test.go` | +11, -2 | Updated tests + added `TestGetTemplateDir_DefaultGraphQL` |

## Verification

- `go vet ./...` — clean
- `go build ./cmd/hadrian` — builds
- `go test -count=1 ./pkg/runner/...` — all pass (16.5s)
- Backend code review — approved
- Security review — no vulnerabilities found

## Test plan

- [x] `TestGetTemplateDir_Default` — REST default `./templates/rest` preserved
- [x] `TestGetTemplateDir_DefaultGraphQL` — GraphQL default `./templates/graphql` works
- [x] `TestGetTemplateDir_EnvOverride` — `HADRIAN_TEMPLATES` env var overrides default
- [x] `TestLoadGraphQLTemplates_ValidDirectory` — templates load from valid directory
- [x] `TestLoadGraphQLTemplates_NonexistentDirectory` — graceful handling when missing
- [x] Manual: `./templates/graphql/` resolves from project root with all 13 YAML templates
- [x] Manual: `os.Stat` gracefully skips when run from directory without templates (e.g., /tmp)
- [x] Manual: `getTemplateDir("./templates/graphql")` returns correct default when no env override
- [x] CI: Format (16s), Build (56s), Lint (1m7s), Test (1m42s) — all passing

Closes LAB-1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)