### PR TITLE
ci: migrate to centralized external-contrib-notify.yml (ENG-3104)

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -8,10 +8,5 @@ on:
 
 jobs:
   notify:
-    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@c357674282ed4de58cecc0f30b4e25d39871aa2f  # v1.2.0
-    with:
-      slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-      linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
-      linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
-      linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@ed9e647c09219b8058da8fcaa908eb03520feccd  # v2.0.0
     secrets: inherit

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -6,23 +6,12 @@ on:
   pull_request_target:
     types: [opened, assigned, closed]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   notify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: praetorian-inc/external-contrib-action@v2
-        with:
-          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
-          linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
-          linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
-          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          dry-run: "false"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@c357674282ed4de58cecc0f30b4e25d39871aa2f  # v1.2.0
+    with:
+      slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+      linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
+      linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+      linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Replaces the inline `external-contribution.yml` workflow (floating `external-contrib-action@v2` tag, PAT-based auth) with a 12-line caller to the centralized reusable workflow at `praetorian-inc/public-workflows`
- SHA-pinned to `c357674282ed4de58cecc0f30b4e25d39871aa2f` (v1.2.0) per ENG-3081 SHA-pinning policy
- Removes the caller-level `permissions:` block — the reusable workflow defines its own least-privilege permissions (`issues: write`, `pull-requests: write`, `contents: read`)

## Why this change

**Security improvements:**
- **SHA pinning**: Floating `@v2` tag replaced with pinned commit SHA + version comment, eliminating tag-mutation supply-chain risk (ENG-3081)
- **GitHub App auth**: The reusable workflow uses `EXTERNAL_CONTRIB_APP_ID` / `EXTERNAL_CONTRIB_APP_PRIVATE_KEY` (org-level secrets) via the dedicated `praetorian-external-contrib-bot` GitHub App, replacing the PAT (`ORG_MEMBER_CHECK_PAT`) that was previously required in each repo
- **Org-level secret consolidation**: `LINEAR_API_KEY`, `SLACK_BOT_TOKEN`, `EXTERNAL_CONTRIB_APP_ID`, `EXTERNAL_CONTRIB_APP_PRIVATE_KEY` are now managed once at org level and passed via `secrets: inherit`; repo-specific secrets are only the channel/team IDs
- **Centralized maintenance**: Bug fixes and improvements to the notification logic only need to happen in `public-workflows` — all 11 repos pick them up automatically

## Follow-on repos (9 remaining in ENG-3104 sweep)

After this pilot merges and is verified, the same migration will be applied to:
augustus, brutus, capability-sdk, julius, nerva, pius, titus, trajan, vespasian

## Linear

[ENG-3104](https://linear.app/praetorianlabs/issue/ENG-3104) | Parent: [ENG-3100](https://linear.app/praetorianlabs/issue/ENG-3100)

## Test plan

- [ ] Merge this PR and open a test issue or PR from an **external** (non-org-member) account → should create Linear issue + Slack notification
- [ ] Open an issue or PR from an **internal** (org member) account → should NOT trigger notifications
- [ ] Confirm the `External Contribution Notify` check passes in CI (previously failing in PR #64 due to missing App secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)