### PR TITLE
feat(llm): add OpenAI and Anthropic providers for LLM triage (LAB-1804)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ The CLI (`cmd/hadrian`) delegates to `pkg/runner.Run()` which orchestrates:
 - **pkg/model**: Data structures for `Finding`, `Operation`, `Evidence`, `Severity`
 - **pkg/matchers**: Response matching (status codes, word/regex patterns)
 - **pkg/reporter**: Output formatters (terminal, JSON, markdown) with finding redaction
-- **pkg/llm**: LLM triage integration (Ollama)
+- **pkg/llm**: LLM triage integration (Ollama, OpenAI, Anthropic)
 
 ### Template System
 
@@ -175,5 +175,5 @@ config := runner.Config{
 - `HADRIAN_TEMPLATES`: Custom templates directory path
 - `OLLAMA_HOST`: Ollama host for LLM triage and planner (default: http://localhost:11434)
 - `OLLAMA_MODEL`: Ollama model name (default: llama3.2:latest)
-- `OPENAI_API_KEY`: OpenAI API key for planner
-- `ANTHROPIC_API_KEY`: Anthropic API key for planner
+- `OPENAI_API_KEY`: OpenAI API key for LLM triage (`--llm-provider openai`) and planner
+- `ANTHROPIC_API_KEY`: Anthropic API key for LLM triage (`--llm-provider anthropic`) and planner

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Most API security scanners test for injection and configuration issues but miss 
 | **Multiple Output Formats** | Terminal, JSON, and Markdown reports for CI/CD integration |
 | **Adaptive Rate Limiting** | Proactive request throttling with reactive backoff on 429/503 responses |
 | **Proxy Support** | Route traffic through Burp Suite or other intercepting proxies |
-| **LLM-Powered Triage** | Optional AI analysis of findings via Ollama to reduce false positives |
+| **LLM-Powered Triage** | Optional AI analysis of findings via Ollama, OpenAI, or Anthropic to reduce false positives |
 | **LLM-Assisted Attack Planning** | AI-driven prioritization of which endpoints and vulnerability patterns to test first |
 | **Claude Code Integration** | Auto-generate auth and role configs from OpenAPI, GraphQL SDL, or proto files |
 
@@ -100,9 +100,15 @@ hadrian test rest --api api.yaml --roles roles.yaml --dry-run
 # Export findings as JSON
 hadrian test rest --api api.yaml --roles roles.yaml --output json --output-file report.json
 
-# AI-powered triage to reduce false positives
+# AI-powered triage with Ollama (local)
 hadrian test rest --api api.yaml --roles roles.yaml \
   --llm-host http://localhost:11434 --llm-model llama3.2:latest
+
+# AI-powered triage with OpenAI (requires OPENAI_API_KEY)
+hadrian test rest --api api.yaml --roles roles.yaml --llm-provider openai
+
+# AI-powered triage with Anthropic (requires ANTHROPIC_API_KEY)
+hadrian test rest --api api.yaml --roles roles.yaml --llm-provider anthropic
 
 # AI-assisted attack planning (requires OPENAI_API_KEY, or use --planner-provider for Anthropic/Ollama)
 hadrian test rest --api api.yaml --roles roles.yaml --auth auth.yaml --planner

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,7 +117,7 @@ Hadrian is a security testing framework designed to identify OWASP API Top 10 vu
 │  │                        ▼                                                │ │
 │  │  ┌────────────────────────────────────────────────────────────────┐    │ │
 │  │  │                    LLM TRIAGE                                   │    │ │
-│  │  │   Ollama (local LLM)                                             │    │ │
+│  │  │   Ollama / OpenAI / Anthropic                                     │    │ │
 │  │  │   → is_vulnerability: true/false                               │    │ │
 │  │  │   → confidence: 0.95                                           │    │ │
 │  │  │   → recommendations: [...]                                     │    │ │
@@ -175,7 +175,7 @@ hadrian/
 │   │   └── grpc/            # Protocol Buffers parser
 │   ├── graphql/             # GraphQL security scanning engine
 │   ├── reporter/            # Output formatting (terminal, JSON, markdown)
-│   ├── llm/                 # LLM integration (Ollama)
+│   ├── llm/                 # LLM integration (Ollama, OpenAI, Anthropic)
 │   └── matchers/            # Detection matchers
 ├── internal/http/           # HTTP client with proxy support
 └── templates/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,18 +301,25 @@ hadrian test rest --api api.yaml --roles roles.yaml \
 
 ## LLM Triage
 
-Hadrian supports optional AI-powered finding analysis using a local LLM via [Ollama](https://ollama.ai/). When enabled, each finding is sent to the LLM for contextual triage to reduce false positives.
+Hadrian supports optional AI-powered finding analysis using [Ollama](https://ollama.ai/) (local), OpenAI, or Anthropic. When enabled, each finding is sent to the LLM for contextual triage to reduce false positives.
 
 ```bash
-# Enable LLM triage with Ollama
+# Ollama (local, default provider)
 hadrian test rest --api api.yaml --roles roles.yaml \
   --llm-host http://localhost:11434 \
   --llm-model llama3.2:latest
 
+# OpenAI (requires OPENAI_API_KEY env var)
+hadrian test rest --api api.yaml --roles roles.yaml \
+  --llm-provider openai
+
+# Anthropic (requires ANTHROPIC_API_KEY env var)
+hadrian test rest --api api.yaml --roles roles.yaml \
+  --llm-provider anthropic
+
 # Add domain context for better analysis
 hadrian test rest --api api.yaml --roles roles.yaml \
-  --llm-host http://localhost:11434 \
-  --llm-model llama3.2:latest \
+  --llm-provider openai \
   --llm-context "This API handles financial data with PCI DSS requirements"
 ```
 
@@ -320,10 +327,19 @@ hadrian test rest --api api.yaml --roles roles.yaml \
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--llm-provider <name>` | `ollama` | LLM provider: `ollama`, `openai`, `anthropic` |
 | `--llm-host <url>` | - | LLM service host URL (e.g., `http://localhost:11434` for Ollama) |
-| `--llm-model <model>` | - | Model name (e.g., `llama3.2:latest`) |
+| `--llm-model <model>` | - | Model name (e.g., `llama3.2:latest`, `gpt-4o`, `claude-sonnet-4-20250514`) |
 | `--llm-timeout <n>` | 180 | Request timeout in seconds |
 | `--llm-context <text>` | - | Additional context for analysis |
+
+### Environment Variables
+
+| Variable | Provider | Description |
+|----------|----------|-------------|
+| `OPENAI_API_KEY` | OpenAI | API key for OpenAI triage |
+| `ANTHROPIC_API_KEY` | Anthropic | API key for Anthropic triage |
+| `OLLAMA_HOST` | Ollama | Custom Ollama host (default: `http://localhost:11434`) |
 
 ### Data Safety
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -329,7 +329,7 @@ hadrian test rest --api api.yaml --roles roles.yaml \
 |------|---------|-------------|
 | `--llm-provider <name>` | `ollama` | LLM provider: `ollama`, `openai`, `anthropic` |
 | `--llm-host <url>` | - | LLM service host URL (e.g., `http://localhost:11434` for Ollama) |
-| `--llm-model <model>` | - | Model name (e.g., `llama3.2:latest`, `gpt-4o`, `claude-sonnet-4-20250514`) |
+| `--llm-model <model>` | - | Model name (e.g., `llama3.2:latest`, `gpt-4o`, `claude-sonnet-4-6`) |
 | `--llm-timeout <n>` | 180 | Request timeout in seconds |
 | `--llm-context <text>` | - | Additional context for analysis |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,7 +333,7 @@ hadrian test rest --api api.yaml --roles roles.yaml \
 | `--llm-timeout <n>` | 180 | Request timeout in seconds |
 | `--llm-context <text>` | - | Additional context for analysis |
 
-### Environment Variables
+### LLM Environment Variables
 
 | Variable | Provider | Description |
 |----------|----------|-------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,7 +339,6 @@ hadrian test rest --api api.yaml --roles roles.yaml \
 |----------|----------|-------------|
 | `OPENAI_API_KEY` | OpenAI | API key for OpenAI triage |
 | `ANTHROPIC_API_KEY` | Anthropic | API key for Anthropic triage |
-| `OLLAMA_HOST` | Ollama | Custom Ollama host (default: `http://localhost:11434`) |
 
 ### Data Safety
 

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -76,7 +76,7 @@ func (c *AnthropicClient) Triage(ctx context.Context, req *TriageRequest) (*Tria
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("Anthropic API call failed: %w", err)
+		return nil, fmt.Errorf("Anthropic API call failed: %w", err) //nolint:staticcheck // proper noun
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -86,7 +86,7 @@ func (c *AnthropicClient) Triage(ctx context.Context, req *TriageRequest) (*Tria
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Anthropic API returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("Anthropic API returned status %d: %.500s", resp.StatusCode, string(respBody)) //nolint:staticcheck // proper noun
 	}
 
 	var result struct {
@@ -106,5 +106,5 @@ func (c *AnthropicClient) Triage(ctx context.Context, req *TriageRequest) (*Tria
 		}
 	}
 
-	return nil, fmt.Errorf("Anthropic returned no text content")
+	return nil, fmt.Errorf("Anthropic returned no text content") //nolint:staticcheck // proper noun
 }

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -3,9 +3,11 @@ package llm
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -14,9 +16,11 @@ import (
 )
 
 // AnthropicClient implements Client using the Anthropic Messages API.
+// AnthropicClient implements Client using the Anthropic Messages API.
 type AnthropicClient struct {
 	apiKey        string
 	model         string
+	endpoint      string // defaults to "https://api.anthropic.com/v1/messages"
 	redactor      *reporter.Redactor
 	client        *http.Client
 	customContext string
@@ -37,10 +41,17 @@ func NewAnthropicClient(apiKey, model string, timeout time.Duration, customConte
 		timeout = 120 * time.Second
 	}
 	return &AnthropicClient{
-		apiKey:        apiKey,
-		model:         model,
-		redactor:      reporter.NewRedactor(),
-		client:        &http.Client{Timeout: timeout},
+		apiKey:   apiKey,
+		model:    model,
+		endpoint: "https://api.anthropic.com/v1/messages",
+		redactor: reporter.NewRedactor(),
+		client: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+				DialContext:     (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			},
+		},
 		customContext: customContext,
 	}, nil
 }
@@ -66,7 +77,7 @@ func (c *AnthropicClient) Triage(ctx context.Context, req *TriageRequest) (*Tria
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -34,7 +34,7 @@ func NewAnthropicClient(apiKey, model string, timeout time.Duration, customConte
 		return nil, fmt.Errorf("ANTHROPIC_API_KEY not set")
 	}
 	if model == "" {
-		model = "claude-sonnet-4-20250514"
+		model = "claude-sonnet-4-6"
 	}
 	if timeout == 0 {
 		timeout = 120 * time.Second

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -66,7 +66,7 @@ func (c *AnthropicClient) Triage(ctx context.Context, req *TriageRequest) (*Tria
 	reqBody := map[string]interface{}{
 		"model":      c.model,
 		"max_tokens": 4096,
-		"system":     "You are a security expert. Respond with valid JSON only.",
+		"system":     "You are a security expert. Respond with valid JSON only. Do NOT wrap the response in markdown code fences or backticks.",
 		"messages": []map[string]string{
 			{"role": "user", "content": prompt},
 		},

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -16,7 +16,6 @@ import (
 )
 
 // AnthropicClient implements Client using the Anthropic Messages API.
-// AnthropicClient implements Client using the Anthropic Messages API.
 type AnthropicClient struct {
 	apiKey        string
 	model         string

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -1,0 +1,110 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/praetorian-inc/hadrian/pkg/reporter"
+)
+
+// AnthropicClient implements Client using the Anthropic Messages API.
+type AnthropicClient struct {
+	apiKey        string
+	model         string
+	redactor      *reporter.Redactor
+	client        *http.Client
+	customContext string
+}
+
+// NewAnthropicClient creates an Anthropic triage client.
+func NewAnthropicClient(apiKey, model string, timeout time.Duration, customContext string) (*AnthropicClient, error) {
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("ANTHROPIC_API_KEY not set")
+	}
+	if model == "" {
+		model = "claude-sonnet-4-20250514"
+	}
+	if timeout == 0 {
+		timeout = 120 * time.Second
+	}
+	return &AnthropicClient{
+		apiKey:        apiKey,
+		model:         model,
+		redactor:      reporter.NewRedactor(),
+		client:        &http.Client{Timeout: timeout},
+		customContext: customContext,
+	}, nil
+}
+
+func (c *AnthropicClient) Name() string {
+	return "anthropic"
+}
+
+func (c *AnthropicClient) Triage(ctx context.Context, req *TriageRequest) (*TriageResult, error) {
+	prompt := BuildTriagePrompt(req, c.redactor, c.customContext)
+
+	reqBody := map[string]interface{}{
+		"model":      c.model,
+		"max_tokens": 4096,
+		"system":     "You are a security expert. Respond with valid JSON only.",
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", c.apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("Anthropic API call failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, MaxLLMResponseBodySize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Anthropic API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse Anthropic response: %w", err)
+	}
+
+	for _, block := range result.Content {
+		if block.Type == "text" {
+			return ParseTriageJSON(block.Text, "anthropic")
+		}
+	}
+
+	return nil, fmt.Errorf("Anthropic returned no text content")
+}

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -47,6 +47,7 @@ func NewAnthropicClient(apiKey, model string, timeout time.Duration, customConte
 		client: &http.Client{
 			Timeout: timeout,
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 				DialContext:     (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
 			},
@@ -104,10 +105,15 @@ func (c *AnthropicClient) Triage(ctx context.Context, req *TriageRequest) (*Tria
 			Type string `json:"type"`
 			Text string `json:"text"`
 		} `json:"content"`
+		StopReason string `json:"stop_reason"`
 	}
 
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse Anthropic response: %w", err)
+	}
+
+	if result.StopReason == "max_tokens" {
+		return nil, fmt.Errorf("Anthropic response truncated (hit max_tokens limit)") //nolint:staticcheck // proper noun
 	}
 
 	for _, block := range result.Content {

--- a/pkg/llm/anthropic_test.go
+++ b/pkg/llm/anthropic_test.go
@@ -21,7 +21,7 @@ func TestAnthropicClient_Name(t *testing.T) {
 
 func TestNewAnthropicClient_RequiresAPIKey(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
-	_, err := NewAnthropicClient("", "claude-sonnet-4-20250514", 120*time.Second, "")
+	_, err := NewAnthropicClient("", "claude-sonnet-4-6", 120*time.Second, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ANTHROPIC_API_KEY not set")
 }
@@ -31,7 +31,7 @@ func TestNewAnthropicClient_UsesEnvKey(t *testing.T) {
 	client, err := NewAnthropicClient("", "", 0, "")
 	require.NoError(t, err)
 	assert.Equal(t, "sk-ant-test-123", client.apiKey)
-	assert.Equal(t, "claude-sonnet-4-20250514", client.model)
+	assert.Equal(t, "claude-sonnet-4-6", client.model)
 }
 
 func TestAnthropicClient_Triage_Success(t *testing.T) {
@@ -51,7 +51,7 @@ func TestAnthropicClient_Triage_Success(t *testing.T) {
 
 	client := &AnthropicClient{
 		apiKey:   "test-key",
-		model:    "claude-sonnet-4-20250514",
+		model:    "claude-sonnet-4-6",
 		endpoint: server.URL,
 		redactor: reporter.NewRedactor(),
 		client:   &http.Client{Timeout: 10 * time.Second},
@@ -74,7 +74,7 @@ func TestAnthropicClient_Triage_HTTPError(t *testing.T) {
 
 	client := &AnthropicClient{
 		apiKey:   "test-key",
-		model:    "claude-sonnet-4-20250514",
+		model:    "claude-sonnet-4-6",
 		endpoint: server.URL,
 		redactor: reporter.NewRedactor(),
 		client:   &http.Client{Timeout: 10 * time.Second},
@@ -98,7 +98,7 @@ func TestAnthropicClient_Triage_NoTextContent(t *testing.T) {
 
 	client := &AnthropicClient{
 		apiKey:   "test-key",
-		model:    "claude-sonnet-4-20250514",
+		model:    "claude-sonnet-4-6",
 		endpoint: server.URL,
 		redactor: reporter.NewRedactor(),
 		client:   &http.Client{Timeout: 10 * time.Second},

--- a/pkg/llm/anthropic_test.go
+++ b/pkg/llm/anthropic_test.go
@@ -2,13 +2,14 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/reporter"
-	"github.com/praetorian-inc/hadrian/pkg/roles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,31 +34,77 @@ func TestNewAnthropicClient_UsesEnvKey(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-20250514", client.model)
 }
 
-func TestNewAnthropicClient_DefaultTimeout(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-	client, err := NewAnthropicClient("", "", 0, "")
-	require.NoError(t, err)
-	assert.Equal(t, 120*time.Second, client.client.Timeout)
-}
+func TestAnthropicClient_Triage_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "test-key", r.Header.Get("x-api-key"))
+		assert.Equal(t, "2023-06-01", r.Header.Get("anthropic-version"))
 
-func TestAnthropicClient_Triage_ConnectionError(t *testing.T) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"content": []map[string]interface{}{
+				{"type": "text", "text": `{"is_vulnerability":true,"confidence":0.85,"reasoning":"BOLA detected","severity":"CRITICAL","recommendations":"Add authz"}`},
+			},
+		}))
+	}))
+	defer server.Close()
+
 	client := &AnthropicClient{
 		apiKey:   "test-key",
 		model:    "claude-sonnet-4-20250514",
+		endpoint: server.URL,
 		redactor: reporter.NewRedactor(),
-		client:   &http.Client{Timeout: 1 * time.Second},
+		client:   &http.Client{Timeout: 10 * time.Second},
 	}
 
-	finding := &model.Finding{
-		Category: "API1", Method: "GET", Endpoint: "/test",
-		Evidence: model.Evidence{Response: model.HTTPResponse{StatusCode: 200, Body: "test"}},
-	}
-	req := &TriageRequest{
-		Finding:      finding,
-		AttackerRole: &roles.Role{Name: "user"},
-		VictimRole:   &roles.Role{Name: "admin"},
+	result, err := client.Triage(context.Background(), testTriageRequest())
+	require.NoError(t, err)
+	assert.True(t, result.IsVulnerability)
+	assert.Equal(t, 0.85, result.Confidence)
+	assert.Equal(t, "anthropic", result.Provider)
+	assert.Equal(t, model.SeverityCritical, result.Severity)
+}
+
+func TestAnthropicClient_Triage_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+		_, _ = w.Write([]byte(`{"error":"invalid key"}`))
+	}))
+	defer server.Close()
+
+	client := &AnthropicClient{
+		apiKey:   "test-key",
+		model:    "claude-sonnet-4-20250514",
+		endpoint: server.URL,
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 10 * time.Second},
 	}
 
-	_, err := client.Triage(context.Background(), req)
-	assert.Error(t, err)
+	_, err := client.Triage(context.Background(), testTriageRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestAnthropicClient_Triage_NoTextContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"content": []map[string]interface{}{
+				{"type": "image", "text": "data"},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	client := &AnthropicClient{
+		apiKey:   "test-key",
+		model:    "claude-sonnet-4-20250514",
+		endpoint: server.URL,
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 10 * time.Second},
+	}
+
+	_, err := client.Triage(context.Background(), testTriageRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no text content")
 }

--- a/pkg/llm/anthropic_test.go
+++ b/pkg/llm/anthropic_test.go
@@ -1,0 +1,63 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/reporter"
+	"github.com/praetorian-inc/hadrian/pkg/roles"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicClient_Name(t *testing.T) {
+	client := &AnthropicClient{}
+	assert.Equal(t, "anthropic", client.Name())
+}
+
+func TestNewAnthropicClient_RequiresAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	_, err := NewAnthropicClient("", "claude-sonnet-4-20250514", 120*time.Second, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ANTHROPIC_API_KEY not set")
+}
+
+func TestNewAnthropicClient_UsesEnvKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-123")
+	client, err := NewAnthropicClient("", "", 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-ant-test-123", client.apiKey)
+	assert.Equal(t, "claude-sonnet-4-20250514", client.model)
+}
+
+func TestNewAnthropicClient_DefaultTimeout(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	client, err := NewAnthropicClient("", "", 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, 120*time.Second, client.client.Timeout)
+}
+
+func TestAnthropicClient_Triage_ConnectionError(t *testing.T) {
+	client := &AnthropicClient{
+		apiKey:   "test-key",
+		model:    "claude-sonnet-4-20250514",
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 1 * time.Second},
+	}
+
+	finding := &model.Finding{
+		Category: "API1", Method: "GET", Endpoint: "/test",
+		Evidence: model.Evidence{Response: model.HTTPResponse{StatusCode: 200, Body: "test"}},
+	}
+	req := &TriageRequest{
+		Finding:      finding,
+		AttackerRole: &roles.Role{Name: "user"},
+		VictimRole:   &roles.Role{Name: "admin"},
+	}
+
+	_, err := client.Triage(context.Background(), req)
+	assert.Error(t, err)
+}

--- a/pkg/llm/anthropic_test.go
+++ b/pkg/llm/anthropic_test.go
@@ -108,3 +108,22 @@ func TestAnthropicClient_Triage_NoTextContent(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no text content")
 }
+
+func TestAnthropicClient_Triage_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{truncated`))
+	}))
+	defer server.Close()
+
+	client := &AnthropicClient{
+		apiKey:   "test-key",
+		model:    "test",
+		endpoint: server.URL,
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 10 * time.Second},
+	}
+
+	_, err := client.Triage(context.Background(), testTriageRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse Anthropic response")
+}

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -46,15 +46,18 @@ func NewClient(ctx context.Context) (Client, error) {
 
 // NewClientWithConfig creates LLM client with explicit configuration
 func NewClientWithConfig(ctx context.Context, host, model string, timeout time.Duration, customContext string) (Client, error) {
-	// If host is specified, assume Ollama at that host
-	if host != "" {
-		if IsOllamaRunningAt(ctx, host) {
-			return NewOllamaClientWithConfig(host, model, timeout, customContext), nil
-		}
-		return nil, fmt.Errorf("ollama not reachable at %s", host)
+	// Resolve host from env var if not specified
+	if host == "" {
+		host = os.Getenv("OLLAMA_HOST")
 	}
-	// Fall back to existing env var logic
-	return NewClient(ctx)
+	if host == "" {
+		host = "http://localhost:11434"
+	}
+
+	if IsOllamaRunningAt(ctx, host) {
+		return NewOllamaClientWithConfig(host, model, timeout, customContext), nil
+	}
+	return nil, fmt.Errorf("ollama not reachable at %s", host)
 }
 
 // NewClientWithProvider creates an LLM client for the specified provider.

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -105,6 +105,20 @@ func formatPermissions(perms []roles.Permission) string {
 	return strings.Join(strs, ", ")
 }
 
+func getAttackerRoleName(role *roles.Role) string {
+	if role == nil {
+		return "(none)"
+	}
+	return role.Name
+}
+
+func getAttackerRolePermissions(role *roles.Role) string {
+	if role == nil {
+		return "(none)"
+	}
+	return formatPermissions(role.Permissions)
+}
+
 func getVictimRoleName(role *roles.Role) string {
 	if role == nil {
 		return "(none)"

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -57,6 +57,20 @@ func NewClientWithConfig(ctx context.Context, host, model string, timeout time.D
 	return NewClient(ctx)
 }
 
+// NewClientWithProvider creates an LLM client for the specified provider.
+func NewClientWithProvider(ctx context.Context, provider, host, model string, timeout time.Duration, customContext string) (Client, error) {
+	switch provider {
+	case "openai":
+		return NewOpenAIClient("", model, timeout, customContext)
+	case "anthropic":
+		return NewAnthropicClient("", model, timeout, customContext)
+	case "ollama", "":
+		return NewClientWithConfig(ctx, host, model, timeout, customContext)
+	default:
+		return nil, fmt.Errorf("unknown LLM provider %q (use ollama, openai, or anthropic)", provider)
+	}
+}
+
 // IsOllamaRunningAt checks if Ollama is reachable at the given URL
 func IsOllamaRunningAt(ctx context.Context, baseURL string) bool {
 	client := &http.Client{Timeout: 2 * time.Second}

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -196,6 +196,32 @@ func TestNewClientWithProvider_Anthropic(t *testing.T) {
 	assert.IsType(t, &AnthropicClient{}, client)
 }
 
+func TestNewClientWithProvider_Ollama(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/tags" {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithProvider(context.Background(), "ollama", server.URL, "", 60*time.Second, "")
+	require.NoError(t, err)
+	assert.Equal(t, "ollama", client.Name())
+}
+
+func TestNewClientWithProvider_EmptyDefaultsToOllama(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/tags" {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithProvider(context.Background(), "", server.URL, "", 60*time.Second, "")
+	require.NoError(t, err)
+	assert.Equal(t, "ollama", client.Name())
+}
+
 func TestNewClientWithProvider_Unknown(t *testing.T) {
 	_, err := NewClientWithProvider(context.Background(), "bogus", "", "", 60*time.Second, "")
 	require.Error(t, err)

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -180,3 +180,25 @@ func TestNewClientWithConfig_EmptyHostFallsBackToEnv(t *testing.T) {
 	assert.Nil(t, client)
 	assert.Contains(t, err.Error(), "no LLM provider available")
 }
+
+// TEST-002: NewClientWithProvider dispatch tests
+func TestNewClientWithProvider_OpenAI(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	client, err := NewClientWithProvider(context.Background(), "openai", "", "", 60*time.Second, "")
+	require.NoError(t, err)
+	assert.IsType(t, &OpenAIClient{}, client)
+}
+
+func TestNewClientWithProvider_Anthropic(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	client, err := NewClientWithProvider(context.Background(), "anthropic", "", "", 60*time.Second, "")
+	require.NoError(t, err)
+	assert.IsType(t, &AnthropicClient{}, client)
+}
+
+func TestNewClientWithProvider_Unknown(t *testing.T) {
+	_, err := NewClientWithProvider(context.Background(), "bogus", "", "", 60*time.Second, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown LLM provider")
+	assert.Contains(t, err.Error(), "bogus")
+}

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -165,20 +165,18 @@ func TestNewClientWithConfig_OllamaNotReachable(t *testing.T) {
 	assert.Contains(t, err.Error(), "not reachable")
 }
 
-func TestNewClientWithConfig_EmptyHostFallsBackToEnv(t *testing.T) {
-	// Arrange
+func TestNewClientWithConfig_EmptyHostFallsBackToDefault(t *testing.T) {
 	_ = os.Unsetenv("OLLAMA_HOST")
 
-	// Act
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
 	client, err := NewClientWithConfig(ctx, "", "", 180*time.Second, "")
 
-	// Assert - Should fall back to NewClient logic, which will fail with no env vars
+	// Should try localhost:11434 and fail because Ollama isn't running
 	assert.Error(t, err)
 	assert.Nil(t, client)
-	assert.Contains(t, err.Error(), "no LLM provider available")
+	assert.Contains(t, err.Error(), "not reachable")
 }
 
 // TEST-002: NewClientWithProvider dispatch tests

--- a/pkg/llm/ollama.go
+++ b/pkg/llm/ollama.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/praetorian-inc/hadrian/pkg/log"
-	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/reporter"
 )
 
@@ -74,10 +72,8 @@ func (o *OllamaClient) Name() string {
 }
 
 func (o *OllamaClient) Triage(ctx context.Context, req *TriageRequest) (*TriageResult, error) {
-	// Build prompt with PII redaction (PII redaction - mandatory)
-	prompt := o.buildPrompt(req)
+	prompt := BuildTriagePrompt(req, o.redactor, o.customContext)
 
-	// Prepare Ollama API request
 	ollamaReq := map[string]interface{}{
 		"model":  o.model,
 		"prompt": prompt,
@@ -90,7 +86,6 @@ func (o *OllamaClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Make HTTP POST to /api/generate
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/api/generate", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -104,129 +99,19 @@ func (o *OllamaClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		// Read error body with size limit (1MB for LLM responses)
-		bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, MaxLLMResponseBodySize))
-		if readErr != nil {
-			log.Warn("Failed to read Ollama error response body: %v", readErr)
-		}
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, MaxLLMResponseBodySize))
 		return nil, fmt.Errorf("ollama API returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
-	// Parse Ollama response
-	result, err := o.parseResponse(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse Ollama response: %w", err)
-	}
-
-	return result, nil
-}
-
-func (o *OllamaClient) buildPrompt(req *TriageRequest) string {
-	// CRITICAL: Redact PII from response before LLM (PII protection)
-	redactedResponse := o.redactor.RedactForLLM(req.Finding.Evidence.Response.Body)
-
-	// Add custom context section if provided
-	contextSection := ""
-	if o.customContext != "" {
-		contextSection = fmt.Sprintf("\nADDITIONAL CONTEXT:\n%s\n", o.customContext)
-	}
-
-	prompt := fmt.Sprintf(`You are a security expert analyzing API authorization.
-
-FINDING:
-- Category: %s
-- Operation: %s %s
-- Attacker Role: %s (permissions: %s)
-- Victim Role: %s (permissions: %s)
-
-REQUEST:
-%s %s
-Authorization: [REDACTED]
-
-RESPONSE (PII REDACTED):
-Status: %d
-Body: %s
-%s
-Think step-by-step:
-1. Could this be legitimate business logic? (e.g., public resource, shared data)
-2. Does the response contain sensitive data for this role?
-3. Are the roles truly unauthorized for this access?
-4. What is the potential impact if exploited?
-
-Respond with JSON only:
-{
-  "is_vulnerability": true/false,
-  "confidence": 0.0-1.0,
-  "reasoning": "your analysis",
-  "severity": "CRITICAL|HIGH|MEDIUM|LOW",
-  "recommendations": "specific mitigation guidance"
-}`,
-		req.Finding.Category,
-		req.Finding.Method,
-		req.Finding.Endpoint,
-		req.AttackerRole.Name,
-		formatPermissions(req.AttackerRole.Permissions),
-		getVictimRoleName(req.VictimRole),
-		getVictimRolePermissions(req.VictimRole),
-		req.Finding.Method,
-		req.Finding.Endpoint,
-		req.Finding.Evidence.Response.StatusCode,
-		redactedResponse, // ← REDACTED PII
-		contextSection,
-	)
-
-	return prompt
-}
-
-func (o *OllamaClient) parseResponse(body io.Reader) (*TriageResult, error) {
-	// Ollama response format:
-	// {
-	//   "model": "llama3.2:latest",
-	//   "response": "{\"is_vulnerability\": true, ...}",
-	//   "done": true
-	// }
+	// Ollama wraps the response in {"response": "<json string>"}
 	var ollamaResp struct {
-		Model    string `json:"model"`
 		Response string `json:"response"`
-		Done     bool   `json:"done"`
 	}
-
-	if err := json.NewDecoder(body).Decode(&ollamaResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, MaxLLMResponseBodySize)).Decode(&ollamaResp); err != nil {
 		return nil, fmt.Errorf("failed to decode Ollama response: %w", err)
 	}
 
-	// Parse the inner response JSON with flexible field types
-	var triageData struct {
-		IsVulnerability bool            `json:"is_vulnerability"`
-		Confidence      float64         `json:"confidence"`
-		Reasoning       json.RawMessage `json:"reasoning"`
-		Severity        string          `json:"severity"`
-		Recommendations json.RawMessage `json:"recommendations"`
-	}
-
-	if err := json.Unmarshal([]byte(ollamaResp.Response), &triageData); err != nil {
-		return nil, fmt.Errorf("failed to parse LLM JSON response: %w", err)
-	}
-
-	// Handle reasoning field - can be string or array
-	reasoning := parseStringOrArray(triageData.Reasoning)
-
-	// Handle recommendations field - can be string or array
-	recommendations := parseStringOrArray(triageData.Recommendations)
-
-	// Map severity string to model.Severity
-	severity := o.mapSeverity(triageData.Severity)
-
-	result := &TriageResult{
-		Provider:        "ollama",
-		IsVulnerability: triageData.IsVulnerability,
-		Confidence:      triageData.Confidence,
-		Reasoning:       reasoning,
-		Severity:        severity,
-		Recommendations: recommendations,
-	}
-
-	return result, nil
+	return ParseTriageJSON(ollamaResp.Response, "ollama")
 }
 
 // parseStringOrArray handles JSON fields that can be either string or []string
@@ -235,33 +120,15 @@ func parseStringOrArray(raw json.RawMessage) string {
 		return ""
 	}
 
-	// Try parsing as string first
 	var str string
 	if err := json.Unmarshal(raw, &str); err == nil {
 		return str
 	}
 
-	// Try parsing as array
 	var arr []string
 	if err := json.Unmarshal(raw, &arr); err == nil {
 		return strings.Join(arr, "; ")
 	}
 
-	// If both fail, return empty string
 	return ""
-}
-
-func (o *OllamaClient) mapSeverity(s string) model.Severity {
-	switch strings.ToUpper(s) {
-	case "CRITICAL":
-		return model.SeverityCritical
-	case "HIGH":
-		return model.SeverityHigh
-	case "MEDIUM":
-		return model.SeverityMedium
-	case "LOW":
-		return model.SeverityLow
-	default:
-		return model.SeverityMedium // Default fallback
-	}
 }

--- a/pkg/llm/ollama_test.go
+++ b/pkg/llm/ollama_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -234,7 +233,7 @@ func TestOllamaClient_BuildPrompt(t *testing.T) {
 	}
 
 	// Act
-	prompt := client.buildPrompt(req)
+	prompt := BuildTriagePrompt(req, client.redactor, client.customContext)
 
 	// Assert - Verify structure
 	assert.Contains(t, prompt, "You are a security expert")
@@ -251,9 +250,7 @@ func TestOllamaClient_BuildPrompt(t *testing.T) {
 	assert.NotContains(t, prompt, "123-45-6789")
 }
 
-func TestOllamaClient_MapSeverity(t *testing.T) {
-	client := NewOllamaClient()
-
+func TestMapSeverity(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -273,24 +270,20 @@ func TestOllamaClient_MapSeverity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := client.mapSeverity(tt.input)
+			result := mapSeverity(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestOllamaClient_ParseResponse_InvalidOllamaJSON(t *testing.T) {
-	// Arrange
-	client := NewOllamaClient()
+func TestParseTriageJSON_InvalidJSON(t *testing.T) {
 	invalidJSON := `{invalid json`
 
-	// Act
-	result, err := client.parseResponse(strings.NewReader(invalidJSON))
+	result, err := ParseTriageJSON(invalidJSON, "test")
 
-	// Assert
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to decode Ollama response")
+	assert.Contains(t, err.Error(), "failed to parse LLM JSON response")
 }
 
 func TestParseStringOrArray(t *testing.T) {

--- a/pkg/llm/openai.go
+++ b/pkg/llm/openai.go
@@ -47,6 +47,7 @@ func NewOpenAIClient(apiKey, model string, timeout time.Duration, customContext 
 		client: &http.Client{
 			Timeout: timeout,
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 				DialContext:     (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
 			},
@@ -68,8 +69,9 @@ func (c *OpenAIClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 			{"role": "system", "content": "You are a security expert. Respond with valid JSON only."},
 			{"role": "user", "content": prompt},
 		},
-		"temperature":     0.2,
-		"response_format": map[string]string{"type": "json_object"},
+		"temperature":           0.2,
+		"max_completion_tokens": 4096,
+		"response_format":       map[string]string{"type": "json_object"},
 	}
 
 	body, err := json.Marshal(reqBody)
@@ -104,6 +106,7 @@ func (c *OpenAIClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 			Message struct {
 				Content string `json:"content"`
 			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
 		} `json:"choices"`
 	}
 
@@ -113,6 +116,10 @@ func (c *OpenAIClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 
 	if len(result.Choices) == 0 {
 		return nil, fmt.Errorf("OpenAI returned no choices") //nolint:staticcheck // proper noun
+	}
+
+	if fr := result.Choices[0].FinishReason; fr == "length" || fr == "content_filter" {
+		return nil, fmt.Errorf("OpenAI response incomplete (finish_reason=%s)", fr) //nolint:staticcheck // proper noun
 	}
 
 	return ParseTriageJSON(result.Choices[0].Message.Content, "openai")

--- a/pkg/llm/openai.go
+++ b/pkg/llm/openai.go
@@ -76,7 +76,7 @@ func (c *OpenAIClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("OpenAI API call failed: %w", err)
+		return nil, fmt.Errorf("OpenAI API call failed: %w", err) //nolint:staticcheck // proper noun
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -86,7 +86,7 @@ func (c *OpenAIClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("OpenAI API returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("OpenAI API returned status %d: %.500s", resp.StatusCode, string(respBody)) //nolint:staticcheck // proper noun
 	}
 
 	var result struct {
@@ -102,7 +102,7 @@ func (c *OpenAIClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 	}
 
 	if len(result.Choices) == 0 {
-		return nil, fmt.Errorf("OpenAI returned no choices")
+		return nil, fmt.Errorf("OpenAI returned no choices") //nolint:staticcheck // proper noun
 	}
 
 	return ParseTriageJSON(result.Choices[0].Message.Content, "openai")

--- a/pkg/llm/openai.go
+++ b/pkg/llm/openai.go
@@ -16,7 +16,6 @@ import (
 )
 
 // OpenAIClient implements Client using the OpenAI chat completions API.
-// OpenAIClient implements Client using the OpenAI chat completions API.
 type OpenAIClient struct {
 	apiKey        string
 	model         string

--- a/pkg/llm/openai.go
+++ b/pkg/llm/openai.go
@@ -1,0 +1,109 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/praetorian-inc/hadrian/pkg/reporter"
+)
+
+// OpenAIClient implements Client using the OpenAI chat completions API.
+type OpenAIClient struct {
+	apiKey        string
+	model         string
+	redactor      *reporter.Redactor
+	client        *http.Client
+	customContext string
+}
+
+// NewOpenAIClient creates an OpenAI triage client.
+func NewOpenAIClient(apiKey, model string, timeout time.Duration, customContext string) (*OpenAIClient, error) {
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("OPENAI_API_KEY not set")
+	}
+	if model == "" {
+		model = "gpt-4o"
+	}
+	if timeout == 0 {
+		timeout = 120 * time.Second
+	}
+	return &OpenAIClient{
+		apiKey:        apiKey,
+		model:         model,
+		redactor:      reporter.NewRedactor(),
+		client:        &http.Client{Timeout: timeout},
+		customContext: customContext,
+	}, nil
+}
+
+func (c *OpenAIClient) Name() string {
+	return "openai"
+}
+
+func (c *OpenAIClient) Triage(ctx context.Context, req *TriageRequest) (*TriageResult, error) {
+	prompt := BuildTriagePrompt(req, c.redactor, c.customContext)
+
+	reqBody := map[string]interface{}{
+		"model": c.model,
+		"messages": []map[string]string{
+			{"role": "system", "content": "You are a security expert. Respond with valid JSON only."},
+			{"role": "user", "content": prompt},
+		},
+		"temperature":     0.2,
+		"response_format": map[string]string{"type": "json_object"},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("OpenAI API call failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, MaxLLMResponseBodySize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OpenAI API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse OpenAI response: %w", err)
+	}
+
+	if len(result.Choices) == 0 {
+		return nil, fmt.Errorf("OpenAI returned no choices")
+	}
+
+	return ParseTriageJSON(result.Choices[0].Message.Content, "openai")
+}

--- a/pkg/llm/openai.go
+++ b/pkg/llm/openai.go
@@ -3,9 +3,11 @@ package llm
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -14,9 +16,11 @@ import (
 )
 
 // OpenAIClient implements Client using the OpenAI chat completions API.
+// OpenAIClient implements Client using the OpenAI chat completions API.
 type OpenAIClient struct {
 	apiKey        string
 	model         string
+	endpoint      string // defaults to "https://api.openai.com/v1/chat/completions"
 	redactor      *reporter.Redactor
 	client        *http.Client
 	customContext string
@@ -37,10 +41,17 @@ func NewOpenAIClient(apiKey, model string, timeout time.Duration, customContext 
 		timeout = 120 * time.Second
 	}
 	return &OpenAIClient{
-		apiKey:        apiKey,
-		model:         model,
-		redactor:      reporter.NewRedactor(),
-		client:        &http.Client{Timeout: timeout},
+		apiKey:   apiKey,
+		model:    model,
+		endpoint: "https://api.openai.com/v1/chat/completions",
+		redactor: reporter.NewRedactor(),
+		client: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+				DialContext:     (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			},
+		},
 		customContext: customContext,
 	}, nil
 }
@@ -67,7 +78,7 @@ func (c *OpenAIClient) Triage(ctx context.Context, req *TriageRequest) (*TriageR
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/pkg/llm/openai_test.go
+++ b/pkg/llm/openai_test.go
@@ -2,7 +2,9 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -33,31 +35,94 @@ func TestNewOpenAIClient_UsesEnvKey(t *testing.T) {
 	assert.Equal(t, "gpt-4o", client.model)
 }
 
-func TestNewOpenAIClient_DefaultTimeout(t *testing.T) {
-	t.Setenv("OPENAI_API_KEY", "sk-test")
-	client, err := NewOpenAIClient("", "", 0, "")
-	require.NoError(t, err)
-	assert.Equal(t, 120*time.Second, client.client.Timeout)
-}
+func TestOpenAIClient_Triage_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
 
-func TestOpenAIClient_Triage_ConnectionError(t *testing.T) {
+		var req map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "gpt-4o", req["model"])
+		assert.Equal(t, 0.2, req["temperature"])
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{
+					"content": `{"is_vulnerability":true,"confidence":0.9,"reasoning":"BOLA","severity":"HIGH","recommendations":"Fix it"}`,
+				}},
+			},
+		}))
+	}))
+	defer server.Close()
+
 	client := &OpenAIClient{
 		apiKey:   "test-key",
 		model:    "gpt-4o",
+		endpoint: server.URL,
 		redactor: reporter.NewRedactor(),
-		client:   &http.Client{Timeout: 1 * time.Second},
+		client:   &http.Client{Timeout: 10 * time.Second},
 	}
 
-	finding := &model.Finding{
-		Category: "API1", Method: "GET", Endpoint: "/test",
-		Evidence: model.Evidence{Response: model.HTTPResponse{StatusCode: 200, Body: "test"}},
-	}
-	req := &TriageRequest{
-		Finding:      finding,
-		AttackerRole: &roles.Role{Name: "user"},
-		VictimRole:   &roles.Role{Name: "admin"},
+	result, err := client.Triage(context.Background(), testTriageRequest())
+	require.NoError(t, err)
+	assert.True(t, result.IsVulnerability)
+	assert.Equal(t, 0.9, result.Confidence)
+	assert.Equal(t, "openai", result.Provider)
+	assert.Equal(t, model.SeverityHigh, result.Severity)
+}
+
+func TestOpenAIClient_Triage_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(429)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		apiKey:   "test-key",
+		model:    "gpt-4o",
+		endpoint: server.URL,
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 10 * time.Second},
 	}
 
-	_, err := client.Triage(context.Background(), req)
-	assert.Error(t, err)
+	_, err := client.Triage(context.Background(), testTriageRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "429")
+}
+
+func TestOpenAIClient_Triage_ParseError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "not json"}},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		apiKey:   "test-key",
+		model:    "gpt-4o",
+		endpoint: server.URL,
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 10 * time.Second},
+	}
+
+	_, err := client.Triage(context.Background(), testTriageRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse LLM JSON response")
+}
+
+func testTriageRequest() *TriageRequest {
+	return &TriageRequest{
+		Finding: &model.Finding{
+			Category: "API1", Method: "GET", Endpoint: "/api/test",
+			Evidence: model.Evidence{Response: model.HTTPResponse{StatusCode: 200, Body: "test"}},
+		},
+		AttackerRole: &roles.Role{Name: "user", Permissions: []roles.Permission{{Raw: "read:users:own"}}},
+		VictimRole:   &roles.Role{Name: "admin", Permissions: []roles.Permission{{Raw: "*:*:*"}}},
+	}
 }

--- a/pkg/llm/openai_test.go
+++ b/pkg/llm/openai_test.go
@@ -1,0 +1,63 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/reporter"
+	"github.com/praetorian-inc/hadrian/pkg/roles"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIClient_Name(t *testing.T) {
+	client := &OpenAIClient{}
+	assert.Equal(t, "openai", client.Name())
+}
+
+func TestNewOpenAIClient_RequiresAPIKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	_, err := NewOpenAIClient("", "gpt-4o", 120*time.Second, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "OPENAI_API_KEY not set")
+}
+
+func TestNewOpenAIClient_UsesEnvKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test-123")
+	client, err := NewOpenAIClient("", "", 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-123", client.apiKey)
+	assert.Equal(t, "gpt-4o", client.model)
+}
+
+func TestNewOpenAIClient_DefaultTimeout(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	client, err := NewOpenAIClient("", "", 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, 120*time.Second, client.client.Timeout)
+}
+
+func TestOpenAIClient_Triage_ConnectionError(t *testing.T) {
+	client := &OpenAIClient{
+		apiKey:   "test-key",
+		model:    "gpt-4o",
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 1 * time.Second},
+	}
+
+	finding := &model.Finding{
+		Category: "API1", Method: "GET", Endpoint: "/test",
+		Evidence: model.Evidence{Response: model.HTTPResponse{StatusCode: 200, Body: "test"}},
+	}
+	req := &TriageRequest{
+		Finding:      finding,
+		AttackerRole: &roles.Role{Name: "user"},
+		VictimRole:   &roles.Role{Name: "admin"},
+	}
+
+	_, err := client.Triage(context.Background(), req)
+	assert.Error(t, err)
+}

--- a/pkg/llm/openai_test.go
+++ b/pkg/llm/openai_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/reporter"
-	"github.com/praetorian-inc/hadrian/pkg/roles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -116,13 +115,24 @@ func TestOpenAIClient_Triage_ParseError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse LLM JSON response")
 }
 
-func testTriageRequest() *TriageRequest {
-	return &TriageRequest{
-		Finding: &model.Finding{
-			Category: "API1", Method: "GET", Endpoint: "/api/test",
-			Evidence: model.Evidence{Response: model.HTTPResponse{StatusCode: 200, Body: "test"}},
-		},
-		AttackerRole: &roles.Role{Name: "user", Permissions: []roles.Permission{{Raw: "read:users:own"}}},
-		VictimRole:   &roles.Role{Name: "admin", Permissions: []roles.Permission{{Raw: "*:*:*"}}},
+func TestOpenAIClient_Triage_EmptyChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{},
+		}))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		apiKey:   "test-key",
+		model:    "gpt-4o",
+		endpoint: server.URL,
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 10 * time.Second},
 	}
+
+	_, err := client.Triage(context.Background(), testTriageRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no choices")
 }

--- a/pkg/llm/openai_test.go
+++ b/pkg/llm/openai_test.go
@@ -136,3 +136,23 @@ func TestOpenAIClient_Triage_EmptyChoices(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no choices")
 }
+
+func TestOpenAIClient_Triage_MalformedEnvelope(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{truncated`))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		apiKey:   "test-key",
+		model:    "gpt-4o",
+		endpoint: server.URL,
+		redactor: reporter.NewRedactor(),
+		client:   &http.Client{Timeout: 10 * time.Second},
+	}
+
+	_, err := client.Triage(context.Background(), testTriageRequest())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse OpenAI response")
+}

--- a/pkg/llm/prompt.go
+++ b/pkg/llm/prompt.go
@@ -1,0 +1,103 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/reporter"
+)
+
+// BuildTriagePrompt constructs the triage prompt with PII redaction.
+func BuildTriagePrompt(req *TriageRequest, redactor *reporter.Redactor, customContext string) string {
+	redactedResponse := redactor.RedactForLLM(req.Finding.Evidence.Response.Body)
+
+	contextSection := ""
+	if customContext != "" {
+		contextSection = fmt.Sprintf("\nADDITIONAL CONTEXT:\n%s\n", customContext)
+	}
+
+	return fmt.Sprintf(`You are a security expert analyzing API authorization.
+
+FINDING:
+- Category: %s
+- Operation: %s %s
+- Attacker Role: %s (permissions: %s)
+- Victim Role: %s (permissions: %s)
+
+REQUEST:
+%s %s
+Authorization: [REDACTED]
+
+RESPONSE (PII REDACTED):
+Status: %d
+Body: %s
+%s
+Think step-by-step:
+1. Could this be legitimate business logic? (e.g., public resource, shared data)
+2. Does the response contain sensitive data for this role?
+3. Are the roles truly unauthorized for this access?
+4. What is the potential impact if exploited?
+
+Respond with JSON only:
+{
+  "is_vulnerability": true/false,
+  "confidence": 0.0-1.0,
+  "reasoning": "your analysis",
+  "severity": "CRITICAL|HIGH|MEDIUM|LOW",
+  "recommendations": "specific mitigation guidance"
+}`,
+		req.Finding.Category,
+		req.Finding.Method,
+		req.Finding.Endpoint,
+		req.AttackerRole.Name,
+		formatPermissions(req.AttackerRole.Permissions),
+		getVictimRoleName(req.VictimRole),
+		getVictimRolePermissions(req.VictimRole),
+		req.Finding.Method,
+		req.Finding.Endpoint,
+		req.Finding.Evidence.Response.StatusCode,
+		redactedResponse,
+		contextSection,
+	)
+}
+
+// ParseTriageJSON parses the raw JSON string from any LLM into a TriageResult.
+func ParseTriageJSON(raw string, provider string) (*TriageResult, error) {
+	var triageData struct {
+		IsVulnerability bool            `json:"is_vulnerability"`
+		Confidence      float64         `json:"confidence"`
+		Reasoning       json.RawMessage `json:"reasoning"`
+		Severity        string          `json:"severity"`
+		Recommendations json.RawMessage `json:"recommendations"`
+	}
+
+	if err := json.Unmarshal([]byte(raw), &triageData); err != nil {
+		return nil, fmt.Errorf("failed to parse LLM JSON response: %w", err)
+	}
+
+	return &TriageResult{
+		Provider:        provider,
+		IsVulnerability: triageData.IsVulnerability,
+		Confidence:      triageData.Confidence,
+		Reasoning:       parseStringOrArray(triageData.Reasoning),
+		Severity:        mapSeverity(triageData.Severity),
+		Recommendations: parseStringOrArray(triageData.Recommendations),
+	}, nil
+}
+
+func mapSeverity(s string) model.Severity {
+	switch strings.ToUpper(s) {
+	case "CRITICAL":
+		return model.SeverityCritical
+	case "HIGH":
+		return model.SeverityHigh
+	case "MEDIUM":
+		return model.SeverityMedium
+	case "LOW":
+		return model.SeverityLow
+	default:
+		return model.SeverityMedium
+	}
+}

