### PR TITLE
chore(ci): bump external-contrib-notify pin to v2.0.2

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -9,4 +9,8 @@ on:
 jobs:
   notify:
     uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   notify:
-    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@ed9e647c09219b8058da8fcaa908eb03520feccd  # v2.0.0
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
     secrets: inherit

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -13,4 +13,13 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    secrets: inherit
+    secrets:
+      EXTERNAL_CONTRIB_APP_ID: ${{ secrets.EXTERNAL_CONTRIB_APP_ID }}
+      EXTERNAL_CONTRIB_APP_PRIVATE_KEY: ${{ secrets.EXTERNAL_CONTRIB_APP_PRIVATE_KEY }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      LINEAR_ASSIGNEE_ID: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+      LINEAR_PARENT_ISSUE_ID: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}


### PR DESCRIPTION
Small bump to v2.0.2 of the `external-contrib-notify.yml` reusable.

No caller-visible behavior change. v2.0.2 added SHA-pinning of internal actions inside `public-workflows` (ENG-3093) — most importantly, replaced `anthropics/claude-code-action@beta` (branch pin running with secrets) with an immutable SHA. Bumping for fleet uniformity.

Related: ENG-3093 (public-workflows internal hardening).