### PR TITLE
feat: add Gemini PR review workflow

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -1,0 +1,28 @@
+name: Codex PR Review
+
+# Thin caller of the centralized hardened Codex PR reviewer
+# (praetorian-inc/public-workflows). All security posture lives there:
+# same-repo gate, anti-injection prompt, drop-sudo sandbox, Harden-Runner,
+# CODEOWNERS on the reusable workflow file. Do not copy security settings
+# back into this file — always widen via a PR to public-workflows.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: codex-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review:
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@0e318c3be433d9c82dab4cec86ed28429611424e  # update to release tag SHA after public-workflows PR #33 merges
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      model: "gpt-5.4"
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@0e318c3be433d9c82dab4cec86ed28429611424e  # update to release tag SHA after public-workflows PR #33 merges
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@c53011b16f91273b2e8bf7b3981d5e64a9d4ad31  # v2.1.0 (codex-code.yml)
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -1,0 +1,24 @@
+name: Gemini PR Review
+
+# Thin caller of the centralized hardened Gemini PR reviewer
+# (praetorian-inc/public-workflows). All security posture lives there.
+# Do not copy security settings back into this file.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: gemini-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gemini-review:
+    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@7207401d1ad8a10ea4289b73a458068787d249af  # update to release tag SHA after merge
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   gemini-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@7207401d1ad8a10ea4289b73a458068787d249af  # update to release tag SHA after merge
+    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@cde8b58405ce8b7ebd30a8b478a32921aba49215  # v2.1.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -1,12 +1,8 @@
-name: Gemini PR Review
-
-# Thin caller of the centralized hardened Gemini PR reviewer
-# (praetorian-inc/public-workflows). All security posture lives there.
-# Do not copy security settings back into this file.
+name: Gemini PR Assistant
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, ready_for_review]
   pull_request_review_comment:
     types: [created]
 
@@ -16,6 +12,9 @@ concurrency:
 
 jobs:
   gemini-review:
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@gemini'))
     uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@cde8b58405ce8b7ebd30a8b478a32921aba49215  # v2.1.0
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Adds AI PR review workflow(s) as thin callers to centralized reusable workflows in `praetorian-inc/public-workflows`
- All security posture managed centrally (CODEOWNERS-gated)

**Depends on:** https://github.com/praetorian-inc/public-workflows/pull/33

## Test plan

- [ ] Merge dependent public-workflows PRs first
- [ ] Verify review posts on a test PR
- [ ] Monitor API costs

🤖 Generated with [Claude Code](https://claude.com/claude-code)