--- a/pkg/llm/prompt.go
+++ b/pkg/llm/prompt.go
@@ -67,7 +67,16 @@ Respond with JSON only:
 }
 
 // ParseTriageJSON parses the raw JSON string from any LLM into a TriageResult.
+// Handles markdown code fences that Claude commonly wraps around JSON responses.
 func ParseTriageJSON(raw string, provider string) (*TriageResult, error) {
+	// Extract JSON object from potential markdown fences or surrounding text.
+	// Claude routinely wraps responses in ```json ... ``` despite system prompt instructions.
+	if start := strings.Index(raw, "{"); start >= 0 {
+		if end := strings.LastIndex(raw, "}"); end > start {
+			raw = raw[start : end+1]
+		}
+	}
+
 	var triageData struct {
 		IsVulnerability bool            `json:"is_vulnerability"`
 		Confidence      float64         `json:"confidence"`

--- a/pkg/llm/prompt.go
+++ b/pkg/llm/prompt.go
@@ -10,6 +10,9 @@ import (
 )
 
 // BuildTriagePrompt constructs the triage prompt with PII redaction.
+// Note: Finding fields (category, endpoint, response body) are interpolated into the prompt.
+// A malicious target API could craft responses to influence triage results. Impact is limited
+// since triage is advisory and PII redaction is applied.
 func BuildTriagePrompt(req *TriageRequest, redactor *reporter.Redactor, customContext string) string {
 	redactedResponse := redactor.RedactForLLM(req.Finding.Evidence.Response.Body)
 
@@ -51,8 +54,8 @@ Respond with JSON only:
 		req.Finding.Category,
 		req.Finding.Method,
 		req.Finding.Endpoint,
-		req.AttackerRole.Name,
-		formatPermissions(req.AttackerRole.Permissions),
+		getAttackerRoleName(req.AttackerRole),
+		getAttackerRolePermissions(req.AttackerRole),
 		getVictimRoleName(req.VictimRole),
 		getVictimRolePermissions(req.VictimRole),
 		req.Finding.Method,

--- a/pkg/llm/prompt_test.go
+++ b/pkg/llm/prompt_test.go
@@ -66,3 +66,28 @@ func TestParseTriageJSON_MalformedJSON(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "failed to parse LLM JSON response"))
 }
+
+func TestParseTriageJSON_MarkdownFenced(t *testing.T) {
+	raw := "```json\n{\"is_vulnerability\":true,\"confidence\":0.9,\"reasoning\":\"BOLA detected\",\"severity\":\"HIGH\",\"recommendations\":\"Fix it\"}\n```"
+	result, err := ParseTriageJSON(raw, "anthropic")
+	require.NoError(t, err)
+	assert.True(t, result.IsVulnerability)
+	assert.Equal(t, 0.9, result.Confidence)
+	assert.Equal(t, model.SeverityHigh, result.Severity)
+}
+
+func TestParseTriageJSON_FencedWithPreamble(t *testing.T) {
+	raw := "Here is my analysis:\n\n```json\n{\"is_vulnerability\":false,\"confidence\":0.3,\"reasoning\":\"Looks fine\",\"severity\":\"LOW\",\"recommendations\":\"None\"}\n```\n\nHope this helps!"
+	result, err := ParseTriageJSON(raw, "anthropic")
+	require.NoError(t, err)
+	assert.False(t, result.IsVulnerability)
+	assert.Equal(t, model.SeverityLow, result.Severity)
+}
+
+func TestParseTriageJSON_RawJSON(t *testing.T) {
+	// Already-clean JSON should still work
+	raw := `{"is_vulnerability":true,"confidence":0.8,"reasoning":"test","severity":"MEDIUM","recommendations":"do this"}`
+	result, err := ParseTriageJSON(raw, "openai")
+	require.NoError(t, err)
+	assert.True(t, result.IsVulnerability)
+}

--- a/pkg/llm/prompt_test.go
+++ b/pkg/llm/prompt_test.go
@@ -1,0 +1,68 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/reporter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTriagePrompt_ContainsFields(t *testing.T) {
+	prompt := BuildTriagePrompt(testTriageRequest(), reporter.NewRedactor(), "")
+	assert.Contains(t, prompt, "API1")
+	assert.Contains(t, prompt, "GET /api/test")
+	assert.Contains(t, prompt, "user")
+	assert.Contains(t, prompt, "admin")
+}
+
+func TestBuildTriagePrompt_CustomContext(t *testing.T) {
+	prompt := BuildTriagePrompt(testTriageRequest(), reporter.NewRedactor(), "This is PCI data")
+	assert.Contains(t, prompt, "ADDITIONAL CONTEXT:")
+	assert.Contains(t, prompt, "This is PCI data")
+}
+
+func TestBuildTriagePrompt_EmptyContext(t *testing.T) {
+	prompt := BuildTriagePrompt(testTriageRequest(), reporter.NewRedactor(), "")
+	assert.NotContains(t, prompt, "ADDITIONAL CONTEXT:")
+}
+
+func TestParseTriageJSON_HappyPath(t *testing.T) {
+	raw := `{"is_vulnerability":true,"confidence":0.9,"reasoning":"BOLA","severity":"HIGH","recommendations":"Fix it"}`
+	result, err := ParseTriageJSON(raw, "test")
+	require.NoError(t, err)
+	assert.True(t, result.IsVulnerability)
+	assert.Equal(t, 0.9, result.Confidence)
+	assert.Equal(t, "BOLA", result.Reasoning)
+	assert.Equal(t, model.SeverityHigh, result.Severity)
+	assert.Equal(t, "test", result.Provider)
+}
+
+func TestParseTriageJSON_ReasoningAsArray(t *testing.T) {
+	raw := `{"is_vulnerability":true,"confidence":0.8,"reasoning":["step1","step2"],"severity":"MEDIUM","recommendations":"do this"}`
+	result, err := ParseTriageJSON(raw, "test")
+	require.NoError(t, err)
+	assert.Equal(t, "step1; step2", result.Reasoning)
+}
+
+func TestParseTriageJSON_RecommendationsAsArray(t *testing.T) {
+	raw := `{"is_vulnerability":false,"confidence":0.5,"reasoning":"ok","severity":"LOW","recommendations":["a","b"]}`
+	result, err := ParseTriageJSON(raw, "test")
+	require.NoError(t, err)
+	assert.Equal(t, "a; b", result.Recommendations)
+}
+
+func TestParseTriageJSON_UnknownSeverity(t *testing.T) {
+	raw := `{"is_vulnerability":true,"confidence":0.5,"reasoning":"x","severity":"UNKNOWN","recommendations":"y"}`
+	result, err := ParseTriageJSON(raw, "test")
+	require.NoError(t, err)
+	assert.Equal(t, model.SeverityMedium, result.Severity) // default fallback
+}
+
+func TestParseTriageJSON_MalformedJSON(t *testing.T) {
+	_, err := ParseTriageJSON(`{not json}`, "test")
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "failed to parse LLM JSON response"))
+}

