### PR TITLE
chore(claude-code): bump public-workflows SHA for ready_for_review fix

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@e7c1f39e9219a3256df321445d558e18cf3027c0  # v2.0.11
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@e64522990f20da94ab7554985ae3c27f1e552d85  # v2.0.12
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

- Bumps public-workflows claude-code.yml SHA to include the `ready_for_review` fix
- Points at [public-workflows@e645229](https://github.com/praetorian-inc/public-workflows/commit/e64522990f20da94ab7554985ae3c27f1e552d85) which accepts `ready_for_review` in job `if:` conditions
- Completes the draft-PR fix: callers now deliver the event AND the reusable workflow accepts it

Generated with [Claude Code](https://claude.com/claude-code)
