### PR TITLE
chore(templates): add consistent OWASP tags to GraphQL, gRPC, and test templates

### DIFF
--- a/pkg/templates/tag_convention_test.go
+++ b/pkg/templates/tag_convention_test.go
@@ -1,0 +1,50 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOWASPTagsConvention guards against tag-drift in the convention-bound
+// OWASP template directories: every YAML template in these directories must
+// carry both "owasp" and "owasp-api-top10" in info.tags so that
+// --category owasp filtering stays consistent across GraphQL, gRPC, and test
+// templates (LAB-2104).
+func TestOWASPTagsConvention(t *testing.T) {
+	dirs := []string{
+		"../../templates/graphql",
+		"../../templates/grpc",
+		"../../test/dvga/templates/owasp",
+		"../../test/grpc-server/templates/owasp",
+	}
+
+	for _, dir := range dirs {
+		t.Run(dir, func(t *testing.T) {
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+
+			yamlFiles := 0
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+					continue
+				}
+				yamlFiles++
+				path := filepath.Join(dir, e.Name())
+
+				tmpl, err := Parse(path)
+				require.NoError(t, err, "%s must parse", path)
+
+				assert.Contains(t, tmpl.Info.Tags, "owasp",
+					`%s is missing the "owasp" tag`, path)
+				assert.Contains(t, tmpl.Info.Tags, "owasp-api-top10",
+					`%s is missing the "owasp-api-top10" tag`, path)
+			}
+			require.Greater(t, yamlFiles, 0, "expected at least one YAML template in %s", dir)
+		})
+	}
+}

--- a/templates/graphql/01-api1-bola-user-access.yaml
+++ b/templates/graphql/01-api1-bola-user-access.yaml
@@ -4,7 +4,7 @@ info:
   category: "API1:2023 Broken Object Level Authorization"
   severity: "HIGH"
   author: "hadrian"