--- a/pkg/llm/testhelpers_test.go
+++ b/pkg/llm/testhelpers_test.go
@@ -1,0 +1,18 @@
+package llm
+
+import (
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/roles"
+)
+
+// testTriageRequest returns a minimal TriageRequest for testing.
+func testTriageRequest() *TriageRequest {
+	return &TriageRequest{
+		Finding: &model.Finding{
+			Category: "API1", Method: "GET", Endpoint: "/api/test",
+			Evidence: model.Evidence{Response: model.HTTPResponse{StatusCode: 200, Body: "test"}},
+		},
+		AttackerRole: &roles.Role{Name: "user", Permissions: []roles.Permission{{Raw: "read:users:own"}}},
+		VictimRole:   &roles.Role{Name: "admin", Permissions: []roles.Permission{{Raw: "*:*:*"}}},
+	}
+}

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -66,10 +66,11 @@ type GraphQLConfig struct {
 	SkipBuiltinChecks bool     // Skip built-in security checks (introspection, depth limit, batching)
 
 	// LLM triage (optional)
-	LLMHost    string   // LLM service host
-	LLMModel   string   // LLM model name
-	LLMTimeout int      // LLM request timeout (seconds)
-	LLMContext string   // Additional context for LLM
+	LLMProvider string // LLM provider: ollama, openai, anthropic
+	LLMHost     string // LLM service host
+	LLMModel    string // LLM model name
+	LLMTimeout  int    // LLM request timeout (seconds)
+	LLMContext  string // Additional context for LLM
 	Headers    []string // Custom HTTP headers (format: "Key: Value")
 }
 