-  tags: ["graphql", "bola", "authorization"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "bola", "authorization"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/02-api2-broken-authentication.yaml
+++ b/templates/graphql/02-api2-broken-authentication.yaml
@@ -5,7 +5,7 @@ info:
   severity: "HIGH"
   author: "hadrian"
   description: "Tests for broken authentication in GraphQL APIs including missing authentication checks, weak token validation, and session management issues."
-  tags: ["graphql", "authentication", "session", "api2"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "authentication", "session", "api2"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/03-api3-excessive-data-exposure.yaml
+++ b/templates/graphql/03-api3-excessive-data-exposure.yaml
@@ -5,7 +5,7 @@ info:
   severity: "HIGH"
   author: "hadrian"
   description: "Tests for excessive data exposure where GraphQL APIs allow querying sensitive fields without proper authorization checks. Attackers can over-fetch data by requesting fields they should not have access to, such as internal IDs, emails, or sensitive user data."
-  tags: ["graphql", "authorization", "data-exposure", "over-fetching", "sensitive-data"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "authorization", "data-exposure", "over-fetching", "sensitive-data"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/04-api3-injection-via-variables.yaml
+++ b/templates/graphql/04-api3-injection-via-variables.yaml
@@ -5,7 +5,7 @@ info:
   severity: "HIGH"
   author: "hadrian"
   description: "Tests for SQL/NoSQL injection vulnerabilities through GraphQL variables. When user input from variables is not properly sanitized before being used in database queries, attackers can inject malicious payloads to access or manipulate data."
-  tags: ["graphql", "injection", "sql-injection", "nosql-injection", "variables"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "injection", "sql-injection", "nosql-injection", "variables"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/05-api4-alias-dos-attack.yaml
+++ b/templates/graphql/05-api4-alias-dos-attack.yaml
@@ -5,7 +5,7 @@ info:
   severity: "HIGH"
   author: "hadrian"
   description: "Tests for GraphQL alias-based denial of service by creating multiple aliases of expensive queries. Attackers can use aliases to execute the same expensive operation many times in a single request, bypassing simple query complexity limits that only count unique fields."
-  tags: ["graphql", "dos", "aliasing", "resource-exhaustion"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dos", "aliasing", "resource-exhaustion"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/06-api4-batching-attack.yaml
+++ b/templates/graphql/06-api4-batching-attack.yaml
@@ -4,7 +4,7 @@ info:
   category: "API4:2023 Unrestricted Resource Consumption"
   severity: "HIGH"
   author: "hadrian"
-  tags: ["graphql", "dos", "batching", "aliasing"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dos", "batching", "aliasing"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/07-api4-circular-fragment-attack.yaml
+++ b/templates/graphql/07-api4-circular-fragment-attack.yaml
@@ -5,7 +5,7 @@ info:
   severity: "HIGH"
   author: "hadrian"
   description: "Tests for circular fragment reference vulnerabilities in GraphQL. Circular or deeply nested fragments can cause infinite loops, stack overflow, or excessive processing during query parsing and execution."
-  tags: ["graphql", "dos", "fragments", "circular-reference", "recursion"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dos", "fragments", "circular-reference", "recursion"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/08-api4-depth-attack.yaml
+++ b/templates/graphql/08-api4-depth-attack.yaml
@@ -4,7 +4,7 @@ info:
   category: "API4:2023 Unrestricted Resource Consumption"
   severity: "HIGH"
   author: "hadrian"
-  tags: ["graphql", "dos", "depth-limit"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dos", "depth-limit"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/09-api4-directive-overloading.yaml
+++ b/templates/graphql/09-api4-directive-overloading.yaml
@@ -5,7 +5,7 @@ info:
   severity: "MEDIUM"
   author: "hadrian"
   description: "Tests for GraphQL directive abuse by overloading queries with excessive @skip, @include, or custom directives. Processing many directives can cause performance degradation and resource exhaustion."
-  tags: ["graphql", "dos", "directives", "skip", "include"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dos", "directives", "skip", "include"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/10-api4-field-duplication-attack.yaml
+++ b/templates/graphql/10-api4-field-duplication-attack.yaml
@@ -5,7 +5,7 @@ info:
   severity: "MEDIUM"
   author: "hadrian"
   description: "Tests for GraphQL field duplication attacks where the same field is requested multiple times with different aliases. This can amplify database queries and processing overhead while appearing as a simple query."
-  tags: ["graphql", "dos", "field-duplication", "resource-exhaustion"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dos", "field-duplication", "resource-exhaustion"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/11-api5-bfla-mutation.yaml
+++ b/templates/graphql/11-api5-bfla-mutation.yaml
@@ -4,7 +4,7 @@ info:
   category: "API5:2023 Broken Function Level Authorization"
   severity: "HIGH"
   author: "hadrian"
-  tags: ["graphql", "bfla", "authorization", "mutation"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "bfla", "authorization", "mutation"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/12-api8-error-disclosure.yaml
+++ b/templates/graphql/12-api8-error-disclosure.yaml
@@ -5,7 +5,7 @@ info:
   severity: "MEDIUM"
   author: "hadrian"
   description: "Tests for verbose error messages in GraphQL responses that may disclose sensitive information about the server, database structure, file paths, or internal implementation details. Production GraphQL APIs should sanitize error messages."
-  tags: ["graphql", "information-disclosure", "error-handling", "debug-mode"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "information-disclosure", "error-handling", "debug-mode"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/graphql/13-api8-introspection-disclosure.yaml
+++ b/templates/graphql/13-api8-introspection-disclosure.yaml
@@ -4,7 +4,7 @@ info:
   category: "API8:2023 Security Misconfiguration"
   severity: "MEDIUM"
   author: "hadrian"
-  tags: ["graphql", "introspection", "information-disclosure"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "introspection", "information-disclosure"]
   requires_llm_triage: false
   test_pattern: "simple"
 

--- a/templates/grpc/01-api1-bola-read.yaml
+++ b/templates/grpc/01-api1-bola-read.yaml
@@ -4,7 +4,7 @@ info:
   category: "API1:2023 Broken Object Level Authorization"
   severity: "HIGH"
   author: "hadrian"
-  tags: ["grpc", "bola", "api1", "authorization"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bola", "api1", "authorization"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/grpc/02-api1-bola-write.yaml
+++ b/templates/grpc/02-api1-bola-write.yaml
@@ -19,7 +19,7 @@ info:
     Phase 3: Verify the resource was actually modified by reading it back.
     A successful test indicates the API does not properly validate object-level permissions
     for update operations, which could lead to unauthorized data modification.
-  tags: ["grpc", "bola", "api1", "authorization", "write", "update", "mutation"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bola", "api1", "authorization", "write", "update", "mutation"]
   requires_llm_triage: true
   test_pattern: "mutation"
 

--- a/templates/grpc/03-api1-bola-delete.yaml
+++ b/templates/grpc/03-api1-bola-delete.yaml
@@ -19,7 +19,7 @@ info:
     Phase 3: Verify the resource was actually deleted by attempting to read it (should return NOT_FOUND).
     A successful test indicates the API does not properly validate object-level permissions
     for delete operations, which could lead to unauthorized data deletion.
-  tags: ["grpc", "bola", "api1", "authorization", "delete", "mutation"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bola", "api1", "authorization", "delete", "mutation"]
   requires_llm_triage: true
   test_pattern: "mutation"
 

--- a/templates/grpc/04-api2-broken-auth.yaml
+++ b/templates/grpc/04-api2-broken-auth.yaml
@@ -4,7 +4,7 @@ info:
   category: "API2:2023 Broken Authentication"
   severity: "CRITICAL"
   author: "hadrian"
-  tags: ["grpc", "authentication", "api2"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "authentication", "api2"]
   requires_llm_triage: false
   test_pattern: "simple"
 

--- a/templates/grpc/05-api3-sensitive-data.yaml
+++ b/templates/grpc/05-api3-sensitive-data.yaml
@@ -4,7 +4,7 @@ info:
   category: "API3:2023 Excessive Data Exposure"
   severity: "MEDIUM"
   author: "hadrian"
-  tags: ["grpc", "data-exposure", "api3"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "data-exposure", "api3"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/grpc/06-api5-bfla.yaml
+++ b/templates/grpc/06-api5-bfla.yaml
@@ -4,7 +4,7 @@ info:
   category: "API5:2023 Broken Function Level Authorization"
   severity: "HIGH"
   author: "hadrian"
-  tags: ["grpc", "bfla", "api5", "authorization"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bfla", "api5", "authorization"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/grpc/07-api8-misconfiguration.yaml
+++ b/templates/grpc/07-api8-misconfiguration.yaml
@@ -4,7 +4,7 @@ info:
   category: "API8:2023 Security Misconfiguration"
   severity: "MEDIUM"
   author: "hadrian"
-  tags: ["grpc", "misconfiguration", "api8", "reflection"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "misconfiguration", "api8", "reflection"]
   requires_llm_triage: false
   test_pattern: "simple"
 

--- a/templates/grpc/08-deadline-manipulation.yaml
+++ b/templates/grpc/08-deadline-manipulation.yaml
@@ -4,7 +4,7 @@ info:
   category: "API4:2023 Unrestricted Resource Consumption"
   severity: "LOW"
   author: "hadrian"
-  tags: ["grpc", "dos", "timeout"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "dos", "timeout"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/templates/grpc/09-metadata-injection.yaml
+++ b/templates/grpc/09-metadata-injection.yaml
@@ -4,7 +4,7 @@ info:
   category: "API8:2023 Security Misconfiguration"
   severity: "MEDIUM"
   author: "hadrian"
-  tags: ["grpc", "injection", "metadata"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "injection", "metadata"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/dvga/templates/owasp/01-api1-bola-delete-paste-mutation.yaml
+++ b/test/dvga/templates/owasp/01-api1-bola-delete-paste-mutation.yaml
@@ -21,7 +21,7 @@ info:
     allowing attackers to delete pastes owned by other users. This template uses a three-phase approach
     to verify the mutation actually persisted: setup confirms resource exists, attack performs unauthorized
     deletion, and verify confirms the resource was deleted (returns null).
-  tags: ["graphql", "dvga", "bola", "authorization", "idor", "mutation", "delete"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dvga", "bola", "authorization", "idor", "mutation", "delete"]
   requires_llm_triage: false
   test_pattern: "mutation"
 

--- a/test/dvga/templates/owasp/02-api1-bola-edit-paste-mutation.yaml
+++ b/test/dvga/templates/owasp/02-api1-bola-edit-paste-mutation.yaml
@@ -21,7 +21,7 @@ info:
     allowing attackers to modify pastes owned by other users. This template uses a three-phase approach
     to verify the mutation actually persisted: setup reads original state, attack performs unauthorized
     modification, and verify confirms the change persisted.
-  tags: ["graphql", "dvga", "bola", "authorization", "idor", "mutation"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dvga", "bola", "authorization", "idor", "mutation"]
   requires_llm_triage: false
   test_pattern: "mutation"
 

--- a/test/dvga/templates/owasp/03-api3-sensitive-data-exposure-dvga.yaml
+++ b/test/dvga/templates/owasp/03-api3-sensitive-data-exposure-dvga.yaml
@@ -5,7 +5,7 @@ info:
   severity: "HIGH"
   author: "hadrian"
   description: "Tests for sensitive data exposure in DVGA's UserObject type. The password field is directly exposed in the GraphQL schema, allowing any authenticated user to query and retrieve plaintext or hashed passwords for all users in the system."
-  tags: ["graphql", "dvga", "sensitive-data", "password-exposure", "information-disclosure"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dvga", "sensitive-data", "password-exposure", "information-disclosure"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/dvga/templates/owasp/04-api8-command-injection-dvga.yaml
+++ b/test/dvga/templates/owasp/04-api8-command-injection-dvga.yaml
@@ -5,7 +5,7 @@ info:
   severity: "CRITICAL"
   author: "hadrian"
   description: "Tests for OS command injection in DVGA's systemDiagnostics query. The cmd parameter is vulnerable to command injection when authentication is bypassed or weak. Attackers can execute arbitrary system commands."
-  tags: ["graphql", "dvga", "command-injection", "rce"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dvga", "command-injection", "rce"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/dvga/templates/owasp/05-api8-information-disclosure-dvga.yaml
+++ b/test/dvga/templates/owasp/05-api8-information-disclosure-dvga.yaml
@@ -5,7 +5,7 @@ info:
   severity: "MEDIUM"
   author: "hadrian"
   description: "Tests for information disclosure vulnerabilities in DVGA's system query endpoints. The systemHealth query exposes sensitive system information without proper authentication. Uses introspection to detect if debug endpoints are exposed in the schema."
-  tags: ["graphql", "dvga", "information-disclosure", "debug-endpoints"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dvga", "information-disclosure", "debug-endpoints"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/dvga/templates/owasp/06-api8-path-traversal-dvga.yaml
+++ b/test/dvga/templates/owasp/06-api8-path-traversal-dvga.yaml
@@ -5,7 +5,7 @@ info:
   severity: "HIGH"
   author: "hadrian"
   description: "Tests for path traversal vulnerabilities in DVGA's uploadPaste mutation. The filename parameter is not properly sanitized, allowing attackers to write files to arbitrary locations on the filesystem using directory traversal sequences."
-  tags: ["graphql", "dvga", "path-traversal", "file-upload"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "dvga", "path-traversal", "file-upload"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/01-api1-bola-get-user.yaml
+++ b/test/grpc-server/templates/owasp/01-api1-bola-get-user.yaml
@@ -4,7 +4,7 @@ info:
   category: "API1:2023 Broken Object Level Authorization"
   severity: "HIGH"
   author: "hadrian-test"
-  tags: ["grpc", "bola", "api1", "authorization", "user-service"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bola", "api1", "authorization", "user-service"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/02-api1-bola-update-user.yaml
+++ b/test/grpc-server/templates/owasp/02-api1-bola-update-user.yaml
@@ -19,7 +19,7 @@ info:
     Phase 3: Verify the user was actually modified by reading it back.
     A successful test indicates the API does not properly validate object-level permissions
     for update operations, which could lead to unauthorized data modification.
-  tags: ["grpc", "bola", "api1", "authorization", "user-service", "write", "mutation"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bola", "api1", "authorization", "user-service", "write", "mutation"]
   requires_llm_triage: true
   test_pattern: "mutation"
 

--- a/test/grpc-server/templates/owasp/03-api1-bola-delete-user.yaml
+++ b/test/grpc-server/templates/owasp/03-api1-bola-delete-user.yaml
@@ -19,7 +19,7 @@ info:
     Phase 3: Verify the user was actually deleted by attempting to read it (should return NOT_FOUND).
     A successful test indicates the API does not properly validate object-level permissions
     for delete operations, which could lead to unauthorized data deletion.
-  tags: ["grpc", "bola", "api1", "authorization", "user-service", "delete", "mutation"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bola", "api1", "authorization", "user-service", "delete", "mutation"]
   requires_llm_triage: true
   test_pattern: "mutation"
 

--- a/test/grpc-server/templates/owasp/04-api1-bola-get-profile.yaml
+++ b/test/grpc-server/templates/owasp/04-api1-bola-get-profile.yaml
@@ -4,7 +4,7 @@ info:
   category: "API1:2023 Broken Object Level Authorization"
   severity: "CRITICAL"
   author: "hadrian-test"
-  tags: ["grpc", "bola", "api1", "authorization", "profile-service", "pii"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bola", "api1", "authorization", "profile-service", "pii"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/05-api1-bola-get-order.yaml
+++ b/test/grpc-server/templates/owasp/05-api1-bola-get-order.yaml
@@ -4,7 +4,7 @@ info:
   category: "API1:2023 Broken Object Level Authorization"
   severity: "CRITICAL"
   author: "hadrian-test"
-  tags: ["grpc", "bola", "api1", "authorization", "order-service", "payment-info"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bola", "api1", "authorization", "order-service", "payment-info"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/06-api2-broken-auth.yaml
+++ b/test/grpc-server/templates/owasp/06-api2-broken-auth.yaml
@@ -4,7 +4,7 @@ info:
   category: "API2:2023 Broken Authentication"
   severity: "CRITICAL"
   author: "hadrian-test"
-  tags: ["grpc", "authentication", "api2", "user-service"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "authentication", "api2", "user-service"]
   requires_llm_triage: false
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/07-api3-sensitive-data-profile.yaml
+++ b/test/grpc-server/templates/owasp/07-api3-sensitive-data-profile.yaml
@@ -4,7 +4,7 @@ info:
   category: "API3:2023 Broken Object Property Level Authorization"
   severity: "HIGH"
   author: "hadrian-test"
-  tags: ["grpc", "sensitive-data", "api3", "pii", "profile-service"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "sensitive-data", "api3", "pii", "profile-service"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/08-api5-bfla-get-config.yaml
+++ b/test/grpc-server/templates/owasp/08-api5-bfla-get-config.yaml
@@ -4,7 +4,7 @@ info:
   category: "API5:2023 Broken Function Level Authorization"
   severity: "CRITICAL"
   author: "hadrian-test"
-  tags: ["grpc", "bfla", "api5", "authorization", "admin-service", "privilege-escalation"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bfla", "api5", "authorization", "admin-service", "privilege-escalation"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/09-api5-bfla-set-config.yaml
+++ b/test/grpc-server/templates/owasp/09-api5-bfla-set-config.yaml
@@ -4,7 +4,7 @@ info:
   category: "API5:2023 Broken Function Level Authorization"
   severity: "CRITICAL"
   author: "hadrian-test"
-  tags: ["grpc", "bfla", "api5", "authorization", "admin-service", "privilege-escalation", "write"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bfla", "api5", "authorization", "admin-service", "privilege-escalation", "write"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/10-api5-bfla-delete-any-user.yaml
+++ b/test/grpc-server/templates/owasp/10-api5-bfla-delete-any-user.yaml
@@ -4,7 +4,7 @@ info:
   category: "API5:2023 Broken Function Level Authorization"
   severity: "CRITICAL"
   author: "hadrian-test"
-  tags: ["grpc", "bfla", "api5", "authorization", "admin-service", "privilege-escalation", "delete"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "bfla", "api5", "authorization", "admin-service", "privilege-escalation", "delete"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/11-api8-metadata-injection.yaml
+++ b/test/grpc-server/templates/owasp/11-api8-metadata-injection.yaml
@@ -4,7 +4,7 @@ info:
   category: "API8:2023 Security Misconfiguration"
   severity: "MEDIUM"
   author: "hadrian-test"
-  tags: ["grpc", "injection", "metadata", "api8", "order-service"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "injection", "metadata", "api8", "order-service"]
   requires_llm_triage: true
   test_pattern: "simple"
 

--- a/test/grpc-server/templates/owasp/12-api8-deadline-manipulation.yaml
+++ b/test/grpc-server/templates/owasp/12-api8-deadline-manipulation.yaml
@@ -4,7 +4,7 @@ info:
   category: "API8:2023 Security Misconfiguration"
   severity: "LOW"
   author: "hadrian-test"
-  tags: ["grpc", "deadline", "timeout", "api8", "order-service", "streaming"]
+  tags: ["grpc", "owasp", "owasp-api-top10", "deadline", "timeout", "api8", "order-service", "streaming"]
   requires_llm_triage: true
   test_pattern: "simple"
 


### PR DESCRIPTION
## Summary

Adds `"owasp"` and `"owasp-api-top10"` tags to the `info.tags` array of 40 templates that already test for OWASP API Top 10 categories but were missing these two tags. This aligns GraphQL/gRPC/test templates with the REST convention so `--category owasp` filtering matches consistently across all three protocols.

## Scope

- `templates/graphql/` — 13 templates
- `templates/grpc/` — 9 templates
- `test/dvga/templates/owasp/` — 6 templates
- `test/grpc-server/templates/owasp/` — 12 templates

## Change

For each file, two tags are inserted immediately after the existing protocol tag, e.g.:

```diff
-  tags: ["graphql", "bola", "authorization"]
+  tags: ["graphql", "owasp", "owasp-api-top10", "bola", "authorization"]
```

No other changes. 40 files, 40 single-line modifications.

## Test plan

- [x] `go build ./cmd/hadrian` passes
- [x] `go test ./...` passes (all packages)
- [x] Each modified file contains both `"owasp"` and `"owasp-api-top10"` after the change

Refs [LAB-2104](https://linear.app/praetorianlabs/issue/LAB-2104/add-consistent-owasp-tags-to-graphql-grpc-and-test-templates)