@@ -131,6 +132,7 @@ func newTestGraphQLCmd() *cobra.Command {
 	cmd.Flags().IntSliceVar(&config.RateLimitStatusCodes, "rate-limit-status-codes", []int{429, 503}, "HTTP status codes that trigger rate limiting")
 
 	// LLM triage (optional)
+	cmd.Flags().StringVar(&config.LLMProvider, "llm-provider", "ollama", "LLM provider for triage: ollama, openai, anthropic")
 	cmd.Flags().StringVar(&config.LLMHost, "llm-host", "", "LLM service host for finding triage")
 	cmd.Flags().StringVar(&config.LLMModel, "llm-model", "", "LLM model name for triage")
 	cmd.Flags().IntVar(&config.LLMTimeout, "llm-timeout", 30, "LLM request timeout (seconds)")
@@ -253,11 +255,11 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 	}
 
 	// LLM triage if configured
-	if config.LLMHost != "" || config.LLMModel != "" {
+	if config.LLMProvider != "" || config.LLMHost != "" || config.LLMModel != "" {
 		if rolesConfig != nil {
 			graphqlVerboseLog(config.Verbose, "Running LLM triage on %d findings", len(modelFindings))
 			modelFindings, err = triageWithLLM(ctx, modelFindings, rolesConfig,
-				config.LLMHost, config.LLMModel, config.LLMTimeout, config.LLMContext, reporter)
+				config.LLMProvider, config.LLMHost, config.LLMModel, config.LLMTimeout, config.LLMContext, nil, reporter)
 			if err != nil {
 				// LLM is optional - continue without it
 				graphqlVerboseLog(config.Verbose, "LLM triage failed: %v", err)

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -247,15 +247,18 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 	endpoint := config.Target + config.Endpoint
 	modelFindings, templatesLoaded := runSecurityChecks(ctx, schema, rateLimitedClient, endpoint, config, authConfigs, reporter, customHeaders)
 
+	// Compute unified LLM-enabled flag (same logic as REST command)
+	graphqlLLMEnabled := hasLLMConfig() || (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMHost != "" || config.LLMModel != ""
+
 	// Only report findings if not already reported via callback (non-verbose mode)
-	if config.Output == "terminal" && config.LLMHost == "" && !config.Verbose {
+	if config.Output == "terminal" && !graphqlLLMEnabled && !config.Verbose {
 		for _, finding := range modelFindings {
 			reporter.ReportFinding(finding)
 		}
 	}
 
-	// LLM triage if configured (exclude default "ollama" when no host is set)
-	if (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMHost != "" || config.LLMModel != "" {
+	// LLM triage if configured
+	if graphqlLLMEnabled {
 		if rolesConfig != nil {
 			graphqlVerboseLog(config.Verbose, "Running LLM triage on %d findings", len(modelFindings))
 			modelFindings, err = triageWithLLM(ctx, modelFindings, rolesConfig,

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -66,12 +66,12 @@ type GraphQLConfig struct {
 	SkipBuiltinChecks bool     // Skip built-in security checks (introspection, depth limit, batching)
 
 	// LLM triage (optional)
-	LLMProvider string // LLM provider: ollama, openai, anthropic
-	LLMHost     string // LLM service host
-	LLMModel    string // LLM model name
-	LLMTimeout  int    // LLM request timeout (seconds)
-	LLMContext  string // Additional context for LLM
-	Headers    []string // Custom HTTP headers (format: "Key: Value")
+	LLMProvider string   // LLM provider: ollama, openai, anthropic
+	LLMHost     string   // LLM service host
+	LLMModel    string   // LLM model name
+	LLMTimeout  int      // LLM request timeout (seconds)
+	LLMContext  string   // Additional context for LLM
+	Headers     []string // Custom HTTP headers (format: "Key: Value")
 }
 
 // newTestGraphQLCmd creates the "test graphql" subcommand
@@ -135,7 +135,7 @@ func newTestGraphQLCmd() *cobra.Command {
 	cmd.Flags().StringVar(&config.LLMProvider, "llm-provider", "ollama", "LLM provider for triage: ollama, openai, anthropic")
 	cmd.Flags().StringVar(&config.LLMHost, "llm-host", "", "LLM service host for finding triage")
 	cmd.Flags().StringVar(&config.LLMModel, "llm-model", "", "LLM model name for triage")
-	cmd.Flags().IntVar(&config.LLMTimeout, "llm-timeout", 30, "LLM request timeout (seconds)")
+	cmd.Flags().IntVar(&config.LLMTimeout, "llm-timeout", 180, "LLM request timeout (seconds)")
 	cmd.Flags().StringVar(&config.LLMContext, "llm-context", "", "Additional context for LLM triage")
 
 	// Custom headers
@@ -254,8 +254,8 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 		}
 	}
 
-	// LLM triage if configured
-	if config.LLMProvider != "" || config.LLMHost != "" || config.LLMModel != "" {
+	// LLM triage if configured (exclude default "ollama" when no host is set)
+	if (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMHost != "" || config.LLMModel != "" {
 		if rolesConfig != nil {
 			graphqlVerboseLog(config.Verbose, "Running LLM triage on %d findings", len(modelFindings))
 			modelFindings, err = triageWithLLM(ctx, modelFindings, rolesConfig,

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/praetorian-inc/hadrian/pkg/auth"
+	"github.com/praetorian-inc/hadrian/pkg/llm"
 	"github.com/praetorian-inc/hadrian/pkg/log"
 	"github.com/praetorian-inc/hadrian/pkg/roles"
 	"github.com/praetorian-inc/hadrian/pkg/templates"
@@ -66,12 +67,13 @@ type GraphQLConfig struct {
 	SkipBuiltinChecks bool     // Skip built-in security checks (introspection, depth limit, batching)
 
 	// LLM triage (optional)
-	LLMProvider string   // LLM provider: ollama, openai, anthropic
-	LLMHost     string   // LLM service host
-	LLMModel    string   // LLM model name
-	LLMTimeout  int      // LLM request timeout (seconds)
-	LLMContext  string   // Additional context for LLM
-	Headers     []string // Custom HTTP headers (format: "Key: Value")
+	LLMProvider     string     // LLM provider: ollama, openai, anthropic
+	LLMHost         string     // LLM service host
+	LLMModel        string     // LLM model name
+	LLMTimeout      int        // LLM request timeout (seconds)
+	LLMContext      string     // Additional context for LLM
+	LLMTriageClient llm.Client // Optional: platform-injected LLM client for triage
+	Headers         []string   // Custom HTTP headers (format: "Key: Value")
 }
 
 // newTestGraphQLCmd creates the "test graphql" subcommand
@@ -248,7 +250,7 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 	modelFindings, templatesLoaded := runSecurityChecks(ctx, schema, rateLimitedClient, endpoint, config, authConfigs, reporter, customHeaders)
 
 	// Compute unified LLM-enabled flag (same logic as REST command)
-	graphqlLLMEnabled := hasLLMConfig() || (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMHost != "" || config.LLMModel != ""
+	graphqlLLMEnabled := hasLLMConfig() || (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMHost != "" || config.LLMModel != "" || config.LLMTriageClient != nil
 
 	// Only report findings if not already reported via callback (non-verbose mode)
 	if config.Output == "terminal" && !graphqlLLMEnabled && !config.Verbose {
@@ -262,7 +264,7 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 		if rolesConfig != nil {
 			graphqlVerboseLog(config.Verbose, "Running LLM triage on %d findings", len(modelFindings))
 			modelFindings, err = triageWithLLM(ctx, modelFindings, rolesConfig,
-				config.LLMProvider, config.LLMHost, config.LLMModel, config.LLMTimeout, config.LLMContext, nil, reporter)
+				config.LLMProvider, config.LLMHost, config.LLMModel, config.LLMTimeout, config.LLMContext, config.LLMTriageClient, reporter)
 			if err != nil {
 				// LLM is optional - continue without it
 				graphqlVerboseLog(config.Verbose, "LLM triage failed: %v", err)

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -92,20 +92,26 @@ func createReporter(format, outputFile string, requestIDsLimit int) (Reporter, e
 }
 
 // triageWithLLM runs LLM triage on findings and reports each finding immediately after analysis
-func triageWithLLM(ctx context.Context, findings []*model.Finding, rolesCfg *roles.RoleConfig, llmHost, llmModel string, llmTimeout int, llmContext string, rep Reporter) ([]*model.Finding, error) {
+func triageWithLLM(ctx context.Context, findings []*model.Finding, rolesCfg *roles.RoleConfig, llmProvider, llmHost, llmModel string, llmTimeout int, llmContext string, injectedClient llm.Client, rep Reporter) ([]*model.Finding, error) {
 	log.Debug("Starting LLM triage for %d findings", len(findings))
 
 	var client llm.Client
 	var err error
 
-	// Convert timeout from seconds to time.Duration
-	timeout := time.Duration(llmTimeout) * time.Second
-
-	// Use explicit config if provided, otherwise fall back to env vars
-	if llmHost != "" || llmModel != "" {
-		client, err = llm.NewClientWithConfig(ctx, llmHost, llmModel, timeout, llmContext)
+	if injectedClient != nil {
+		client = injectedClient
 	} else {
-		client, err = llm.NewClient(ctx)
+		// Convert timeout from seconds to time.Duration
+		timeout := time.Duration(llmTimeout) * time.Second
+
+		// Use provider-based routing if specified
+		if llmProvider != "" && llmProvider != "ollama" {
+			client, err = llm.NewClientWithProvider(ctx, llmProvider, llmHost, llmModel, timeout, llmContext)
+		} else if llmHost != "" || llmModel != "" {
+			client, err = llm.NewClientWithConfig(ctx, llmHost, llmModel, timeout, llmContext)
+		} else {
+			client, err = llm.NewClient(ctx)
+		}
 	}
 
 	if err != nil {

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -129,13 +129,15 @@ func triageWithLLM(ctx context.Context, findings []*model.Finding, rolesCfg *rol
 			}
 		}
 
-		// Defense-in-depth: redact both request and response bodies before they enter the LLM pipeline.
+		// Defense-in-depth: redact all evidence fields before they enter the LLM pipeline.
 		// BuildTriagePrompt also redacts response body in the prompt, but we redact here too so
 		// the TriageRequest never carries unredacted PII regardless of how clients use it.
 		redactor := reporter.NewRedactor()
 		redactedFinding := *finding
 		redactedFinding.Evidence.Request.Body = redactor.RedactForLLM(finding.Evidence.Request.Body)
+		redactedFinding.Evidence.Request.URL = redactor.RedactForLLM(finding.Evidence.Request.URL)
 		redactedFinding.Evidence.Response.Body = redactor.RedactForLLM(finding.Evidence.Response.Body)
+		redactedFinding.Description = redactor.RedactForLLM(finding.Description)
 		req := &llm.TriageRequest{
 			Finding:      &redactedFinding,
 			AttackerRole: attackerRole,

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -101,17 +101,8 @@ func triageWithLLM(ctx context.Context, findings []*model.Finding, rolesCfg *rol
 	if injectedClient != nil {
 		client = injectedClient
 	} else {
-		// Convert timeout from seconds to time.Duration
 		timeout := time.Duration(llmTimeout) * time.Second
-
-		// Use provider-based routing if specified
-		if llmProvider != "" && llmProvider != "ollama" {
-			client, err = llm.NewClientWithProvider(ctx, llmProvider, llmHost, llmModel, timeout, llmContext)
-		} else if llmHost != "" || llmModel != "" {
-			client, err = llm.NewClientWithConfig(ctx, llmHost, llmModel, timeout, llmContext)
-		} else {
-			client, err = llm.NewClient(ctx)
-		}
+		client, err = llm.NewClientWithProvider(ctx, llmProvider, llmHost, llmModel, timeout, llmContext)
 	}
 
 	if err != nil {

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -129,9 +129,12 @@ func triageWithLLM(ctx context.Context, findings []*model.Finding, rolesCfg *rol
 			}
 		}
 
-		// PII redaction is handled by BuildTriagePrompt — no need to redact here
+		// Defense-in-depth: redact request body before it enters the LLM pipeline.
+		// BuildTriagePrompt also redacts response body in the prompt itself.
+		redactedFinding := *finding
+		redactedFinding.Evidence.Request.Body = reporter.NewRedactor().RedactForLLM(finding.Evidence.Request.Body)
 		req := &llm.TriageRequest{
-			Finding:      finding,
+			Finding:      &redactedFinding,
 			AttackerRole: attackerRole,
 			VictimRole:   victimRole,
 			RoleConfig:   rolesCfg,

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -129,10 +129,13 @@ func triageWithLLM(ctx context.Context, findings []*model.Finding, rolesCfg *rol
 			}
 		}
 
-		// Defense-in-depth: redact request body before it enters the LLM pipeline.
-		// BuildTriagePrompt also redacts response body in the prompt itself.
+		// Defense-in-depth: redact both request and response bodies before they enter the LLM pipeline.
+		// BuildTriagePrompt also redacts response body in the prompt, but we redact here too so
+		// the TriageRequest never carries unredacted PII regardless of how clients use it.
+		redactor := reporter.NewRedactor()
 		redactedFinding := *finding
-		redactedFinding.Evidence.Request.Body = reporter.NewRedactor().RedactForLLM(finding.Evidence.Request.Body)
+		redactedFinding.Evidence.Request.Body = redactor.RedactForLLM(finding.Evidence.Request.Body)
+		redactedFinding.Evidence.Response.Body = redactor.RedactForLLM(finding.Evidence.Response.Body)
 		req := &llm.TriageRequest{
 			Finding:      &redactedFinding,
 			AttackerRole: attackerRole,

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -111,8 +111,6 @@ func triageWithLLM(ctx context.Context, findings []*model.Finding, rolesCfg *rol
 		return findings, nil
 	}
 
-	redactor := reporter.NewRedactor()
-
 	for i, finding := range findings {
 		log.Debug("Triaging finding %d/%d: %s", i+1, len(findings), finding.ID)
 		// Skip already-triaged findings
@@ -131,13 +129,9 @@ func triageWithLLM(ctx context.Context, findings []*model.Finding, rolesCfg *rol
 			}
 		}
 
-		// Redact sensitive data before sending to LLM (PII protection)
-		redactedFinding := *finding
-		redactedFinding.Evidence.Request.Body = redactor.RedactForLLM(finding.Evidence.Request.Body)
-		redactedFinding.Evidence.Response.Body = redactor.RedactForLLM(finding.Evidence.Response.Body)
-
+		// PII redaction is handled by BuildTriagePrompt — no need to redact here
 		req := &llm.TriageRequest{
-			Finding:      &redactedFinding,
+			Finding:      finding,
 			AttackerRole: attackerRole,
 			VictimRole:   victimRole,
 			RoleConfig:   rolesCfg,

--- a/pkg/runner/helpers_test.go
+++ b/pkg/runner/helpers_test.go
@@ -1081,12 +1081,14 @@ detection:
 
 // TEST-007: triageWithLLM with injected client
 
-type fakeLLMClient struct {
-	calls int
+type capturingLLMClient struct {
+	calls    int
+	requests []*llm.TriageRequest
 }
 
-func (f *fakeLLMClient) Triage(_ context.Context, _ *llm.TriageRequest) (*llm.TriageResult, error) {
+func (f *capturingLLMClient) Triage(_ context.Context, req *llm.TriageRequest) (*llm.TriageResult, error) {
 	f.calls++
+	f.requests = append(f.requests, req)
 	return &llm.TriageResult{
 		Provider:        "fake",
 		IsVulnerability: true,
@@ -1096,7 +1098,7 @@ func (f *fakeLLMClient) Triage(_ context.Context, _ *llm.TriageRequest) (*llm.Tr
 	}, nil
 }
 
-func (f *fakeLLMClient) Name() string { return "fake" }
+func (f *capturingLLMClient) Name() string { return "fake" }
 
 func TestTriageWithLLM_InjectedClient(t *testing.T) {
 	ctx := context.Background()
@@ -1111,12 +1113,57 @@ func TestTriageWithLLM_InjectedClient(t *testing.T) {
 	defer func() { _ = tmpFile.Close() }()
 	rep := NewTerminalReporter(tmpFile, 1)
 
-	fake := &fakeLLMClient{}
-	// Provider/host/model should be ignored when injected client is set
+	fake := &capturingLLMClient{}
 	result, err := triageWithLLM(ctx, findings, rolesCfg, "bogus-provider", "bogus-host", "bogus-model", 1, "", fake, rep)
 	require.NoError(t, err)
 	assert.Len(t, result, 2)
-	assert.Equal(t, 2, fake.calls) // called once per finding
+	assert.Equal(t, 2, fake.calls)
 	assert.NotNil(t, result[0].LLMAnalysis)
 	assert.Equal(t, "fake", result[0].LLMAnalysis.Provider)
+}
+
+func TestTriageWithLLM_RedactsPII(t *testing.T) {
+	ctx := context.Background()
+	// Seed findings with recognizable PII that the redactor will replace
+	findings := []*model.Finding{
+		{
+			ID:           "f1",
+			Severity:     model.SeverityHigh,
+			Category:     "API1",
+			Name:         "Test",
+			Method:       "GET",
+			Endpoint:     "/test",
+			AttackerRole: "user",
+			Evidence: model.Evidence{
+				Request: model.HTTPRequest{
+					Method: "GET",
+					URL:    "/test",
+					Body:   `{"email":"user@example.com","ssn":"123-45-6789"}`,
+				},
+				Response: model.HTTPResponse{
+					StatusCode: 200,
+					Body:       `{"email":"admin@secret.com","card":"4111-1111-1111-1111"}`,
+				},
+			},
+		},
+	}
+	rolesCfg := &roles.RoleConfig{Roles: []*roles.Role{{Name: "user"}}}
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "output")
+	require.NoError(t, err)
+	defer func() { _ = tmpFile.Close() }()
+	rep := NewTerminalReporter(tmpFile, 1)
+
+	fake := &capturingLLMClient{}
+	_, err = triageWithLLM(ctx, findings, rolesCfg, "", "", "", 180, "", fake, rep)
+	require.NoError(t, err)
+	require.Len(t, fake.requests, 1)
+
+	// Assert PII is redacted in both request and response bodies
+	reqBody := fake.requests[0].Finding.Evidence.Request.Body
+	respBody := fake.requests[0].Finding.Evidence.Response.Body
+	assert.NotContains(t, reqBody, "user@example.com", "request body email should be redacted")
+	assert.NotContains(t, reqBody, "123-45-6789", "request body SSN should be redacted")
+	assert.NotContains(t, respBody, "admin@secret.com", "response body email should be redacted")
+	assert.NotContains(t, respBody, "4111-1111-1111-1111", "response body card should be redacted")
 }

--- a/pkg/runner/helpers_test.go
+++ b/pkg/runner/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/praetorian-inc/hadrian/pkg/llm"
 	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/roles"
 	"github.com/praetorian-inc/hadrian/pkg/templates"
@@ -1076,4 +1077,46 @@ detection:
 	// Dry-run must not send any HTTP requests to the target server
 	assert.Equal(t, int32(0), atomic.LoadInt32(&requestCount),
 		"dry-run mode must not make HTTP requests to the target server")
+}
+
+// TEST-007: triageWithLLM with injected client
+
+type fakeLLMClient struct {
+	calls int
+}
+
+func (f *fakeLLMClient) Triage(_ context.Context, _ *llm.TriageRequest) (*llm.TriageResult, error) {
+	f.calls++
+	return &llm.TriageResult{
+		Provider:        "fake",
+		IsVulnerability: true,
+		Confidence:      0.95,
+		Reasoning:       "fake triage",
+		Severity:        model.SeverityHigh,
+	}, nil
+}
+
+func (f *fakeLLMClient) Name() string { return "fake" }
+
+func TestTriageWithLLM_InjectedClient(t *testing.T) {
+	ctx := context.Background()
+	findings := []*model.Finding{
+		{ID: "f1", Severity: model.SeverityHigh, Category: "API1", Name: "Test", Method: "GET", Endpoint: "/test", AttackerRole: "user"},
+		{ID: "f2", Severity: model.SeverityMedium, Category: "API1", Name: "Test2", Method: "POST", Endpoint: "/test2", AttackerRole: "user"},
+	}
+	rolesCfg := &roles.RoleConfig{Roles: []*roles.Role{{Name: "user"}, {Name: "admin"}}}
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "output")
+	require.NoError(t, err)
+	defer func() { _ = tmpFile.Close() }()
+	rep := NewTerminalReporter(tmpFile, 1)
+
+	fake := &fakeLLMClient{}
+	// Provider/host/model should be ignored when injected client is set
+	result, err := triageWithLLM(ctx, findings, rolesCfg, "bogus-provider", "bogus-host", "bogus-model", 1, "", fake, rep)
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, 2, fake.calls) // called once per finding
+	assert.NotNil(t, result[0].LLMAnalysis)
+	assert.Equal(t, "fake", result[0].LLMAnalysis.Provider)
 }

--- a/pkg/runner/helpers_test.go
+++ b/pkg/runner/helpers_test.go
@@ -554,7 +554,7 @@ func TestTriageWithLLM_NoProvider(t *testing.T) {
 	rep := NewTerminalReporter(tmpFile, 1)
 
 	// Should return findings unchanged (no LLM available)
-	result, err := triageWithLLM(ctx, findings, rolesCfg, "", "", 180, "", rep)
+	result, err := triageWithLLM(ctx, findings, rolesCfg, "", "", "", 180, "", nil, rep)
 	require.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "test-1", result[0].ID)
@@ -594,7 +594,7 @@ func TestTriageWithLLM_PrintsFindingsImmediately(t *testing.T) {
 	rep := NewTerminalReporter(tmpFile, 1)
 
 	// Should not panic with reporter parameter
-	result, err := triageWithLLM(ctx, findings, rolesCfg, "", "", 180, "", rep)
+	result, err := triageWithLLM(ctx, findings, rolesCfg, "", "", "", 180, "", nil, rep)
 	require.NoError(t, err)
 	assert.Len(t, result, 1)
 
@@ -628,7 +628,7 @@ func TestTriageWithLLM_WithContext(t *testing.T) {
 
 	// Should return findings unchanged (no LLM available)
 	// This test verifies the signature accepts llmContext parameter
-	result, err := triageWithLLM(ctx, findings, rolesCfg, "", "", 180, customContext, rep)
+	result, err := triageWithLLM(ctx, findings, rolesCfg, "", "", "", 180, customContext, nil, rep)
 	require.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "test-1", result[0].ID)

--- a/pkg/runner/rest.go
+++ b/pkg/runner/rest.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/praetorian-inc/hadrian/pkg/llm"
 	"github.com/praetorian-inc/hadrian/pkg/log"
 	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/planner"
@@ -39,19 +40,21 @@ type Config struct {
 	AuditLog             string
 	Verbose              bool
 	DryRun               bool
-	RequestIDsLimit      int               // Number of request IDs to display per finding (0 = all)
-	LLMHost              string            // LLM provider host (e.g., http://localhost:11434 for Ollama)
-	LLMModel             string            // LLM model name (e.g., llama3.2:latest)
-	LLMTimeout           int               // LLM request timeout in seconds
-	LLMContext           string            // Additional context for LLM prompts
-	Headers              []string          // Custom HTTP headers (format: "Key: Value")
-	PlannerEnabled       bool              // Enable LLM-assisted attack planning (experimental)
-	PlannerOnly          bool              // Run ONLY the LLM-planned steps, skip brute-force
-	PlannerProvider      string            // LLM provider: openai, anthropic, ollama
-	PlannerModel         string            // LLM model for planner
-	PlannerTimeout       int               // Planner LLM timeout in seconds (default 120)
-	PlannerContext       string            // Additional context for planner prompt
-	PlannerLLMClient     planner.LLMClient // Optional: platform-injected LLM client (takes priority over provider flags)
+	RequestIDsLimit  int               // Number of request IDs to display per finding (0 = all)
+	LLMProvider      string            // LLM provider: ollama, openai, anthropic
+	LLMHost          string            // LLM provider host (e.g., http://localhost:11434 for Ollama)
+	LLMModel         string            // LLM model name (e.g., llama3.2:latest)
+	LLMTimeout       int               // LLM request timeout in seconds
+	LLMContext       string            // Additional context for LLM prompts
+	LLMTriageClient  llm.Client        // Optional: platform-injected LLM client for triage
+	Headers          []string          // Custom HTTP headers (format: "Key: Value")
+	PlannerEnabled   bool              // Enable LLM-assisted attack planning (experimental)
+	PlannerOnly      bool              // Run ONLY the LLM-planned steps, skip brute-force
+	PlannerProvider  string            // LLM provider: openai, anthropic, ollama
+	PlannerModel     string            // LLM model for planner
+	PlannerTimeout   int               // Planner LLM timeout in seconds (default 120)
+	PlannerContext   string            // Additional context for planner prompt
+	PlannerLLMClient planner.LLMClient // Optional: platform-injected LLM client
 }
 
 // newTestRestCmd creates the "test rest" subcommand (was previously the main test command)
@@ -95,6 +98,7 @@ func newTestRestCmd() *cobra.Command {
 	cmd.Flags().IntVar(&config.RequestIDsLimit, "request-ids", 1, "Number of request IDs to display per finding (0 = all)")
 
 	// LLM configuration
+	cmd.Flags().StringVar(&config.LLMProvider, "llm-provider", "ollama", "LLM provider for triage: ollama, openai, anthropic")
 	cmd.Flags().StringVar(&config.LLMHost, "llm-host", "", "LLM provider host URL (e.g., http://localhost:11434 for Ollama)")
 	cmd.Flags().StringVar(&config.LLMModel, "llm-model", "", "LLM model name (e.g., llama3.2:latest)")
 	cmd.Flags().IntVar(&config.LLMTimeout, "llm-timeout", 180, "LLM request timeout in seconds")
@@ -138,7 +142,7 @@ func runTest(ctx context.Context, config Config) error {
 	}
 	defer func() { _ = rep.Close() }()
 
-	llmEnabled := hasLLMConfig() || config.LLMHost != ""
+	llmEnabled := hasLLMConfig() || config.LLMHost != "" || (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMTriageClient != nil
 	if terminalReporter, ok := rep.(*TerminalReporter); ok && llmEnabled {
 		terminalReporter.SetLLMMode(true)
 		log.Debug("LLM mode enabled on terminal reporter")
@@ -183,7 +187,7 @@ func runTest(ctx context.Context, config Config) error {
 
 	if llmEnabled {
 		var triageErr error
-		allFindings, triageErr = triageWithLLM(ctx, allFindings, rolesCfg, config.LLMHost, config.LLMModel, config.LLMTimeout, config.LLMContext, rep)
+		allFindings, triageErr = triageWithLLM(ctx, allFindings, rolesCfg, config.LLMProvider, config.LLMHost, config.LLMModel, config.LLMTimeout, config.LLMContext, config.LLMTriageClient, rep)
 		if triageErr != nil {
 			log.Warn("LLM triage failed, returning original findings: %v", triageErr)
 		}

--- a/pkg/runner/rest.go
+++ b/pkg/runner/rest.go
@@ -142,7 +142,7 @@ func runTest(ctx context.Context, config Config) error {
 	}
 	defer func() { _ = rep.Close() }()
 
-	llmEnabled := hasLLMConfig() || config.LLMHost != "" || (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMTriageClient != nil
+	llmEnabled := hasLLMConfig() || config.LLMHost != "" || config.LLMModel != "" || (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMTriageClient != nil
 	if terminalReporter, ok := rep.(*TerminalReporter); ok && llmEnabled {
 		terminalReporter.SetLLMMode(true)
 		log.Debug("LLM mode enabled on terminal reporter")

--- a/pkg/runner/rest.go
+++ b/pkg/runner/rest.go
@@ -40,21 +40,21 @@ type Config struct {
 	AuditLog             string
 	Verbose              bool
 	DryRun               bool
-	RequestIDsLimit  int               // Number of request IDs to display per finding (0 = all)
-	LLMProvider      string            // LLM provider: ollama, openai, anthropic
-	LLMHost          string            // LLM provider host (e.g., http://localhost:11434 for Ollama)
-	LLMModel         string            // LLM model name (e.g., llama3.2:latest)
-	LLMTimeout       int               // LLM request timeout in seconds
-	LLMContext       string            // Additional context for LLM prompts
-	LLMTriageClient  llm.Client        // Optional: platform-injected LLM client for triage
-	Headers          []string          // Custom HTTP headers (format: "Key: Value")
-	PlannerEnabled   bool              // Enable LLM-assisted attack planning (experimental)
-	PlannerOnly      bool              // Run ONLY the LLM-planned steps, skip brute-force
-	PlannerProvider  string            // LLM provider: openai, anthropic, ollama
-	PlannerModel     string            // LLM model for planner
-	PlannerTimeout   int               // Planner LLM timeout in seconds (default 120)
-	PlannerContext   string            // Additional context for planner prompt
-	PlannerLLMClient planner.LLMClient // Optional: platform-injected LLM client
+	RequestIDsLimit      int               // Number of request IDs to display per finding (0 = all)
+	LLMProvider          string            // LLM provider: ollama, openai, anthropic
+	LLMHost              string            // LLM provider host (e.g., http://localhost:11434 for Ollama)
+	LLMModel             string            // LLM model name (e.g., llama3.2:latest)
+	LLMTimeout           int               // LLM request timeout in seconds
+	LLMContext           string            // Additional context for LLM prompts
+	LLMTriageClient      llm.Client        // Optional: platform-injected LLM client for triage
+	Headers              []string          // Custom HTTP headers (format: "Key: Value")
+	PlannerEnabled       bool              // Enable LLM-assisted attack planning (experimental)
+	PlannerOnly          bool              // Run ONLY the LLM-planned steps, skip brute-force
+	PlannerProvider      string            // LLM provider: openai, anthropic, ollama
+	PlannerModel         string            // LLM model for planner
+	PlannerTimeout       int               // Planner LLM timeout in seconds (default 120)
+	PlannerContext       string            // Additional context for planner prompt
+	PlannerLLMClient     planner.LLMClient // Optional: platform-injected LLM client
 }
 
 // newTestRestCmd creates the "test rest" subcommand (was previously the main test command)

--- a/test/test-llm-triage.sh
+++ b/test/test-llm-triage.sh
@@ -82,7 +82,7 @@ USER_TOKEN=$(crapi_login "user1@test.com" "Testpass123!")
 USER2_TOKEN=$(crapi_login "user2@test.com" "Testpass123!")
 MECH_TOKEN=$(crapi_login "mechanic1@test.com" "Testpass123!")
 
-if [ -z "$USER_TOKEN" ] || [ -z "$USER2_TOKEN" ]; then
+if [ -z "$USER_TOKEN" ] || [ -z "$USER2_TOKEN" ] || [ -z "$MECH_TOKEN" ]; then
     log_fail "Failed to get crAPI tokens. Create users first (see test/crapi/README.md)"
     exit 1
 fi

--- a/test/test-llm-triage.sh
+++ b/test/test-llm-triage.sh
@@ -91,6 +91,7 @@ log_ok "Tokens acquired"
 # Write temp auth config
 mkdir -p "$OUTPUT_DIR"
 AUTH_FILE="${OUTPUT_DIR}/llm-triage-auth.yaml"
+trap 'rm -f "$AUTH_FILE"' EXIT
 (umask 077; cat > "$AUTH_FILE" <<EOF
 method: bearer
 location: header

--- a/test/test-llm-triage.sh
+++ b/test/test-llm-triage.sh
@@ -144,6 +144,6 @@ elif [ "$FINDING_COUNT" -gt 0 ] && [ "$LLM_COUNT" -eq 0 ]; then
     log_fail "Findings detected but none have LLM analysis — triage may not have fired"
     exit 1
 else
-    log_info "No findings detected (tokens may be expired or crAPI needs setup)"
-    exit 0
+    log_fail "No findings detected — crAPI may not be running or tokens are expired"
+    exit 1
 fi

--- a/test/test-llm-triage.sh
+++ b/test/test-llm-triage.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test-llm-triage.sh
+#
+# Tests LLM triage with OpenAI or Anthropic against crAPI.
+# Verifies that findings include LLM analysis when a cloud provider is used.
+#
+# Prerequisites:
+#   - crAPI running on localhost:8888
+#   - OPENAI_API_KEY or ANTHROPIC_API_KEY set
+#   - hadrian binary built
+#
+# Usage:
+#   ./test/test-llm-triage.sh [openai|anthropic]
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HADRIAN_BIN="${HADRIAN_BIN:-${REPO_ROOT}/hadrian}"
+OUTPUT_DIR="${SCRIPT_DIR}/.results"
+CRAPI_PORT="${CRAPI_PORT:-8888}"
+CRAPI_URL="http://localhost:${CRAPI_PORT}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
+log_ok()   { echo -e "${GREEN}[OK]${NC} $1"; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+
+# Parse provider argument
+PROVIDER="${1:-openai}"
+case "$PROVIDER" in
+    openai)
+        if [ -z "${OPENAI_API_KEY:-}" ]; then
+            log_fail "OPENAI_API_KEY not set"
+            exit 1
+        fi
+        ;;
+    anthropic)
+        if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            log_fail "ANTHROPIC_API_KEY not set"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Usage: $0 [openai|anthropic]"
+        exit 1
+        ;;
+esac
+
+# Check prerequisites
+if [ ! -f "$HADRIAN_BIN" ]; then
+    log_info "Building hadrian..."
+    (cd "$REPO_ROOT" && go build -o hadrian ./cmd/hadrian)
+fi
+
+if ! curl -sf -o /dev/null "$CRAPI_URL" 2>/dev/null; then
+    log_fail "crAPI not running on $CRAPI_URL"
+    echo "Start it with: cd crAPI/deploy/docker && docker-compose up -d"
+    exit 1
+fi
+
+# Setup crAPI users and tokens
+log_info "Setting up crAPI tokens..."
+
+crapi_login() {
+    local email="$1" password="$2"
+    printf '{"email":"%s","password":"%s"}' "$email" "$password" | \
+        curl -sf -X POST "${CRAPI_URL}/identity/api/auth/login" \
+            -H "Content-Type: application/json" \
+            --data-binary @- 2>/dev/null | \
+        python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo ""
+}
+
+USER_TOKEN=$(crapi_login "user1@test.com" "Testpass123!")
+USER2_TOKEN=$(crapi_login "user2@test.com" "Testpass123!")
+MECH_TOKEN=$(crapi_login "mechanic1@test.com" "Testpass123!")
+
+if [ -z "$USER_TOKEN" ] || [ -z "$USER2_TOKEN" ]; then
+    log_fail "Failed to get crAPI tokens. Create users first (see test/crapi/README.md)"
+    exit 1
+fi
+log_ok "Tokens acquired"
+
+# Write temp auth config
+mkdir -p "$OUTPUT_DIR"
+AUTH_FILE="${OUTPUT_DIR}/llm-triage-auth.yaml"
+(umask 077; cat > "$AUTH_FILE" <<EOF
+method: bearer
+location: header
+roles:
+  admin:
+    token: "${USER_TOKEN}"
+  mechanic:
+    token: "${MECH_TOKEN}"
+  user:
+    token: "${USER_TOKEN}"
+  user2:
+    token: "${USER2_TOKEN}"
+  anonymous:
+    token: ""
+EOF
+)
+
+# Run hadrian with LLM triage
+RESULT_FILE="${OUTPUT_DIR}/llm-triage-${PROVIDER}-results.json"
+log_info "Running hadrian with --llm-provider ${PROVIDER}..."
+
+"$HADRIAN_BIN" test rest \
+    --api "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
+    --roles "${SCRIPT_DIR}/crapi/roles.yaml" \
+    --auth "$AUTH_FILE" \
+    --template-dir "${SCRIPT_DIR}/crapi/templates/owasp" \
+    --llm-provider "$PROVIDER" \
+    --output json \
+    --output-file "$RESULT_FILE"
+
+# Validate results
+if [ ! -f "$RESULT_FILE" ]; then
+    log_fail "No results file generated"
+    exit 1
+fi
+
+FINDING_COUNT=$(python3 -c "import json; d=json.load(open('$RESULT_FILE')); print(len(d.get('findings',[])))" 2>/dev/null || echo "0")
+LLM_COUNT=$(python3 -c "import json; d=json.load(open('$RESULT_FILE')); print(sum(1 for f in d.get('findings',[]) if f.get('llm_analysis')))" 2>/dev/null || echo "0")
+
+echo ""
+echo -e "${BOLD}=== LLM Triage Test Results (${PROVIDER}) ===${NC}"
+echo "  Total findings: $FINDING_COUNT"
+echo "  With LLM analysis: $LLM_COUNT"
+echo "  Results: $RESULT_FILE"
+
+if [ "$FINDING_COUNT" -gt 0 ] && [ "$LLM_COUNT" -gt 0 ]; then
+    log_ok "LLM triage working — ${LLM_COUNT}/${FINDING_COUNT} findings have analysis"
+    exit 0
+elif [ "$FINDING_COUNT" -gt 0 ] && [ "$LLM_COUNT" -eq 0 ]; then
+    log_fail "Findings detected but none have LLM analysis — triage may not have fired"
+    exit 1
+else
+    log_info "No findings detected (tokens may be expired or crAPI needs setup)"
+    exit 0
+fi


### PR DESCRIPTION
## Description
Adds OpenAI and Anthropic as LLM providers for finding triage (LAB-1804), alongside the existing Ollama support. Users can now run `--llm-provider openai` or `--llm-provider anthropic` to use cloud LLMs for more accurate vulnerability classification. Shared prompt building and response parsing extracted so all providers use identical triage logic. Platform can inject its own LLM client via `Config.LLMTriageClient`.

## Changes
  - Extract shared `BuildTriagePrompt()` and `ParseTriageJSON()` into `pkg/llm/prompt.go`
  - Add `pkg/llm/openai.go` — OpenAI adapter implementing `llm.Client`
  - Add `pkg/llm/anthropic.go` — Anthropic adapter implementing `llm.Client`
  - Add `llm.NewClientWithProvider()` for provider-based routing
  - Add `--llm-provider` flag to REST and GraphQL commands (ollama, openai, anthropic)
  - Add `Config.LLMTriageClient` for platform-injected LLM providers
  - Refactor `OllamaClient` to use shared prompt/parsing (no behavior change)
  - Add live test script `test/test-llm-triage.sh`
  - Update README with OpenAI/Anthropic triage examples

## Testing

<!-- How was this tested? -->

  - [x] Unit tests pass (`make test`)
  - [x] Linter passes (`make lint`)
  - [x] Manual verification:
    - Tested `--llm-provider openai` against crAPI — findings include LLM analysis
    - Tested existing Ollama path unchanged (no `--llm-provider` flag)
    - Live test script: `./test/test-llm-triage.sh openai`


## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated for new functionality
- [x] Documentation updated (if applicable)