### PR TITLE
fix(test): repair setup-live-targets.sh for reproducible crAPI live tests (LAB-2247)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,24 @@ Built-in safeguards in `pkg/runner/ratelimit_client.go`:
 
 ## Testing with crAPI
 
-The `test/crapi/` directory contains a complete example for testing [OWASP crAPI](https://github.com/OWASP/crAPI), an intentionally vulnerable API. See `test/crapi/README.md` for full setup instructions.
+The `test/crapi/` directory contains a complete example for testing [OWASP crAPI](https://github.com/OWASP/crAPI), an intentionally vulnerable API. The supported flow is the wrapper scripts under `test/`:
 
-Quick start:
 ```bash
-# Start crAPI (note: compose file is in deploy/docker/)
-git clone https://github.com/OWASP/crAPI.git && cd crAPI/deploy/docker && docker-compose up -d
+# One-time setup: clones crAPI, patches its compose to bind 8888,
+# starts the stack, signs up canonical users, writes .live-test-config.
+./test/setup-live-targets.sh --targets crapi
 
-# Run Hadrian (after setting up test users and tokens per the README)
+# Run hadrian against the prepared target.
+./test/run-live-tests.sh --targets crapi
+
+# Tear down (volumes too — required for repeatable runs).
+./test/setup-live-targets.sh --teardown
+```
+
+Note: upstream crAPI's compose default has shifted between 8888 and 8889 over time; `setup-live-targets.sh` auto-detects the current upstream port and patches the compose so hadrian's downstream code keeps using whatever you resolve. See `test/crapi/README.md` for the canonical user credentials, port-override env vars, and a manual fallback flow.
+
+Programmatic invocation (without the wrapper):
+```bash
 HADRIAN_TEMPLATES=test/crapi/templates/rest ./hadrian test \
   --api test/crapi/crapi-openapi-spec.json \
   --roles test/crapi/roles.yaml \

--- a/test/README.md
+++ b/test/README.md
@@ -21,6 +21,9 @@ Automated security testing against four intentionally vulnerable applications co
 
 # Or set up specific targets only
 ./test/setup-live-targets.sh --targets vulnerable-api,grpc
+
+# Skip rebuild on re-runs (useful when iterating)
+./test/setup-live-targets.sh --no-build
 ```
 
 The setup script handles:
@@ -29,8 +32,17 @@ The setup script handles:
 - Generating protobuf code for gRPC server
 - Pulling Docker images (dvga)
 - Cloning and starting crAPI (8 Docker containers)
-- Auto-resolving port conflicts (finds next available port)
-- Writing a config file (`.live-test-config`) with resolved ports
+- Auto-resolving port conflicts: walks forward from each target's
+  default port and skips ports already claimed by another target in
+  the same run. If discovery still picks badly, set
+  `<TARGET>_PORT_OVERRIDE` (see [Configuration](#configuration)).
+- Signing up the canonical crAPI users (see
+  [test/crapi/README.md](crapi/README.md))
+- Writing the patched OpenAPI spec to `.live-test-cache/`
+- Writing a config file (`.live-test-config`) with resolved ports and
+  the patched-spec path
+- Hard-failing (`exit 1`) if crAPI does not become ready within 180s,
+  so CI doesn't treat a partial setup as success
 
 ### 2. Run Tests
 
@@ -58,7 +70,16 @@ The setup script handles:
 ```bash
 # Stop all services and clean up
 ./test/setup-live-targets.sh --teardown
+
+# Also remove the cached crAPI clone (forces a fresh re-clone next setup)
+./test/setup-live-targets.sh --teardown --purge
 ```
+
+`--teardown` runs `docker compose down -v --remove-orphans` for crAPI, so
+named Postgres/Mongo volumes are dropped along with the containers.
+Without `-v`, leftover state would cause "phone number already
+registered" errors on the next setup. Stderr from the docker calls is
+surfaced (not swallowed) so failures are visible.
 
 ## What the Test Runner Does
 
@@ -81,6 +102,13 @@ For each target, `run-live-tests.sh` automatically:
 | grpc-server | Uses pre-configured static tokens |
 | crapi | Creates 4 users (admin, user1, user2, mechanic), gets tokens, uploads test videos |
 
+Canonical crAPI user identities (emails, mechanic code, default
+password) and the `crapi_signup`/`crapi_login`/`crapi_setup_users`/
+`crapi_patch_openapi_spec` helpers live in
+[`crapi/crapi-helpers.sh`](crapi/crapi-helpers.sh). Both
+`run-live-tests.sh` and `test-llm-planner.sh` source it so all crAPI
+test paths share the same accounts and spec-patching logic.
+
 ### vulnerable-api Multi-Auth Testing
 
 The vulnerable-api is tested three times, once per authentication method:
@@ -97,14 +125,24 @@ The server is restarted with each `AUTH_METHOD` and API data is reset between ru
 
 ### Environment Variables
 
-All ports can be overridden via environment variables:
+**At setup time** (binds services to specific ports), set `*_PORT_OVERRIDE`:
+
+```bash
+VULN_API_PORT_OVERRIDE=9080 ./test/setup-live-targets.sh --targets vulnerable-api
+CRAPI_PORT_OVERRIDE=8895    ./test/setup-live-targets.sh --targets crapi
+```
+
+**At run time** (when services are already running on non-default ports),
+set the bare `*_PORT` env var so `run-live-tests.sh` connects to the right place:
 
 ```bash
 VULN_API_PORT=9080 ./test/run-live-tests.sh --targets vulnerable-api
-DVGA_PORT=5014 ./test/run-live-tests.sh --targets dvga
-GRPC_PORT=50052 ./test/run-live-tests.sh --targets grpc
-CRAPI_PORT=8889 ./test/run-live-tests.sh --targets crapi
+CRAPI_PORT=8895    ./test/run-live-tests.sh --targets crapi
 ```
+
+Normally you don't need either — `setup-live-targets.sh` writes
+`.live-test-config` with the resolved ports and `run-live-tests.sh` reads
+that automatically.
 
 ### Config File
 
@@ -114,7 +152,7 @@ CRAPI_PORT=8889 ./test/run-live-tests.sh --targets crapi
 
 | Target | Default Port |
 |--------|-------------|
-| vulnerable-api | 8889 |
+| vulnerable-api | 9889 |
 | dvga | 5013 |
 | grpc-server | 50051 |
 | crapi | 8888 |
@@ -145,9 +183,25 @@ test/.results/
 
 ### Port conflicts
 
-The setup script auto-resolves port conflicts by finding the next available port. If you see issues, check:
+`setup-live-targets.sh` walks forward from each target's default port
+and skips ports already claimed by another target in the same run, so
+common dev-machine collisions (e.g. VS Code Live Preview on 8888)
+resolve automatically.
+
+If the auto-pick still picks badly — for instance, you want crAPI on a
+specific port — use the override env var:
+
 ```bash
-lsof -i :8888  # Check what's using a port
+CRAPI_PORT_OVERRIDE=8895 ./test/setup-live-targets.sh --targets crapi
+```
+
+Override env vars: `VULN_API_PORT_OVERRIDE`, `DVGA_PORT_OVERRIDE`,
+`GRPC_PORT_OVERRIDE`, `CRAPI_PORT_OVERRIDE`. They're collision-checked
+against both the host and other targets in the same run.
+
+To inspect what's holding a port:
+```bash
+lsof -i :8888
 ```
 
 ### dvga not responding
@@ -175,20 +229,43 @@ make build
 ./test/setup-live-targets.sh --teardown  # Clean up
 ```
 
+## Regression harness
+
+`test/regression/lab-2247-regression-tests.sh` is a fast, Docker-free
+harness that asserts the **shape** of every fix from LAB-2247. Run it
+in CI before the end-to-end flow — it catches a regression of any
+individual bug fix in seconds without needing a live crAPI:
+
+```bash
+bash test/regression/lab-2247-regression-tests.sh
+# Tests run: 101, Tests failed: 0
+```
+
+Add a new assertion when you change any of: the safety regex in
+`run-live-tests.sh` / `test-llm-planner.sh`, the heredoc in
+`setup-live-targets.sh`, or any helper in `crapi-helpers.sh`. Same idea
+as a unit test in a language with one — bash has none, this is the
+substitute.
+
 ## Directory Structure
 
 ```
 test/
-  setup-live-targets.sh    # One-time setup (this file)
-  run-live-tests.sh        # Test runner
+  setup-live-targets.sh    # One-time setup
+  run-live-tests.sh        # End-to-end test runner
+  test-llm-planner.sh      # LLM-planner regression tests
   README.md                # This file
-  .live-test-config        # Auto-generated port config (gitignored)
+  .live-test-config        # Auto-generated port + path config (gitignored)
+  .live-test-cache/        # Patched OpenAPI specs (gitignored)
   .results/                # JSON test results (gitignored)
-  .crapi-repo/             # Cloned crAPI repo (gitignored)
+  .crapi-repo/             # Cloned crAPI repo (gitignored, --purge to remove)
+  regression/
+    lab-2247-regression-tests.sh   # Shape harness for LAB-2247 fixes
   vulnerable-api/          # REST vulnerable API source + templates
   dvga/                    # GraphQL test config + templates
   grpc-server/             # gRPC server source + templates
   crapi/                   # crAPI test config + templates
+    crapi-helpers.sh       # Shared signup/login/spec-patch helpers
 ```
 
 ## Expected result

--- a/test/crapi/README.md
+++ b/test/crapi/README.md
@@ -2,68 +2,111 @@
 
 Configuration files for testing [OWASP crAPI](https://github.com/OWASP/crAPI) with Hadrian.
 
-## Setup
+## Recommended: automated setup
+
+`test/setup-live-targets.sh` handles everything below — clone, start,
+patch the compose to bind crAPI to your chosen port, sign up the
+canonical users, and write a config file `run-live-tests.sh` and
+`test-llm-planner.sh` consume:
+
+```bash
+# From the repository root
+./test/setup-live-targets.sh --targets crapi
+./test/run-live-tests.sh     --targets crapi
+```
+
+See [`test/README.md`](../README.md) for the full workflow, including
+port-override env vars and `--teardown --purge`.
+
+### Canonical users (created by `setup-live-targets.sh`)
+
+The setup script signs up these accounts via
+[`crapi-helpers.sh`](crapi-helpers.sh). All values are overridable via
+environment variables of the same name before invoking setup.
+
+| Role     | Email                          | Phone        | Password (`CRAPI_PASSWORD`) |
+|----------|--------------------------------|--------------|-----------------------------|
+| admin    | `hadrian-admin@test.com`       | `1111111111` | `HadrianTest123!`           |
+| user     | `hadrian-user1@test.com`       | `2222222222` | `HadrianTest123!`           |
+| user2    | `hadrian-user2@test.com`       | `3333333333` | `HadrianTest123!`           |
+| mechanic | `hadrian-mechanic@test.com`    | `4444444444` | `HadrianTest123!` (`mechanic_code` `TRAC_MECH1`) |
+
+`setup-live-targets.sh` also writes a port-patched copy of
+`crapi-openapi-spec.json` to `test/.live-test-cache/` and emits its path
+as `CRAPI_SPEC_FILE` in `.live-test-config`. Downstream scripts read
+that path so they always point hadrian at the port crAPI is actually
+listening on, regardless of upstream's compose default.
+
+## Manual setup (fallback)
+
+If you'd rather start crAPI by hand — for development, debugging
+upstream compose issues, or running hadrian without the wrapper
+scripts — these are the underlying steps.
 
 ### 1. Start crAPI
 
 ```bash
-# Clone crAPI
 git clone https://github.com/OWASP/crAPI.git
-
-# Start with Docker Compose (note: compose file is in deploy/docker/)
 cd crAPI/deploy/docker
-docker-compose up -d
+docker compose up -d
 ```
 
-**Troubleshooting**: If containers fail with "No space left on device" errors, run `docker system prune -a` to free up disk space, then retry.
+**Troubleshooting**: If containers fail with "No space left on device"
+errors, run `docker system prune -a` to free up disk space, then retry.
 
 crAPI will be available at:
-- **Web UI**: http://localhost:8888
+- **Web UI**: http://localhost:8888 (set by `setup-live-targets.sh` via
+  the compose patch; upstream's current default is 8889 — check
+  `docker port crapi-web 80`)
 - **Email (MailHog)**: http://localhost:8025
 
-### 2. Create Test Users
+### 2. Create test users
 
-Create accounts for each role:
+You can run the canonical-roster signup with one call:
 
 ```bash
-# User 1 (regular user)
+. test/crapi/crapi-helpers.sh
+crapi_setup_users http://localhost:8888
+```
+
+Or do it manually with `curl`. The values below match the **canonical
+roster** that `crapi-helpers.sh` provisions, so `run-live-tests.sh` and
+`test-llm-planner.sh` will recognize the accounts you create here:
+
+```bash
+# user1 — canonical "user" role
 curl -X POST http://localhost:8888/identity/api/auth/signup \
   -H "Content-Type: application/json" \
-  -d '{"email":"user1@test.com","name":"Test User 1","number":"1234567890","password":"TestPass123"}'
+  -d '{"email":"hadrian-user1@test.com","name":"Hadrian User1","number":"2222222222","password":"HadrianTest123!"}'
 
-# User 2 (for BOLA testing)
+# user2 — canonical "user2" role (BOLA target)
 curl -X POST http://localhost:8888/identity/api/auth/signup \
   -H "Content-Type: application/json" \
-  -d '{"email":"user2@test.com","name":"Test User 2","number":"0987654321","password":"TestPass123"}'
+  -d '{"email":"hadrian-user2@test.com","name":"Hadrian User2","number":"3333333333","password":"HadrianTest123!"}'
 
-# Mechanic
+# mechanic — canonical "mechanic" role
 curl -X POST http://localhost:8888/workshop/api/mechanic/signup \
   -H "Content-Type: application/json" \
-  -d '{"email":"mechanic@test.com","name":"Test Mechanic","number":"5555555555","password":"TestPass123","mechanic_code":"MECH001"}'
+  -d '{"email":"hadrian-mechanic@test.com","name":"Hadrian Mechanic","number":"4444444444","password":"HadrianTest123!","mechanic_code":"TRAC_MECH1"}'
 ```
 
-### 3. Get JWT Tokens
-
-Login with each user to get JWT tokens:
+### 3. Get JWT tokens
 
 ```bash
-# Get user token
 curl -X POST http://localhost:8888/identity/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"user1@test.com","password":"TestPass123"}' | jq -r '.token'
+  -d '{"email":"hadrian-user1@test.com","password":"HadrianTest123!"}' | jq -r '.token'
 
-# Get user2 token
 curl -X POST http://localhost:8888/identity/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"user2@test.com","password":"TestPass123"}' | jq -r '.token'
+  -d '{"email":"hadrian-user2@test.com","password":"HadrianTest123!"}' | jq -r '.token'
 
-# Get mechanic token
 curl -X POST http://localhost:8888/identity/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"mechanic@test.com","password":"TestPass123"}' | jq -r '.token'
+  -d '{"email":"hadrian-mechanic@test.com","password":"HadrianTest123!"}' | jq -r '.token'
 ```
 
-### 4. Set Environment Variables
+### 4. Set environment variables
 
 Create a `.env` file in this directory with your tokens:
 
@@ -77,29 +120,30 @@ CRAPI_ADMIN_TOKEN=eyJ...
 
 Note: The `.env` file is gitignored to prevent committing secrets.
 
-### 5. Upload Test Videos (Required for BFLA/BOPLA tests)
+### 5. Upload test videos (required for BFLA/BOPLA tests)
 
-The BFLA and BOPLA mass assignment tests require each user to have an uploaded video:
+The BFLA and BOPLA mass assignment tests require each user to have an
+uploaded video:
 
 ```bash
-# Run the setup script (requires .env file with tokens)
 ./test/crapi/setup-videos.sh
 ```
 
-This script uploads test videos for user, user2, and mechanic accounts. The videos are required because:
+This script uploads test videos for user, user2, and mechanic accounts.
+The videos are required because:
 - **BFLA test**: Detects if regular users can delete admin videos
 - **BOPLA test**: Detects mass assignment via ID field injection in video updates
 
+`run-live-tests.sh` does the equivalent video upload automatically.
+
 ### 6. (Optional) Start Burp Suite
 
-If you want to inspect requests in Burp Suite, start it and configure the proxy listener on `127.0.0.1:8080`.
+If you want to inspect requests in Burp Suite, start it and configure
+the proxy listener on `127.0.0.1:8080`.
 
 ### 7. Run Hadrian
 
-From the repository root:
-
 ```bash
-# Load environment variables and run tests
 set -a && source test/crapi/.env && set +a && \
 HADRIAN_TEMPLATES=test/crapi/templates/rest ./hadrian test \
   --api test/crapi/crapi-openapi-spec.json \
@@ -110,26 +154,27 @@ HADRIAN_TEMPLATES=test/crapi/templates/rest ./hadrian test \
 # Optional: add --proxy http://127.0.0.1:8080 to route through Burp Suite
 ```
 
-## Expected Vulnerabilities
+## Expected vulnerabilities
 
 crAPI is intentionally vulnerable. Hadrian should detect:
 
 | OWASP Category | Vulnerability | Endpoint Example | Template |
 |----------------|---------------|------------------| -------- |
-| API1:2023 | ✅ BOLA - Access other user's vehicle | `GET /identity/api/v2/vehicle/{vehicleId}/location` | `01-api1-bola-read.yaml` |
-| API1:2023 | ✅ BOLA - Access other user's order | `GET /workshop/api/shop/orders/{order_id}` |  `01-api1-bola-read.yaml` |
-| API2:2023 | ✅ Broken Auth - No rate limit on OTP | `POST /identity/api/auth/v2/check-otp` | `03-api2-otp-bruteforce` |
-| API3:2023 | ✅ BOPLA - Mass assignment via ID injection | `PUT /identity/api/v2/user/videos/{video_id}` | `05-api3-bopla-mass-assignment.yaml` |
-| API5:2023 | ✅ BFLA - User deleting admin videos | `DELETE /identity/api/v2/admin/videos/{video_id}` | `06-api5-bfla-admin-video-delete.yaml` |
+| API1:2023 | BOLA - Access other user's vehicle | `GET /identity/api/v2/vehicle/{vehicleId}/location` | `01-api1-bola-read.yaml` |
+| API1:2023 | BOLA - Access other user's order | `GET /workshop/api/shop/orders/{order_id}` |  `01-api1-bola-read.yaml` |
+| API2:2023 | Broken Auth - No rate limit on OTP | `POST /identity/api/auth/v2/check-otp` | `03-api2-otp-bruteforce` |
+| API3:2023 | BOPLA - Mass assignment via ID injection | `PUT /identity/api/v2/user/videos/{video_id}` | `05-api3-bopla-mass-assignment.yaml` |
+| API5:2023 | BFLA - User deleting admin videos | `DELETE /identity/api/v2/admin/videos/{video_id}` | `06-api5-bfla-admin-video-delete.yaml` |
 
-## Expected No Vulnerabilities
-crAPI is does not have the following vulnerability. Hadrian should not detect:
+## Expected absence of vulnerabilities
+
+crAPI does not have the following vulnerability. Hadrian should not detect:
 
 | OWASP Category | Vulnerability | Endpoint Example | Template |
 |----------------|---------------|------------------| -------- |
-| API1:2023 | ✅ BOLA - Access other user's video | `GET /identity/api/v2/user/videos/{video_id}` |  `02-api1-bola-video-mutation.yaml` |
+| API1:2023 | BOLA - Access other user's video | `GET /identity/api/v2/user/videos/{video_id}` |  `02-api1-bola-video-mutation.yaml` |
 
-## Roles Overview
+## Roles overview
 
 | Role | Description | Token Env Var |
 |------|-------------|---------------|

--- a/test/crapi/crapi-helpers.sh
+++ b/test/crapi/crapi-helpers.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# =============================================================================
+# crapi-helpers.sh
+#
+# Shared crAPI helpers for the live-test scripts. SOURCE THIS FILE — do not
+# execute it directly. It defines:
+#
+#   - Canonical user identities (CRAPI_*_EMAIL, CRAPI_PASSWORD, etc.) used by
+#     setup-live-targets.sh, run-live-tests.sh, and test-llm-planner.sh so
+#     every test against crAPI uses the same accounts. All values are
+#     overridable via environment variables.
+#
+#   - crapi_signup, crapi_login, crapi_mechanic_signup: thin wrappers around
+#     the corresponding HTTP endpoints. Idempotent — duplicate signup against
+#     a dirty DB is silently ignored.
+#
+#   - crapi_setup_users: signs up the full canonical roster (admin, two
+#     users, mechanic). Safe to call multiple times.
+#
+#   - crapi_patch_openapi_spec: copies the OpenAPI spec to a destination
+#     directory, substituting localhost:<default> with localhost:<port>.
+#     Echoes the resulting path. Used by every script that points hadrian at
+#     the spec when CRAPI_PORT differs from the spec's hardcoded default.
+#
+# Sourcing this file does NOT make any network calls. The functions only
+# touch the network when invoked.
+# =============================================================================
+
+# Default port the spec hardcodes. Used when patching to a different port.
+: "${CRAPI_OPENAPI_SPEC_DEFAULT_PORT:=8888}"
+
+# Canonical user identities. Each script that talks to crAPI uses these so
+# the DB ends up with the same users regardless of entry point.
+: "${CRAPI_PASSWORD:=HadrianTest123!}"
+: "${CRAPI_ADMIN_EMAIL:=hadrian-admin@test.com}"
+: "${CRAPI_ADMIN_NUMBER:=1111111111}"
+: "${CRAPI_USER_EMAIL:=hadrian-user1@test.com}"
+: "${CRAPI_USER_NUMBER:=2222222222}"
+: "${CRAPI_USER2_EMAIL:=hadrian-user2@test.com}"
+: "${CRAPI_USER2_NUMBER:=3333333333}"
+: "${CRAPI_MECHANIC_EMAIL:=hadrian-mechanic@test.com}"
+: "${CRAPI_MECHANIC_NUMBER:=4444444444}"
+: "${CRAPI_MECHANIC_CODE:=TRAC_MECH1}"
+
+# _crapi_json <key=value>... — emits a JSON object with each key set to
+# the corresponding value, using python3's json.dumps to handle
+# escaping. We use python3 here because every other crAPI helper
+# already requires it (login parses the token), and printf-built JSON
+# silently breaks if a value contains '"' or '\' — overrides like
+# CRAPI_PASSWORD='ab"cd' or names with backslashes would produce
+# malformed bodies that the API rejects, surfacing only as silent
+# retry exhaustion.
+_crapi_json() {
+    python3 -c '
+import json, sys
+out = {}
+for arg in sys.argv[1:]:
+    k, _, v = arg.partition("=")
+    out[k] = v
+sys.stdout.write(json.dumps(out))
+' "$@"
+}
+
+# crapi_signup <base_url> <email> <name> <number> <password>
+# Returns 0 always; signup against an already-registered email is treated
+# as success.
+crapi_signup() {
+    local base_url="$1" email="$2" name="$3" number="$4" password="$5"
+    _crapi_json "email=$email" "name=$name" "number=$number" "password=$password" | \
+        curl -sf -X POST "${base_url}/identity/api/auth/signup" \
+            -H "Content-Type: application/json" \
+            --data-binary @- 2>/dev/null || true
+}
+
+# crapi_login <base_url> <email> <password>
+# Echoes the bearer token, or empty string on failure.
+crapi_login() {
+    local base_url="$1" email="$2" password="$3"
+    _crapi_json "email=$email" "password=$password" | \
+        curl -sf -X POST "${base_url}/identity/api/auth/login" \
+            -H "Content-Type: application/json" \
+            --data-binary @- 2>/dev/null | \
+        python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo ""
+}
+
+# crapi_mechanic_signup <base_url> <email> <name> <number> <password> <code>
+crapi_mechanic_signup() {
+    local base_url="$1" email="$2" name="$3" number="$4" password="$5" code="$6"
+    _crapi_json "email=$email" "name=$name" "number=$number" "password=$password" "mechanic_code=$code" | \
+        curl -sf -X POST "${base_url}/workshop/api/mechanic/signup" \
+            -H "Content-Type: application/json" \
+            --data-binary @- 2>/dev/null || true
+}
+
+# _crapi_provision_user <base_url> <kind: regular|mechanic> <email> <name> <number> <password> [code]
+# Signs up a single user, then verifies the result by attempting a
+# login. Retries the signup up to CRAPI_PROVISION_RETRIES (default 5)
+# times with linear backoff if verification fails — crAPI's identity
+# and workshop services intermittently 4xx during the first few seconds
+# after boot, and `crapi_signup` swallows that silently because it can
+# also legitimately mean "user already exists." The login probe
+# disambiguates: a non-empty token proves the row actually landed.
+# Idempotent: a pre-existing user takes the fast path because login
+# succeeds on the first try.
+_crapi_provision_user() {
+    local base_url="$1" kind="$2" email="$3" name="$4" number="$5" password="$6" code="${7:-}"
+    local attempts="${CRAPI_PROVISION_RETRIES:-5}"
+    local i=0
+    while [ "$i" -lt "$attempts" ]; do
+        i=$((i + 1))
+        if [ "$kind" = "mechanic" ]; then
+            crapi_mechanic_signup "$base_url" "$email" "$name" "$number" "$password" "$code" >/dev/null
+        else
+            crapi_signup "$base_url" "$email" "$name" "$number" "$password" >/dev/null
+        fi
+        local token
+        token=$(crapi_login "$base_url" "$email" "$password")
+        if [ -n "$token" ]; then
+            return 0
+        fi
+        sleep $((i * 2))
+    done
+    echo "ERROR: could not provision crAPI user $email after $attempts attempts" >&2
+    return 1
+}
+
+# crapi_setup_users <base_url>
+# Signs up the canonical roster, verifying each user by login before
+# moving on. Idempotent. Returns non-zero if any user could not be
+# provisioned after retries.
+crapi_setup_users() {
+    local base_url="$1"
+    _crapi_provision_user "$base_url" regular  "$CRAPI_ADMIN_EMAIL"    "Hadrian Admin"    "$CRAPI_ADMIN_NUMBER"    "$CRAPI_PASSWORD" || return 1
+    _crapi_provision_user "$base_url" regular  "$CRAPI_USER_EMAIL"     "Hadrian User1"    "$CRAPI_USER_NUMBER"     "$CRAPI_PASSWORD" || return 1
+    _crapi_provision_user "$base_url" regular  "$CRAPI_USER2_EMAIL"    "Hadrian User2"    "$CRAPI_USER2_NUMBER"    "$CRAPI_PASSWORD" || return 1
+    _crapi_provision_user "$base_url" mechanic "$CRAPI_MECHANIC_EMAIL" "Hadrian Mechanic" "$CRAPI_MECHANIC_NUMBER" "$CRAPI_PASSWORD" "$CRAPI_MECHANIC_CODE" || return 1
+}
+
+# crapi_patch_openapi_spec <src_spec_path> <target_port> <dest_dir>
+# Copies the spec to <dest_dir>/crapi-openapi-spec.json, substituting the
+# default port with <target_port>. If <target_port> equals the default,
+# echoes <src_spec_path> unchanged (no copy). Echoes the spec path on
+# stdout. Returns non-zero on failure.
+crapi_patch_openapi_spec() {
+    local src="$1" target_port="$2" dest_dir="$3"
+    if [ ! -f "$src" ]; then
+        echo "crapi_patch_openapi_spec: source spec not found: $src" >&2
+        return 1
+    fi
+    if [ "$target_port" = "$CRAPI_OPENAPI_SPEC_DEFAULT_PORT" ]; then
+        echo "$src"
+        return 0
+    fi
+    mkdir -p "$dest_dir"
+    local dst="${dest_dir}/crapi-openapi-spec.json"
+    sed "s|http://localhost:${CRAPI_OPENAPI_SPEC_DEFAULT_PORT}|http://localhost:${target_port}|g" \
+        "$src" > "$dst"
+    # Validate the substitution actually landed. If the source spec no
+    # longer contains localhost:<default> (e.g. upstream changed the
+    # spec format or hostname), sed silently produces a copy with no
+    # change and downstream callers point hadrian at the wrong port. Be
+    # loud — same defense pattern as patch_crapi_compose_port.
+    if ! grep -q "localhost:${target_port}" "$dst"; then
+        echo "crapi_patch_openapi_spec: substitution did not land in $dst (source missing localhost:${CRAPI_OPENAPI_SPEC_DEFAULT_PORT}?)" >&2
+        rm -f "$dst"
+        return 1
+    fi
+    echo "$dst"
+}

--- a/test/crapi/port-helpers.sh
+++ b/test/crapi/port-helpers.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# =============================================================================
+# port-helpers.sh
+#
+# Pure (no global state) port + crAPI-compose helpers. SOURCE THIS FILE —
+# do not execute. Functions defined here:
+#
+#   - port_in_use <port>             OS-level check (lsof/ss/dev-tcp fallback)
+#   - find_available_port <base> [excluded...]   walks forward, skips OS-busy
+#                                                AND in-run-claimed ports
+#   - _port_excluded <needle> [hay...]   private; helper for find_available_port
+#   - resolve_target_port <override> <default> <label> [claimed...]
+#                                    honors *_PORT_OVERRIDE env vars then
+#                                    falls back to find_available_port,
+#                                    collision-checks against host + claimed
+#   - patch_crapi_compose_port <compose_file> <target_port>
+#                                    auto-detects upstream's current crAPI
+#                                    web port, rewrites it to target_port,
+#                                    validates the patch landed
+#
+# Each function relies on log_info / log_ok / log_warn / log_fail being
+# defined in the sourcing scope (setup-live-targets.sh provides them; the
+# regression harness stubs them with no-ops). This is intentional: the
+# helpers are I/O-light and let the consumer decide formatting.
+#
+# Sourced by:
+#   - test/setup-live-targets.sh — production use
+#   - test/regression/lab-2247-regression-tests.sh — single source of truth
+#     for the regression harness, so a prod-source change can't drift away
+#     from what the harness asserts (formerly inlined; see LAB-2247
+#     iteration-2 review TEST-003).
+# =============================================================================
+
+# port_in_use <port>
+# Returns 0 (true) iff the OS reports something using the given port.
+# `lsof -i :PORT` reports ALL socket states (LISTEN + ESTABLISHED +
+# TIME_WAIT + ...). To match that with ss we need `-a` (all states).
+# Earlier iterations used `-ltn` (listen-only) which missed
+# ESTABLISHED/TIME_WAIT, then `-tn` (non-listening) which missed LISTEN
+# entirely — both produced false-frees that find_available_port would
+# then hand out. `-atn` covers everything ss can show.
+port_in_use() {
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -i :"$1" >/dev/null 2>&1
+    elif command -v ss >/dev/null 2>&1; then
+        ss -atn | grep -q ":$1 "
+    else
+        # Fallback: try to connect
+        (echo >/dev/tcp/localhost/"$1") 2>/dev/null
+    fi
+}
+
+# _port_excluded <needle> [hay...]
+# Returns 0 iff <needle> is in the [hay...] list. Private helper — find_available_port
+# uses this to skip ports claimed earlier in the same setup run.
+_port_excluded() {
+    local needle=$1
+    shift
+    local p
+    for p in "$@"; do
+        [ "$p" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+# find_available_port <base_port> [excluded_port]...
+# Walks forward from base_port until it finds a port that is both not in
+# use by the OS AND not in the excluded list. The excluded list is how
+# callers tell us about ports they've already claimed earlier in the same
+# setup run — those ports are still "free" from the OS's perspective
+# (nothing is bound there yet), but binding to them later would collide.
+# Echoes the resolved port on stdout, or empty + non-zero on no-port-found.
+find_available_port() {
+    local base_port=$1
+    shift
+    local excluded=("$@")
+    local port=$base_port
+    while port_in_use "$port" || _port_excluded "$port" "${excluded[@]+"${excluded[@]}"}"; do
+        port=$((port + 1))
+        if [ $((port - base_port)) -gt 20 ]; then
+            echo ""
+            return 1
+        fi
+    done
+    echo "$port"
+}
+
+# resolve_target_port <override_value> <default_port> <label> [claimed_port]...
+# Resolves a port for one target:
+# - if <override_value> is non-empty, validate it isn't OS-busy and isn't
+#   already claimed by another target in the same run; on conflict log
+#   fail-mode diagnostics to stderr (via log_fail) and return 1.
+# - otherwise call find_available_port from <default_port> skipping the
+#   already-claimed list.
+# Echoes the resolved port on stdout. log_fail must be defined in the
+# sourcing scope.
+resolve_target_port() {
+    local override_value=$1 default_port=$2 label=$3
+    shift 3
+    local claimed=("$@")
+    if [ -n "$override_value" ]; then
+        if port_in_use "$override_value"; then
+            log_fail "${label}: override port ${override_value} is already in use"
+            return 1
+        fi
+        if _port_excluded "$override_value" "${claimed[@]+"${claimed[@]}"}"; then
+            log_fail "${label}: override port ${override_value} collides with another target"
+            return 1
+        fi
+        echo "$override_value"
+        return 0
+    fi
+    local resolved
+    resolved=$(find_available_port "$default_port" "${claimed[@]+"${claimed[@]}"}")
+    if [ -z "$resolved" ]; then
+        log_fail "No available port near ${default_port} for ${label}"
+        return 1
+    fi
+    echo "$resolved"
+}
+
+# patch_crapi_compose_port <compose_file> <target_port>
+# Rewrites the crAPI public web port mapping in <compose_file> to bind to
+# <target_port>. Auto-detects the current upstream port (its first
+# `${LISTEN_IP...}:N:80` line that isn't 30080) so a future upstream
+# rebase doesn't silently no-op the patch. Validates the rewrite by grep
+# before returning success. log_info/log_ok/log_fail must be defined.
+patch_crapi_compose_port() {
+    local compose_file="$1"
+    local target_port="$2"
+    local current_port
+
+    # Find the LISTEN_IP-prefixed :N:80 mapping (the crAPI public web
+    # port), excluding the 30080 HTTP redirector. Upstream's syntax is
+    # "${LISTEN_IP:-127.0.0.1}:N:80".
+    current_port=$(grep -oE '\$\{LISTEN_IP[^}]*\}:[0-9]+:80"' "$compose_file" 2>/dev/null \
+        | sed -E 's/.*:([0-9]+):80".*/\1/' \
+        | grep -v '^30080$' \
+        | head -1)
+
+    if [ -z "$current_port" ]; then
+        log_fail "Cannot find crapi-web :N:80 port mapping in $compose_file"
+        log_info "Upstream compose syntax may have changed. Inspect manually:"
+        log_info "  grep -nE ':[0-9]+:80' $compose_file"
+        return 1
+    fi
+
+    if [ "$current_port" = "$target_port" ]; then
+        log_ok "crAPI compose already bound to port $target_port (no patch needed)"
+        return 0
+    fi
+
+    log_info "Patching crAPI compose port: ${current_port} -> ${target_port}"
+    sed -i.bak -E \
+        "s|(\\\$\\{LISTEN_IP[^}]*\\}):${current_port}:80\"|\\1:${target_port}:80\"|" \
+        "$compose_file"
+
+    # Validate the patch actually landed.
+    if grep -qE "\\\$\\{LISTEN_IP[^}]*\\}:${target_port}:80\"" "$compose_file"; then
+        log_ok "Patched crAPI compose to port $target_port"
+        return 0
+    fi
+
+    log_fail "Compose patch did not land. Compose still references port $current_port."
+    return 1
+}

--- a/test/regression/lab-2247-regression-tests.sh
+++ b/test/regression/lab-2247-regression-tests.sh
@@ -1,0 +1,1191 @@
+#!/usr/bin/env bash
+# =============================================================================
+# lab-2247-regression-tests.sh
+#
+# Regression harness for LAB-2247
+# (https://linear.app/praetorianlabs/issue/LAB-2247).
+#
+# The 11 bugs called out in that ticket all sit in the live-test setup
+# scripts (test/setup-live-targets.sh, test/run-live-tests.sh,
+# test/test-llm-planner.sh, test/crapi/crapi-helpers.sh, plus the
+# vulnerable-api default-port move). This harness asserts the **shape**
+# of each fix without booting docker — every check works against the
+# committed source so it can run anywhere bash + python3 + grep + sed
+# exist.
+#
+# It does NOT replace the end-to-end flow
+# (`./test/setup-live-targets.sh && ./test/run-live-tests.sh`), which
+# only works on a developer box with Docker; what it does is catch a
+# regression of any individual fix in CI before that end-to-end run
+# even attempts to start.
+#
+# Usage (from repo root):
+#     bash test/regression/lab-2247-regression-tests.sh
+#
+# Exits 0 on full pass, non-zero on any failure.
+# =============================================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Quoted-value safety regex matches the format setup-live-targets.sh writes.
+SAFE_REGEX='^[[:space:]]*(#.*)?$|^[A-Za-z_][A-Za-z0-9_]*="[A-Za-z0-9_./:@,+ -]*"$'
+TESTS_RUN=0
+TESTS_FAIL=0
+
+pass() { echo "  PASS: $1"; TESTS_RUN=$((TESTS_RUN+1)); }
+fail() { echo "  FAIL: $1"; TESTS_RUN=$((TESTS_RUN+1)); TESTS_FAIL=$((TESTS_FAIL+1)); }
+
+# guard_mktemp / guard_mktemp_d wrap mktemp so a silent mktemp failure
+# can't leave us with an empty path (which without `set -e` would let
+# downstream `> "$VAR"` clobber an unrelated file or make later checks
+# false-pass). Per CodeRabbit iter-3 review.
+guard_mktemp() {
+    local v
+    v=$(mktemp "$@") || { fail "FATAL: mktemp failed"; exit 1; }
+    [ -n "$v" ] || { fail "FATAL: mktemp produced empty path"; exit 1; }
+    echo "$v"
+}
+guard_mktemp_d() {
+    local v
+    v=$(mktemp -d "$@") || { fail "FATAL: mktemp -d failed"; exit 1; }
+    [ -n "$v" ] && [ -d "$v" ] || { fail "FATAL: mktemp -d produced unusable path: $v"; exit 1; }
+    echo "$v"
+}
+
+cd "$ROOT" || { echo "FATAL: cannot cd to $ROOT" >&2; exit 1; }
+
+echo "=== Bug #1, #6: teardown uses 'down -v --remove-orphans' and surfaces stderr ==="
+if grep -qE 'docker compose down -v --remove-orphans' test/setup-live-targets.sh; then
+    pass "teardown uses -v --remove-orphans"
+else
+    fail "teardown still missing -v"
+fi
+if ! grep -qE 'docker compose down 2>/dev/null' test/setup-live-targets.sh; then
+    pass "teardown no longer swallows stderr unconditionally"
+else
+    fail "teardown still swallows stderr"
+fi
+
+echo
+echo "=== Bug #2: setup writes CRAPI_SPEC_FILE; downstream scripts read it ==="
+if grep -q 'CRAPI_SPEC_FILE=' test/setup-live-targets.sh; then
+    pass "setup writes CRAPI_SPEC_FILE"
+else
+    fail "setup does not write CRAPI_SPEC_FILE"
+fi
+if grep -q 'CRAPI_SPEC_FILE' test/run-live-tests.sh && \
+   grep -q 'CRAPI_SPEC_FILE' test/test-llm-planner.sh; then
+    pass "both run-live-tests.sh and test-llm-planner.sh consume CRAPI_SPEC_FILE"
+else
+    fail "downstream scripts do not consume CRAPI_SPEC_FILE"
+fi
+# CRAPI_SPEC_FILE staleness fix (Codex review) + iter-5 CodeRabbit:
+# the staleness predicate must use ANCHORED port matching so port 889
+# doesn't false-match localhost:8895.
+if grep -qE 'grep -qE "localhost:\$\{?CRAPI_PORT\}?\(\[\^0-9\]\|\\\$\)"' test/run-live-tests.sh && \
+   grep -qE 'grep -qE "localhost:\$\{?CRAPI_PORT\}?\(\[\^0-9\]\|\\\$\)"' test/test-llm-planner.sh; then
+    pass "downstream scripts use ANCHORED port match (boundary-safe vs substring)"
+else
+    fail "stale CRAPI_SPEC_FILE check uses substring grep — port 889 false-matches 8895"
+fi
+
+echo
+echo "=== Bug #3: CRAPI_READY=false hard-fails ==="
+if awk '
+        flag && /^fi[[:space:]]*$/ { flag=0 }
+        flag && /exit 1/ { found=1 }
+        /CRAPI_READY/ && /!= true/ { flag=1 }
+        END { exit found ? 0 : 1 }
+    ' test/setup-live-targets.sh; then
+    pass "setup exits 1 when crAPI readiness fails"
+else
+    fail "setup does not exit on readiness failure"
+fi
+
+echo
+echo "=== Bug #4, #11: compose patch auto-detects upstream port and validates ==="
+# log_* stubs so the sourced helpers (which call them) don't pollute output.
+# shellcheck disable=SC2317  # called indirectly by the sourced helper
+log_info()  { :; }
+# shellcheck disable=SC2317
+log_ok()    { :; }
+# shellcheck disable=SC2317
+log_warn()  { :; }
+# shellcheck disable=SC2317
+log_fail()  { :; }
+
+# Source the SAME port-helpers.sh that setup-live-targets.sh uses. The
+# previous version of this harness reimplemented patch_crapi_compose_port
+# and find_available_port inline, so a prod-source change would not have
+# affected these tests. (LAB-2247 iteration-2 review TEST-003.)
+# shellcheck source=test/crapi/port-helpers.sh
+. test/crapi/port-helpers.sh
+
+TMP=$(guard_mktemp_d)
+cat > "$TMP/compose.yml" <<EOF
+services:
+  crapi-web:
+    ports:
+      - "\${LISTEN_IP:-127.0.0.1}:5500:5500"
+      - "\${LISTEN_IP:-127.0.0.1}:8889:80"
+      - "\${LISTEN_IP:-127.0.0.1}:30080:80"
+      - "\${LISTEN_IP:-127.0.0.1}:8443:443"
+EOF
+
+if patch_crapi_compose_port "$TMP/compose.yml" 8888 && \
+   grep -q ':8888:80"' "$TMP/compose.yml" && \
+   ! grep -q ':8889:80"' "$TMP/compose.yml"; then
+    pass "compose patched 8889 -> 8888 (upstream rebase scenario)"
+else
+    fail "compose patch failed for 8889 -> 8888"
+fi
+if [ "$(grep -c ':30080:80"' "$TMP/compose.yml")" = "1" ]; then
+    pass "30080 redirector untouched"
+else
+    fail "30080 redirector mistakenly modified"
+fi
+
+# TEST-002 follow-up: same-port no-op branch.
+# When target_port == current upstream port, the function must short-circuit
+# and not invoke sed (no .bak file should appear).
+cat > "$TMP/compose-noop.yml" <<EOF
+services:
+  crapi-web:
+    ports:
+      - "\${LISTEN_IP:-127.0.0.1}:8888:80"
+      - "\${LISTEN_IP:-127.0.0.1}:30080:80"
+EOF
+rm -f "$TMP/compose-noop.yml.bak"
+if patch_crapi_compose_port "$TMP/compose-noop.yml" 8888 && \
+   [ ! -f "$TMP/compose-noop.yml.bak" ]; then
+    pass "patch_crapi_compose_port no-op when target == current upstream port"
+else
+    fail "patch_crapi_compose_port unexpectedly invoked sed when target == current"
+fi
+
+# TEST-002 follow-up: missing-source branch (compose has no LISTEN_IP mapping).
+echo "(empty compose)" > "$TMP/compose-empty.yml"
+if ! patch_crapi_compose_port "$TMP/compose-empty.yml" 8888 2>/dev/null; then
+    pass "patch_crapi_compose_port returns non-zero when no LISTEN_IP mapping found"
+else
+    fail "patch_crapi_compose_port silently succeeded on a compose without LISTEN_IP mapping"
+fi
+
+rm -rf "$TMP"
+
+echo
+echo "=== Bug #5: shared helper exists with canonical creds and signup functions ==="
+if [ -f test/crapi/crapi-helpers.sh ]; then
+    pass "test/crapi/crapi-helpers.sh exists"
+else
+    fail "test/crapi/crapi-helpers.sh missing"
+fi
+# shellcheck source=test/crapi/crapi-helpers.sh
+. test/crapi/crapi-helpers.sh
+for fn in crapi_signup crapi_login crapi_mechanic_signup crapi_setup_users crapi_patch_openapi_spec _crapi_provision_user _crapi_json; do
+    if declare -F "$fn" >/dev/null; then
+        pass "helper exports $fn"
+    else
+        fail "helper missing $fn"
+    fi
+done
+for var in CRAPI_PASSWORD CRAPI_ADMIN_EMAIL CRAPI_USER_EMAIL CRAPI_USER2_EMAIL CRAPI_MECHANIC_EMAIL CRAPI_OPENAPI_SPEC_DEFAULT_PORT; do
+    if [ -n "${!var:-}" ]; then
+        pass "helper sets $var"
+    else
+        fail "helper does not set $var"
+    fi
+done
+for f in test/setup-live-targets.sh test/run-live-tests.sh test/test-llm-planner.sh; do
+    if grep -q 'crapi/crapi-helpers.sh' "$f"; then
+        pass "$f sources crapi-helpers.sh"
+    else
+        fail "$f does not source crapi-helpers.sh"
+    fi
+done
+
+echo
+echo "=== Bug #2 follow-up: spec patcher branches (review feedback TEST-002) ==="
+TMP=$(guard_mktemp_d)
+# Branch (a): different port — substitutes both occurrences.
+patched=$(crapi_patch_openapi_spec test/crapi/crapi-openapi-spec.json 8895 "$TMP")
+n_new=$(grep -c 'localhost:8895' "$patched")
+n_old=$(grep -c 'localhost:8888' "$patched")
+if [ "$n_new" -ge 2 ] && [ "$n_old" -eq 0 ]; then
+    pass "spec patcher rewrites both 8888 occurrences (servers + report_link)"
+else
+    fail "spec patcher left ${n_old} occurrences; produced ${n_new} new"
+fi
+
+# Branch (b): same port (target == default) — echo source path unchanged,
+# do not write a copy.
+out=$(crapi_patch_openapi_spec test/crapi/crapi-openapi-spec.json \
+        "${CRAPI_OPENAPI_SPEC_DEFAULT_PORT}" "$TMP/noop")
+if [ "$out" = "test/crapi/crapi-openapi-spec.json" ] && [ ! -e "$TMP/noop/crapi-openapi-spec.json" ]; then
+    pass "spec patcher no-ops (echoes source path) when target == default port"
+else
+    fail "spec patcher unexpectedly wrote a copy on no-op path (out=$out, file_exists=$([ -e "$TMP/noop/crapi-openapi-spec.json" ] && echo yes || echo no))"
+fi
+
+# Branch (c): missing source — return non-zero, write nothing.
+if ! crapi_patch_openapi_spec /nonexistent/path/spec.json 8895 "$TMP/missing" 2>/dev/null; then
+    if [ ! -e "$TMP/missing/crapi-openapi-spec.json" ]; then
+        pass "spec patcher returns non-zero AND writes nothing when source is missing"
+    else
+        fail "spec patcher returned non-zero but still wrote a destination file"
+    fi
+else
+    fail "spec patcher silently succeeded with a missing source"
+fi
+rm -rf "$TMP"
+
+echo
+echo "=== Bug #5 follow-up: _crapi_provision_user retry-on-failure execution (review feedback TEST-001) ==="
+# Stub crapi_signup and crapi_login so we can drive _crapi_provision_user
+# through its retry loop and assert it converges. The first two login
+# attempts return empty (signup didn't take); the third returns a token.
+# We override CRAPI_PROVISION_RETRIES via env. Use a tmp counter file to
+# avoid subshell-isolation gotchas in `local` declarations.
+LOGIN_ATTEMPTS=$(guard_mktemp)
+SIGNUP_ATTEMPTS=$(guard_mktemp)
+echo 0 > "$LOGIN_ATTEMPTS"
+echo 0 > "$SIGNUP_ATTEMPTS"
+# shellcheck disable=SC2317  # called by _crapi_provision_user
+crapi_signup() {
+    local n
+    n=$(($(cat "$SIGNUP_ATTEMPTS") + 1))
+    echo "$n" > "$SIGNUP_ATTEMPTS"
+}
+# shellcheck disable=SC2317
+crapi_mechanic_signup() { crapi_signup "$@"; }
+# shellcheck disable=SC2317
+crapi_login() {
+    local n
+    n=$(($(cat "$LOGIN_ATTEMPTS") + 1))
+    echo "$n" > "$LOGIN_ATTEMPTS"
+    if [ "$n" -ge 3 ]; then
+        echo "fake-token-after-${n}-attempts"
+    else
+        echo ""
+    fi
+}
+# `sleep` shadowing keeps the test fast (default backoff is 2+4+6+... s).
+# shellcheck disable=SC2317
+sleep() { :; }
+# SC2218: shellcheck sees a later override of _crapi_provision_user in
+# the iter-7 hard-stop test and warns the function is "only defined
+# later" — but the actual definition is in test/crapi/crapi-helpers.sh
+# (sourced at line 165) so this call is sound.
+# shellcheck disable=SC2218
+CRAPI_PROVISION_RETRIES=5 \
+  _crapi_provision_user "http://stub" regular "x@example.com" "X" "0" "p"
+rc=$?
+logins=$(cat "$LOGIN_ATTEMPTS")
+signups=$(cat "$SIGNUP_ATTEMPTS")
+if [ "$rc" -eq 0 ] && [ "$logins" -eq 3 ] && [ "$signups" -eq 3 ]; then
+    pass "_crapi_provision_user retries (3 signups, 3 logins, exit 0) — convergence path"
+else
+    fail "_crapi_provision_user retry mismatch: rc=$rc logins=$logins signups=$signups (expected rc=0 each=3)"
+fi
+
+# Branch: every attempt fails → exhaust retries → exit non-zero.
+# Also asserts crapi_signup is called every iteration (CodeRabbit iter-3
+# review TEST-LEAD-7-B): a regression that loops without re-attempting
+# signup would now be caught.
+echo 0 > "$LOGIN_ATTEMPTS"
+echo 0 > "$SIGNUP_ATTEMPTS"
+# shellcheck disable=SC2317
+crapi_login() {
+    local n
+    n=$(($(cat "$LOGIN_ATTEMPTS") + 1))
+    echo "$n" > "$LOGIN_ATTEMPTS"
+    echo ""   # always-empty
+}
+# shellcheck disable=SC2218  # see comment above re: sourced helper
+CRAPI_PROVISION_RETRIES=3 \
+  _crapi_provision_user "http://stub" regular "y@example.com" "Y" "0" "p" 2>/dev/null
+rc=$?
+logins=$(cat "$LOGIN_ATTEMPTS")
+signups=$(cat "$SIGNUP_ATTEMPTS")
+if [ "$rc" -ne 0 ] && [ "$logins" -eq 3 ] && [ "$signups" -eq 3 ]; then
+    pass "_crapi_provision_user exhausts retries (3 signups, 3 logins, non-zero exit) — failure path"
+else
+    fail "_crapi_provision_user exhaustion mismatch: rc=$rc logins=$logins signups=$signups (expected rc!=0 each=3)"
+fi
+
+# Re-source crapi-helpers.sh so subsequent sections see the REAL helpers
+# (CodeRabbit iter-3 review CR-2 + iter-3 my-review FRESH-002): `unset -f`
+# would permanently strip the originals; re-sourcing restores them.
+unset -f sleep crapi_signup crapi_login crapi_mechanic_signup
+# shellcheck source=test/crapi/crapi-helpers.sh
+. test/crapi/crapi-helpers.sh
+rm -f "$LOGIN_ATTEMPTS" "$SIGNUP_ATTEMPTS"
+
+echo
+echo "=== Bug #5 follow-up: _crapi_json correctly escapes special chars (review feedback) ==="
+# Single-quoted strings preserve backslashes literally — the email here
+# contains a real " and the password contains two real backslashes.
+# Round-trip via python proves _crapi_json emits well-formed JSON that
+# parses back to the original bytes (which printf-format-string JSON
+# building would have corrupted).
+expected_email='ab"cd@test.com'
+expected_password='p\\ssw0rd!'
+out=$(_crapi_json "email=$expected_email" "password=$expected_password")
+roundtrip=$(printf '%s' "$out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+print(d.get("email","") + "|" + d.get("password",""))
+' 2>/dev/null || echo "ERR")
+if [ "$roundtrip" = "${expected_email}|${expected_password}" ]; then
+    pass "_crapi_json escapes quotes and backslashes for JSON-safe payloads"
+else
+    fail "_crapi_json round-trip mismatch: expected '${expected_email}|${expected_password}', got '${roundtrip}'"
+fi
+
+echo
+echo "=== Bug #5 follow-up: crapi_setup_users self-heals via _crapi_provision_user retry ==="
+if grep -qE '_crapi_provision_user' test/crapi/crapi-helpers.sh && \
+   grep -qE 'CRAPI_PROVISION_RETRIES' test/crapi/crapi-helpers.sh; then
+    pass "_crapi_provision_user retries with backoff on empty token"
+else
+    fail "missing retry logic in crapi_setup_users"
+fi
+
+echo
+echo "=== Bug #9: find_available_port skips ports already claimed in this run ==="
+# Use the SOURCED port_in_use override pattern: bash function lookup is
+# dynamic, so redefining port_in_use after the helper is sourced makes
+# the helper's find_available_port use our stub.
+port_in_use() { [ "$1" = "8888" ]; }   # simulate VS Code holding 8888
+
+claimed=()
+v=$(find_available_port 9889 "${claimed[@]+${claimed[@]}}")
+claimed+=("$v")
+c=$(find_available_port 8888 "${claimed[@]+${claimed[@]}}")
+claimed+=("$c")
+if [ -n "$v" ] && [ -n "$c" ] && [ "$v" != "$c" ]; then
+    pass "vulnerable-api ($v) and crapi ($c) get distinct ports with 8888 simulated taken"
+else
+    fail "port collision: vulnerable-api=$v crapi=$c"
+fi
+
+# TEST-005: resolve_target_port honors override AND rejects collisions.
+# Use the same port_in_use stub from above.
+# (a) Override wins when free + not claimed.
+out=$(resolve_target_port 9999 8888 "test" "${claimed[@]+${claimed[@]}}")
+if [ "$out" = "9999" ]; then
+    pass "resolve_target_port honors override when free + not claimed"
+else
+    fail "resolve_target_port did not honor free override (got: $out)"
+fi
+# (b) Override that's OS-busy → return 1, log_fail.
+log_fail_msg=""
+log_fail() { log_fail_msg="$*"; }
+if ! resolve_target_port 8888 9999 "test" "${claimed[@]+${claimed[@]}}" >/dev/null 2>&1; then
+    if [ -n "$log_fail_msg" ] && echo "$log_fail_msg" | grep -q "already in use"; then
+        pass "resolve_target_port rejects override that's already in use on host"
+    else
+        fail "resolve_target_port rejected override but log_fail message unexpected: $log_fail_msg"
+    fi
+else
+    fail "resolve_target_port silently accepted an override port that's in use"
+fi
+# (c) Override that collides with a port claimed earlier this run → return 1.
+log_fail_msg=""
+already_claimed=("$v" "$c")
+if ! resolve_target_port "${already_claimed[0]}" 9000 "test" "${already_claimed[@]}" >/dev/null 2>&1; then
+    if [ -n "$log_fail_msg" ] && echo "$log_fail_msg" | grep -q "collides with another target"; then
+        pass "resolve_target_port rejects override that collides with claimed list"
+    else
+        fail "resolve_target_port rejected claimed-list override but log_fail message unexpected: $log_fail_msg"
+    fi
+else
+    fail "resolve_target_port silently accepted an override port that was already claimed"
+fi
+# Restore log_fail to the no-op for downstream tests; clear scratch var.
+# Also unset the port_in_use stub so any later test that needs the real
+# OS-level check gets it (CodeRabbit iter-3 review CR-4 + my iter-3
+# review TEST-004).
+# shellcheck disable=SC2317  # called indirectly by sourced helpers below
+log_fail() { :; }
+unset log_fail_msg
+unset -f port_in_use
+
+echo
+echo "=== Bug #10: *_PORT_OVERRIDE env vars are honored by setup ==="
+if grep -qE 'VULN_API_PORT_OVERRIDE|CRAPI_PORT_OVERRIDE' test/setup-live-targets.sh; then
+    pass "setup recognizes *_PORT_OVERRIDE env vars"
+else
+    fail "setup does not implement *_PORT_OVERRIDE"
+fi
+if grep -q 'resolve_target_port' test/setup-live-targets.sh; then
+    pass "setup uses a single resolve_target_port helper consistently"
+else
+    fail "setup lacks a unified port-resolution helper"
+fi
+
+echo
+echo "=== Bug #11: vulnerable-api default is 9889 (not 8889) ==="
+if grep -q 'port = "9889"' test/vulnerable-api/main.go; then
+    pass "vulnerable-api/main.go default is 9889"
+else
+    fail "vulnerable-api/main.go default still 8889"
+fi
+if grep -q 'localhost:9889' test/vulnerable-api/openapi.yaml; then
+    pass "openapi.yaml advertises 9889"
+else
+    fail "openapi.yaml still advertises 8889"
+fi
+if grep -q 'DEFAULT_VULN_API_PORT=9889' test/setup-live-targets.sh; then
+    pass "setup default vulnerable-api port is 9889"
+else
+    fail "setup still defaults vulnerable-api to 8889"
+fi
+# Q2: hardcoded port literals replaced with named constants in run-live-tests.sh
+if grep -q 'VULN_API_DEFAULT_PORT' test/run-live-tests.sh && \
+   grep -q 'CRAPI_OPENAPI_SPEC_DEFAULT_PORT' test/run-live-tests.sh; then
+    pass "run-live-tests.sh uses named port constants instead of hardcoded literals"
+else
+    fail "run-live-tests.sh still hardcodes 9889/8888 in conditionals"
+fi
+# Q3: Makefile uses API_PORT variable for reset URL.
+# `$(API_URL)` here is a Makefile variable reference, not shell.
+# shellcheck disable=SC2016  # intentional literal Makefile $(...) expression
+if grep -q '^API_PORT' test/vulnerable-api/Makefile && \
+   grep -q '\$(API_URL)/api/reset' test/vulnerable-api/Makefile; then
+    pass "Makefile reset target uses API_PORT/API_URL variables"
+else
+    fail "Makefile reset target still hardcodes the port"
+fi
+
+echo
+echo "=== Bug #7: --no-build flag exists and gates Go-build steps (TEST-006) ==="
+if grep -q '\-\-no-build' test/setup-live-targets.sh; then
+    pass "setup exposes --no-build flag"
+else
+    fail "setup lacks --no-build flag"
+fi
+# Structural: the build step must be guarded such that DO_BUILD=true OR
+# the binary is missing — i.e. when --no-build is passed AND the binary
+# already exists, we must NOT rebuild.
+if awk '
+    tolower($0) ~ /building hadrian and go targets/{flag=1}
+    flag && /\[ "\$DO_BUILD" = true \] \|\| \[ ! -x .*hadrian/{found=1}
+    flag && /^# ==== Pull/{exit}
+    END{exit found ? 0 : 1}
+' test/setup-live-targets.sh; then
+    pass "hadrian build is gated by [DO_BUILD=true OR binary missing]"
+else
+    fail "hadrian build is not properly gated for --no-build"
+fi
+# Same gate for vulnerable-api and grpc-server inside their target-specific blocks.
+# shellcheck disable=SC2016  # we want the literal "$DO_BUILD" string in the source file
+if grep -qE '\[ "\$DO_BUILD" = true \] \|\| \[ ! -x .*vulnerable-api/vulnerable-api' test/setup-live-targets.sh; then
+    pass "vulnerable-api build is gated by [DO_BUILD=true OR binary missing]"
+else
+    fail "vulnerable-api build is not properly gated for --no-build"
+fi
+# shellcheck disable=SC2016
+if grep -qE '\[ "\$DO_BUILD" = true \] \|\| \[ ! -x .*grpc-server/grpc-server' test/setup-live-targets.sh; then
+    pass "grpc-server build is gated by [DO_BUILD=true OR binary missing]"
+else
+    fail "grpc-server build is not properly gated for --no-build"
+fi
+
+echo
+echo "=== Bug #8: --purge flag exists and is gated on --teardown (TEST-004) ==="
+if grep -q '\-\-purge' test/setup-live-targets.sh; then
+    pass "setup exposes --purge flag"
+else
+    fail "setup lacks --purge flag"
+fi
+# Structural: the purge action (rm -rf .crapi-repo) must live INSIDE the
+# `if [ "$TEARDOWN" = true ]; then ... fi` block so passing --purge alone
+# (without --teardown) cannot remove the cached clone.
+# We assert by extracting the line numbers of (a) the teardown block
+# bounds and (b) the purge `rm -rf "$CRAPI_REPO_DEFAULT"`, and checking
+# the rm is bracketed.
+# shellcheck disable=SC2016  # literal "$TEARDOWN" / "$CRAPI_REPO_DEFAULT" patterns
+teardown_start=$(grep -n '^if \[ "\$TEARDOWN" = true \]; then' test/setup-live-targets.sh | head -1 | cut -d: -f1)
+teardown_end=$(awk -v s="$teardown_start" 'NR>s && /^fi$/{print NR; exit}' test/setup-live-targets.sh)
+# shellcheck disable=SC2016
+purge_rm=$(grep -n 'rm -rf "\$CRAPI_REPO_DEFAULT"' test/setup-live-targets.sh | head -1 | cut -d: -f1)
+if [ -n "$teardown_start" ] && [ -n "$teardown_end" ] && [ -n "$purge_rm" ] && \
+   [ "$purge_rm" -gt "$teardown_start" ] && [ "$purge_rm" -lt "$teardown_end" ]; then
+    pass "--purge clone-removal is structurally inside the --teardown block (lines: teardown=${teardown_start}..${teardown_end}, purge_rm=${purge_rm})"
+else
+    fail "--purge clone-removal is NOT inside --teardown block (teardown=${teardown_start}..${teardown_end}, purge_rm=${purge_rm})"
+fi
+
+echo
+echo "=== Reviewer regression: .live-test-config matches safety regex ==="
+TMP=$(mktemp)
+cat > "$TMP" <<'EOF'
+# Auto-generated by setup-live-targets.sh on 2026-05-09T00:00:00Z
+VULN_API_PORT="9889"
+DVGA_PORT="5013"
+GRPC_PORT="50051"
+CRAPI_PORT="8888"
+CRAPI_DIR="/some/path/.crapi-repo"
+CRAPI_SPEC_FILE="/some/path/.live-test-cache/crapi-openapi-spec.json"
+TARGETS_SETUP="vulnerable-api,dvga,grpc,crapi"
+EOF
+if grep -qvE "$SAFE_REGEX" "$TMP"; then
+    fail ".live-test-config has lines that fail the safety regex"
+    grep -vE "$SAFE_REGEX" "$TMP"
+else
+    pass ".live-test-config (quoted format) passes safety regex"
+fi
+rm -f "$TMP"
+
+# Path-with-space injection guard (Codex / SEC-BE-003): the safety regex
+# must NOT accept an unquoted value containing a space.
+TMP=$(mktemp)
+echo 'CRAPI_DIR=/tmp/foo bar' > "$TMP"
+if grep -qvE "$SAFE_REGEX" "$TMP"; then
+    pass "unquoted value containing space is rejected (path-with-space injection guard)"
+else
+    fail "safety regex accepts unquoted value with space — injection guard is broken"
+fi
+rm -f "$TMP"
+
+# Conversely: a QUOTED value containing a space MUST pass — repos cloned
+# under paths like "/Users/name/My Code/hadrian/" are valid use cases
+# (CodeRabbit review 4258701255 CR-7-3). The earlier whitespace-rejection
+# loop in setup-live-targets.sh broke this; we removed it and rely on
+# the quoted-value safety regex + heredoc quoting to keep `source` safe.
+TMP=$(mktemp)
+echo 'CRAPI_DIR="/tmp/foo bar"' > "$TMP"
+if grep -qvE "$SAFE_REGEX" "$TMP"; then
+    fail "safety regex rejects QUOTED path with space — would break valid setups (e.g. /Users/Name/My Code/...)"
+else
+    pass "safety regex accepts QUOTED path with space (round-trips safely via source)"
+fi
+rm -f "$TMP"
+# And the loop itself must be GONE from setup-live-targets.sh.
+if grep -qE 'for _name in CRAPI_DIR CRAPI_SPEC_FILE; do' test/setup-live-targets.sh; then
+    fail "stale whitespace-rejection loop survives — would block valid repo paths"
+else
+    pass "whitespace-rejection loop removed (safety now via quoted heredoc + tightened regex)"
+fi
+
+echo
+echo "=== Review-feedback regressions ==="
+
+# Gemini #1 / CodeRabbit: log_* helpers redirect to stderr so command-substituted
+# helpers don't capture log lines as port values.
+if awk '
+    /^log_(info|ok|warn|fail|header)/{flag=1}
+    flag && />&2/{found=1}
+    flag && /^}/{flag=0}
+    END {exit found ? 0 : 1}
+' test/setup-live-targets.sh; then
+    pass "setup-live-targets.sh log_* helpers redirect to stderr"
+else
+    fail "log_* helpers still write to stdout (will pollute \$(...) captures)"
+fi
+
+# Codex #1: go check is conditional on --no-build + selected targets
+if grep -qE 'need_go=' test/setup-live-targets.sh; then
+    pass "setup-live-targets.sh skips Go check when no Go build is needed"
+else
+    fail "setup-live-targets.sh still requires Go unconditionally"
+fi
+
+# Codex #3 / SEC-BE-003: heredoc values are quoted in the writer
+if grep -qE 'CRAPI_DIR="\$\{CRAPI_DIR\}"' test/setup-live-targets.sh; then
+    pass "setup-live-targets.sh quotes CRAPI_DIR in the config heredoc"
+else
+    fail "CRAPI_DIR still unquoted in heredoc (path-with-space injection)"
+fi
+
+echo
+echo "=== Iteration-3 + iteration-4 review feedback ==="
+
+# My iter-3 TEST-001: harness asserts port-helpers.sh is actually sourced
+# from setup-live-targets.sh (not just that the function names appear).
+if grep -q 'crapi/port-helpers.sh' test/setup-live-targets.sh; then
+    pass "setup-live-targets.sh sources test/crapi/port-helpers.sh"
+else
+    fail "setup-live-targets.sh does NOT source port-helpers.sh — re-inline regression risk"
+fi
+
+# CodeRabbit iter-3 CR-1: token-empty gate covers admin AND mechanic.
+# The gate may span multiple lines (line-wrapped), so check both names appear
+# in the same `if [ ... ]; then ... log_fail ... fi` block.
+if awk '
+    /^[[:space:]]*if .*-z "\$CRAPI_/ { in_if=1; block="" }
+    in_if { block = block "\n" $0 }
+    in_if && /; then/ {
+        if (block ~ /CRAPI_ADMIN_TOKEN/ && block ~ /CRAPI_MECHANIC_TOKEN/ \
+            && block ~ /CRAPI_USER_TOKEN/ && block ~ /CRAPI_USER2_TOKEN/) {
+            found=1
+        }
+        in_if=0
+    }
+    END { exit found ? 0 : 1 }
+' test/run-live-tests.sh; then
+    pass "run-live-tests.sh token-empty gate covers admin, user, user2, AND mechanic"
+else
+    fail "token-empty gate does not check all four tokens — degraded auth would silently slip through"
+fi
+
+# CodeRabbit iter-3 CR-5: --purge alone emits a pre-flight warning.
+if grep -q -- '--purge requires --teardown' test/setup-live-targets.sh; then
+    pass "--purge without --teardown emits a pre-flight warning"
+else
+    fail "--purge without --teardown is silently a no-op"
+fi
+
+# CodeRabbit iter-3 CR-6: test-llm-planner writes the patched spec into the same
+# SPEC_CACHE_DIR setup uses (test/.live-test-cache/), not OUTPUT_DIR.
+if grep -q 'SPEC_CACHE_DIR' test/test-llm-planner.sh; then
+    pass "test-llm-planner.sh writes patched spec into SPEC_CACHE_DIR (aligned with setup)"
+else
+    fail "test-llm-planner.sh still writes spec into OUTPUT_DIR (cache artifact in results dir)"
+fi
+
+# CodeRabbit iter-3 CR-7: crapi_patch_openapi_spec validates the substitution
+# actually landed (defensive against upstream spec rewording).
+TMP=$(guard_mktemp_d)
+echo '{"servers":[{"url":"http://localhost:9999"}]}' > "$TMP/spec.json"
+if ! crapi_patch_openapi_spec "$TMP/spec.json" 8895 "$TMP/out" 2>/dev/null; then
+    if [ ! -e "$TMP/out/crapi-openapi-spec.json" ]; then
+        pass "crapi_patch_openapi_spec returns non-zero AND writes nothing when source lacks localhost:DEFAULT"
+    else
+        fail "crapi_patch_openapi_spec rejected but left a destination file"
+    fi
+else
+    fail "crapi_patch_openapi_spec silently succeeded with an unsubstitutable source"
+fi
+rm -rf "$TMP"
+
+# CodeRabbit iter-3 CR-9 → iter-4 QUAL-1: port_in_use uses ss -atn (all
+# states), matches lsof coverage. Earlier iterations got this wrong twice
+# (-ltn missed ESTABLISHED, -tn missed LISTEN); -atn covers everything.
+# This duplicates the QUAL-1 assertion below and is kept here as a
+# CR-9-anchored sentinel that the regression has stayed fixed.
+if grep -qE 'ss -atn \| grep -q' test/crapi/port-helpers.sh && \
+   ! grep -qE 'ss -[lt]+n[[:space:]]*\| grep' test/crapi/port-helpers.sh; then
+    pass "port_in_use uses ss -atn (CR-9 sentinel: not -ltn / not -tn)"
+else
+    fail "port_in_use ss flag regressed; expected -atn"
+fi
+
+# My iter-3 FRESH-001: test-llm-planner acquires ADMIN_TOKEN and uses it
+# for the admin role (not USER_TOKEN, which previously degraded admin
+# templates to regular-user creds in the planner test).
+if grep -qE 'ADMIN_TOKEN=\$\(crapi_login.*CRAPI_ADMIN_EMAIL' test/test-llm-planner.sh && \
+   grep -qE 'admin:[[:space:]]*$' test/test-llm-planner.sh; then
+    if awk '/^roles:/{flag=1} flag && /admin:/{getline next_line; if (next_line ~ /\$\{ADMIN_TOKEN\}/) found=1} END{exit found?0:1}' test/test-llm-planner.sh; then
+        pass "test-llm-planner.sh acquires ADMIN_TOKEN and binds it to the admin role"
+    else
+        fail "test-llm-planner.sh acquires ADMIN_TOKEN but admin role still uses a different var"
+    fi
+else
+    fail "test-llm-planner.sh does not acquire ADMIN_TOKEN — admin templates run with degraded creds"
+fi
+
+echo
+echo "=== Iteration-4 review feedback ==="
+
+# QUAL-1 (iter-4 capability-reviewer): port_in_use uses ss -atn (all states),
+# matching lsof's coverage of LISTEN + ESTABLISHED + TIME_WAIT.
+if grep -qE 'ss -atn \| grep -q' test/crapi/port-helpers.sh && \
+   ! grep -qE 'ss -ltn \| grep' test/crapi/port-helpers.sh && \
+   ! grep -qE 'ss -tn \| grep' test/crapi/port-helpers.sh; then
+    pass "port_in_use uses ss -atn (covers LISTEN + non-LISTEN, matches lsof)"
+else
+    fail "port_in_use ss flag wrong — must be -atn (not -ltn / not -tn)"
+fi
+
+# QUAL-2 (iter-4): setup-live-targets.sh guards against empty CRAPI_SPEC_FILE
+# from a failed crapi_patch_openapi_spec call.
+if grep -qE '\[ -z "\$CRAPI_SPEC_FILE" \].*$' test/setup-live-targets.sh && \
+   awk '/CRAPI_SPEC_FILE=\$\(crapi_patch_openapi_spec/{flag=1} flag && /\[ -z "\$CRAPI_SPEC_FILE" \]/{found=1; exit} flag && /^fi/{exit} END{exit found?0:1}' test/setup-live-targets.sh; then
+    pass "setup-live-targets.sh guards against empty CRAPI_SPEC_FILE"
+else
+    fail "setup-live-targets.sh does not validate crapi_patch_openapi_spec result is non-empty"
+fi
+
+# QUAL-3 (iter-4): run-live-tests.sh guards against empty CRAPI_SPEC.
+if grep -qE '\[ -z "\$CRAPI_SPEC" \] \|\| \[ ! -f "\$CRAPI_SPEC" \]' test/run-live-tests.sh; then
+    pass "run-live-tests.sh guards against empty/missing CRAPI_SPEC"
+else
+    fail "run-live-tests.sh does not validate CRAPI_SPEC before passing to hadrian"
+fi
+# Same in test-llm-planner.sh
+if grep -qE '\[ -z "\$CRAPI_SPEC" \] \|\| \[ ! -f "\$CRAPI_SPEC" \]' test/test-llm-planner.sh; then
+    pass "test-llm-planner.sh guards against empty/missing CRAPI_SPEC"
+else
+    fail "test-llm-planner.sh does not validate CRAPI_SPEC before passing to hadrian"
+fi
+
+# test-lead iter-4 #1: SPEC_CACHE_DIR alignment in run-live-tests.sh too
+# (iteration 3 only fixed test-llm-planner.sh).
+if grep -q 'SPEC_CACHE_DIR' test/run-live-tests.sh; then
+    pass "run-live-tests.sh writes patched spec into SPEC_CACHE_DIR (aligned with setup)"
+else
+    fail "run-live-tests.sh still writes spec into OUTPUT_DIR — diverges from setup"
+fi
+
+# test-lead iter-4 #2: assert ALL four DEFAULT_PORT constants present.
+for c in VULN_API_DEFAULT_PORT DVGA_DEFAULT_PORT GRPC_DEFAULT_PORT; do
+    if grep -qE "^${c}=" test/run-live-tests.sh; then
+        pass "run-live-tests.sh defines ${c}"
+    else
+        fail "run-live-tests.sh missing ${c} constant"
+    fi
+done
+# CRAPI default comes from helpers' CRAPI_OPENAPI_SPEC_DEFAULT_PORT.
+if grep -q 'CRAPI_OPENAPI_SPEC_DEFAULT_PORT' test/run-live-tests.sh; then
+    pass "run-live-tests.sh references CRAPI_OPENAPI_SPEC_DEFAULT_PORT"
+else
+    fail "run-live-tests.sh missing CRAPI_OPENAPI_SPEC_DEFAULT_PORT reference"
+fi
+
+# test-lead iter-4 #3: crapi_setup_users provisions all four canonical roles.
+for email_var in CRAPI_ADMIN_EMAIL CRAPI_USER_EMAIL CRAPI_USER2_EMAIL CRAPI_MECHANIC_EMAIL; do
+    if grep -qE "_crapi_provision_user.*${email_var}" test/crapi/crapi-helpers.sh; then
+        pass "crapi_setup_users provisions ${email_var}"
+    else
+        fail "crapi_setup_users does NOT provision ${email_var}"
+    fi
+done
+
+# test-lead iter-4 #7: setup hard-fails when crapi_setup_users returns non-zero.
+if awk '
+    /^[[:space:]]*if ! crapi_setup_users/ { flag=1 }
+    flag && /^[[:space:]]*fi[[:space:]]*$/ { flag=0 }
+    flag && /exit 1/ { found=1 }
+    END { exit found ? 0 : 1 }
+' test/setup-live-targets.sh; then
+    pass "setup-live-targets.sh exits 1 on crapi_setup_users provisioning failure"
+else
+    fail "setup-live-targets.sh does not exit on user-provisioning failure"
+fi
+
+echo
+echo "=== Iteration-6 review feedback ==="
+
+# TEST-001: patch_crapi_compose_port post-sed validation-failure branch.
+# Drive the function with sed shadowed to a no-op in a subshell, so the
+# function detects current_port, runs the no-op sed (file unchanged),
+# then the validation grep fails and the function returns 1.
+TMP=$(guard_mktemp_d)
+cat > "$TMP/compose.yml" <<EOF
+services:
+  crapi-web:
+    ports:
+      - "\${LISTEN_IP:-127.0.0.1}:8889:80"
+      - "\${LISTEN_IP:-127.0.0.1}:30080:80"
+EOF
+( # subshell so sed shadowing doesn't escape
+    # shellcheck disable=SC2317  # called by patch_crapi_compose_port
+    sed() { :; }
+    if ! patch_crapi_compose_port "$TMP/compose.yml" 9999 2>/dev/null; then
+        exit 0
+    fi
+    exit 1
+)
+if [ $? -eq 0 ]; then
+    pass "patch_crapi_compose_port returns non-zero when post-sed validation fails"
+else
+    fail "patch_crapi_compose_port silently succeeds when sed doesn't substitute"
+fi
+rm -rf "$TMP"
+
+# TEST-002: _crapi_provision_user "mechanic" kind dispatches to crapi_mechanic_signup.
+SIGNUP_REGULAR=$(guard_mktemp)
+SIGNUP_MECH=$(guard_mktemp)
+echo 0 > "$SIGNUP_REGULAR"
+echo 0 > "$SIGNUP_MECH"
+# shellcheck disable=SC2317
+crapi_signup() {
+    n=$(($(cat "$SIGNUP_REGULAR") + 1))
+    echo "$n" > "$SIGNUP_REGULAR"
+}
+# shellcheck disable=SC2317
+crapi_mechanic_signup() {
+    n=$(($(cat "$SIGNUP_MECH") + 1))
+    echo "$n" > "$SIGNUP_MECH"
+}
+# shellcheck disable=SC2317
+crapi_login() { echo "fake-token"; }   # immediate convergence
+# shellcheck disable=SC2317
+sleep() { :; }
+# shellcheck disable=SC2218  # _crapi_provision_user is sourced from crapi-helpers.sh
+CRAPI_PROVISION_RETRIES=2 \
+  _crapi_provision_user "http://stub" mechanic "m@example.com" "M" "0" "p" "CODE" >/dev/null
+reg_count=$(cat "$SIGNUP_REGULAR")
+mech_count=$(cat "$SIGNUP_MECH")
+if [ "$mech_count" -eq 1 ] && [ "$reg_count" -eq 0 ]; then
+    pass "_crapi_provision_user kind=mechanic dispatches to crapi_mechanic_signup (mech=1, regular=0)"
+else
+    fail "_crapi_provision_user mechanic dispatch wrong: regular=$reg_count mechanic=$mech_count (expected 0/1)"
+fi
+unset -f sleep crapi_signup crapi_mechanic_signup crapi_login
+. test/crapi/crapi-helpers.sh
+rm -f "$SIGNUP_REGULAR" "$SIGNUP_MECH"
+
+# TEST-003: resolve_target_port with empty override falls back to find_available_port.
+# Stub port_in_use so 8888 is free; resolve with empty override should return 8888.
+port_in_use() { return 1; }   # everything is "free"
+out=$(resolve_target_port "" 8888 "fallback-test")
+rc=$?
+unset -f port_in_use
+if [ "$rc" -eq 0 ] && [ "$out" = "8888" ]; then
+    pass "resolve_target_port empty override falls back to find_available_port (returns 8888)"
+else
+    fail "resolve_target_port empty-override fallback mismatch: rc=$rc out=[$out]"
+fi
+
+# TEST-004 (updated for iter-7 CR-7-2 fix): --purge guard. The rm -rf
+# of the default cached clone must be wrapped in BOTH `if [ "$PURGE" = true ]`
+# AND a CRAPI_DIR-tolerant condition (empty OR equals CRAPI_REPO_DEFAULT).
+# A regression that drops the empty-OR-equals branch would either
+# silently no-op (CR-7-2 case) or rm an operator-supplied custom dir.
+if awk '
+    /^[[:space:]]*if \[ "\$PURGE" = true \]; then$/ { p=1; next }
+    p && /\[ -z "\$CRAPI_DIR" \]/ && /\[ "\$CRAPI_DIR" = "\$CRAPI_REPO_DEFAULT" \]/ { gate=1 }
+    p && /rm -rf "\$CRAPI_REPO_DEFAULT"/ && gate { found=1 }
+    p && /^[[:space:]]*fi[[:space:]]*$/ { p=0 }
+    END { exit found ? 0 : 1 }
+' test/setup-live-targets.sh; then
+    pass "--purge rm -rf is gated by [PURGE=true] AND [CRAPI_DIR empty OR equals default] (custom dir survives, default purged)"
+else
+    fail "--purge guard wrong: must permit rm of default when CRAPI_DIR is unset OR equals CRAPI_REPO_DEFAULT"
+fi
+
+# TEST-006: SPEC_CACHE_DIR positional-arg assertion is location-agnostic.
+# Tighten by requiring SPEC_CACHE_DIR appear as the LAST argument before
+# the closing paren of the patcher call (the dest_dir position).
+if awk '
+    /CRAPI_SPEC=\$\(crapi_patch_openapi_spec/ { flag=1; arg_count=0; next }
+    flag {
+        # trim whitespace
+        line=$0; gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        # the call is multi-line: source spec, port, dest_dir.
+        if (line ~ /^\)$/) { exit }
+        if (line ~ /SPEC_CACHE_DIR/) { last_arg=line; arg_count++ }
+        else if (line !~ /^[[:space:]]*\\?$/) { other_arg=line; arg_count++ }
+    }
+    END { exit (last_arg ~ /SPEC_CACHE_DIR/ && arg_count >= 3) ? 0 : 1 }
+' test/run-live-tests.sh; then
+    pass "run-live-tests.sh patcher dest_dir is SPEC_CACHE_DIR specifically (not just contained)"
+else
+    fail "SPEC_CACHE_DIR positional check unable to confirm dest_dir position"
+fi
+
+# TEST-007: anchored-port-match negative assertion must catch BOTH
+# `grep -q ` and `grep -qE ` substring forms (a regression to either
+# would re-introduce the false-match).
+if ! grep -qE 'grep -qE? "localhost:\$\{?CRAPI_PORT[}]*"$' test/run-live-tests.sh test/test-llm-planner.sh && \
+   ! grep -qE 'grep -qE? "localhost:\$\{?CRAPI_PORT\}?"' test/run-live-tests.sh test/test-llm-planner.sh; then
+    pass "no remaining substring grep for localhost:CRAPI_PORT (catches both grep -q AND grep -qE forms)"
+else
+    fail "substring grep (either -q or -qE form) for localhost:CRAPI_PORT still present"
+fi
+
+echo
+echo "=== Iteration-5 review feedback ==="
+
+# Iter-5 my-TEST-001 (was the only blocker): exercise find_available_port's
+# 20-port walk-forward exhaustion branch. Stub port_in_use to claim every
+# port; assert empty result + non-zero return.
+port_in_use() { return 0; }   # everything is "busy"
+out=$(find_available_port 8888)
+rc=$?
+unset -f port_in_use
+if [ -z "$out" ] && [ "$rc" -ne 0 ]; then
+    pass "find_available_port returns empty + non-zero when 20-port walk exhausts"
+else
+    fail "find_available_port walk-forward exhaustion mismatch: rc=$rc out=[$out]"
+fi
+
+# Iter-5 my-TEST-002: SPEC_CACHE_DIR assertion was comment-permissive.
+# Tighten: the variable must appear as an assignment AND be passed as the
+# third arg to crapi_patch_openapi_spec (the dest_dir position).
+if grep -qE '^[[:space:]]*SPEC_CACHE_DIR=' test/run-live-tests.sh && \
+   awk '/CRAPI_SPEC=\$\(crapi_patch_openapi_spec/{flag=1}
+        flag && /SPEC_CACHE_DIR/{found=1; exit}
+        flag && /^[[:space:]]*\)/{exit}
+        END{exit found?0:1}' test/run-live-tests.sh; then
+    pass "run-live-tests.sh defines SPEC_CACHE_DIR AND passes it as the patcher dest dir"
+else
+    fail "run-live-tests.sh SPEC_CACHE_DIR assertion incomplete (assignment + use both required)"
+fi
+
+# Iter-5 my-TEST-003: roster-coverage assertion now binds email to role kind.
+# admin/user1/user2 must use kind=regular; mechanic must use kind=mechanic.
+if awk '
+    /_crapi_provision_user .* "?regular"? .*CRAPI_ADMIN_EMAIL/{a=1}
+    /_crapi_provision_user .* "?regular"? .*CRAPI_USER_EMAIL/{u1=1}
+    /_crapi_provision_user .* "?regular"? .*CRAPI_USER2_EMAIL/{u2=1}
+    /_crapi_provision_user .* "?mechanic"? .*CRAPI_MECHANIC_EMAIL/{m=1}
+    END{exit (a && u1 && u2 && m) ? 0 : 1}
+' test/crapi/crapi-helpers.sh; then
+    pass "crapi_setup_users binds admin/user1/user2 -> regular, mechanic -> mechanic"
+else
+    fail "crapi_setup_users role-kind binding incorrect (a regression that swaps mechanic to regular would slip through)"
+fi
+
+# CodeRabbit iter-5 CR-1: ANCHORED port match in run-live-tests.sh AND
+# test-llm-planner.sh (already partially covered above; assert non-anchored
+# substring greps are GONE).
+if ! grep -qE 'grep -q "localhost:\$\{?CRAPI_PORT' test/run-live-tests.sh test/test-llm-planner.sh; then
+    pass "no remaining substring grep for localhost:CRAPI_PORT (boundary-anchored only)"
+else
+    fail "substring grep for localhost:CRAPI_PORT survives — port 889 would false-match 8895"
+fi
+
+# CodeRabbit iter-5 CR-2: teardown reads saved CRAPI_DIR from .live-test-config.
+if awk '
+    /^if \[ "\$TEARDOWN" = true \]; then/{flag=1}
+    flag && /^fi$/{flag=0}
+    flag && /\. "\$CONFIG_FILE"/{found=1}
+    flag && /CRAPI_DIR.*from .live-test-config/{has_diag=1}
+    END{exit found?0:1}
+' test/setup-live-targets.sh; then
+    pass "teardown sources .live-test-config to recover saved CRAPI_DIR"
+else
+    fail "teardown does not load CRAPI_DIR from .live-test-config — custom --crapi-dir setups leak containers/volumes"
+fi
+
+# CodeRabbit iter-5 CR-3: per-target need_go check (vulnerable-api and grpc
+# evaluated independently). Two distinct `if echo "$TARGETS" | grep -q "X" && ...` blocks.
+if awk '
+    /^if echo "\$TARGETS" \| grep -q "vulnerable-api" && /{vuln=1}
+    /^if echo "\$TARGETS" \| grep -q "grpc" && /{grpc=1}
+    END{exit (vuln && grpc) ? 0 : 1}
+' test/setup-live-targets.sh; then
+    pass "need_go is split per Go target (vulnerable-api and grpc checked separately)"
+else
+    fail "need_go still combines vulnerable-api OR grpc — `--targets vulnerable-api --no-build` still requires grpc-server binary"
+fi
+
+# Iter-5 lane-dropped (capability-reviewer): test-llm-planner.sh wraps
+# crapi_setup_users in `if ! ... log_fail ...` like the sibling scripts do.
+if grep -qE 'if ! crapi_setup_users' test/test-llm-planner.sh; then
+    pass "test-llm-planner.sh wraps crapi_setup_users with diagnostic guard"
+else
+    fail "test-llm-planner.sh leaves crapi_setup_users bare — failure surfaces as raw set-e abort"
+fi
+
+echo
+echo "=== Iteration-7 review feedback ==="
+
+# Iter-7 lane-dropped (capability-reviewer): test-llm-planner.sh CRAPI_PORT
+# default now references CRAPI_OPENAPI_SPEC_DEFAULT_PORT (single source of
+# truth) rather than hardcoding 8888. The helper must be sourced BEFORE
+# the CRAPI_PORT default assignment.
+if awk '
+    /\. "\$\{SCRIPT_DIR\}\/crapi\/crapi-helpers\.sh"/ { sourced=1 }
+    /CRAPI_PORT="\$\{CRAPI_PORT:-\$CRAPI_OPENAPI_SPEC_DEFAULT_PORT\}"/ && sourced { found=1 }
+    END { exit found ? 0 : 1 }
+' test/test-llm-planner.sh; then
+    pass "test-llm-planner.sh sources helper BEFORE CRAPI_PORT default (uses CRAPI_OPENAPI_SPEC_DEFAULT_PORT)"
+else
+    fail "test-llm-planner.sh CRAPI_PORT default does not reference helper constant — port-default redundancy"
+fi
+
+# Iter-7 lane-dropped (capability-reviewer): setup-live-targets.sh
+# DEFAULT_CRAPI_PORT now derives from CRAPI_OPENAPI_SPEC_DEFAULT_PORT
+# (helper-sourced first). Asserts the literal `=8888` is gone for the
+# crAPI default, AND that the helper source line precedes the
+# DEFAULT_CRAPI_PORT assignment (otherwise CRAPI_OPENAPI_SPEC_DEFAULT_PORT
+# would be unset at assignment time — set -u would catch it loudly, but
+# we want a structural guarantee parallel to the test-llm-planner check).
+if awk '
+    /\. "\$\{?SCRIPT_DIR\}?\/crapi\/crapi-helpers\.sh"/ { sourced=1 }
+    /^DEFAULT_CRAPI_PORT="\$CRAPI_OPENAPI_SPEC_DEFAULT_PORT"/ && sourced { found=1 }
+    END { exit found ? 0 : 1 }
+' test/setup-live-targets.sh && \
+   ! grep -qE '^DEFAULT_CRAPI_PORT=8888' test/setup-live-targets.sh; then
+    pass "setup-live-targets.sh sources helper BEFORE DEFAULT_CRAPI_PORT assignment (no hardcoded 8888)"
+else
+    fail "setup-live-targets.sh DEFAULT_CRAPI_PORT either hardcodes 8888 or doesn't source helper first"
+fi
+
+# Iter-7 TEST-002: kind=regular dispatch (negative direction).
+# Mirror of the mechanic test at lines 794+: with kind=regular, regular
+# signup must be called once and mechanic signup not at all.
+SIGNUP_REGULAR=$(guard_mktemp)
+SIGNUP_MECH=$(guard_mktemp)
+echo 0 > "$SIGNUP_REGULAR"
+echo 0 > "$SIGNUP_MECH"
+# shellcheck disable=SC2317
+crapi_signup() {
+    n=$(($(cat "$SIGNUP_REGULAR") + 1))
+    echo "$n" > "$SIGNUP_REGULAR"
+}
+# shellcheck disable=SC2317
+crapi_mechanic_signup() {
+    n=$(($(cat "$SIGNUP_MECH") + 1))
+    echo "$n" > "$SIGNUP_MECH"
+}
+# shellcheck disable=SC2317
+crapi_login() { echo "fake-token"; }
+# shellcheck disable=SC2317
+sleep() { :; }
+# shellcheck disable=SC2218  # _crapi_provision_user is sourced from crapi-helpers.sh
+CRAPI_PROVISION_RETRIES=2 \
+  _crapi_provision_user "http://stub" regular "r@example.com" "R" "0" "p" >/dev/null
+reg_count=$(cat "$SIGNUP_REGULAR")
+mech_count=$(cat "$SIGNUP_MECH")
+if [ "$reg_count" -eq 1 ] && [ "$mech_count" -eq 0 ]; then
+    pass "_crapi_provision_user kind=regular dispatches to crapi_signup (regular=1, mechanic=0)"
+else
+    fail "_crapi_provision_user regular dispatch wrong: regular=$reg_count mechanic=$mech_count (expected 1/0)"
+fi
+unset -f sleep crapi_signup crapi_mechanic_signup crapi_login
+. test/crapi/crapi-helpers.sh
+rm -f "$SIGNUP_REGULAR" "$SIGNUP_MECH"
+
+# Iter-7 TEST-003: crapi_setup_users hard-stop ordering. Stub
+# _crapi_provision_user to count calls and fail on the 3rd (user2).
+# Assert mechanic was NOT provisioned, exit code is non-zero.
+PROV_CALLS=$(guard_mktemp)
+: > "$PROV_CALLS"   # truncate to truly-empty (echo "" leaves a newline)
+# shellcheck disable=SC2317,SC2218
+# SC2218: intentional override of the sourced _crapi_provision_user for
+# this test; the original is restored by re-sourcing crapi-helpers.sh at
+# the end of this block.
+_crapi_provision_user() {
+    echo "$1 $2 $3" >> "$PROV_CALLS"
+    n=$(grep -c . "$PROV_CALLS")
+    if [ "$n" -ge 3 ]; then return 1; fi
+    return 0
+}
+crapi_setup_users "http://stub" 2>/dev/null
+rc=$?
+# `grep -c X` already prints 0 on no match (and exits 1). The `|| echo 0`
+# fallback would run a SECOND echo on no-match, smashing both into one
+# captured value like "0\n0". Just trust grep -c's output.
+calls=$(grep -c . "$PROV_CALLS")
+# The stub records `$1 $2 $3` = base_url + kind + email. Match against the
+# EXPANDED canonical mechanic email (from crapi-helpers.sh) — grepping
+# the literal var name `CRAPI_MECHANIC_EMAIL` was a tautology since the
+# file never contains the var name, only its value.
+mech_called=$(grep -c "$CRAPI_MECHANIC_EMAIL" "$PROV_CALLS")
+[ -z "$mech_called" ] && mech_called=0
+if [ "$rc" -ne 0 ] && [ "$calls" -eq 3 ] && [ "$mech_called" -eq 0 ]; then
+    pass "crapi_setup_users hard-stops on first failure (3 calls made, mechanic NOT reached, rc!=0)"
+else
+    fail "crapi_setup_users hard-stop wrong: rc=$rc calls=$calls mechanic_called=$mech_called (expected rc!=0 calls=3 mech=0)"
+fi
+unset -f _crapi_provision_user
+. test/crapi/crapi-helpers.sh
+rm -f "$PROV_CALLS"
+
+# Iter-7 TEST-004 (extended in iter-8 for behavioral coverage): drive a
+# subshell that RECONSTRUCTS the teardown safety-regex gate (not extracts
+# verbatim from setup-live-targets.sh — bash function-extraction would be
+# fragile and the gate is just three lines). Drift between this
+# reconstruction and the prod loader is caught by the SAFE_REGEX
+# byte-equality pin against all three prod copies (TEST-005 below).
+# Together these two tests cover both behavior (subshell mirror) and
+# byte-level correctness (regex pin).
+TMP=$(guard_mktemp_d)
+cat > "$TMP/.live-test-config" <<'EOF'
+# malformed: unquoted value with shell meta-character (command substitution)
+CRAPI_DIR=/tmp/`whoami`
+EOF
+# (a) Inline assertion that the regex rejects it (cheap sanity)
+if grep -qvE "$SAFE_REGEX" "$TMP/.live-test-config"; then
+    pass "safety regex rejects unsafe config (would prevent teardown from sourcing it)"
+else
+    fail "safety regex accepts unsafe config — teardown could source command-injection attempt"
+fi
+
+# (b) Behavioral: extract the actual teardown loader block from
+# setup-live-targets.sh and run it against the malformed config in a
+# subshell. The loader uses `! grep -qvE <regex> "$CONFIG_FILE"` to
+# decide whether to source — so a malformed config means grep -qvE
+# matches (returns 0), the negation fails, and we DON'T enter the
+# source branch. Assert the malicious assignment is NOT applied.
+( # subshell — prod loader uses CONFIG_FILE, mirror it
+    CONFIG_FILE="$TMP/.live-test-config"
+    CRAPI_DIR="(unset)"
+    # shellcheck disable=SC2310 # using guard like prod does
+    if [ -f "$CONFIG_FILE" ]; then
+        if ! grep -qvE "$SAFE_REGEX" "$CONFIG_FILE"; then
+            # shellcheck source=/dev/null
+            . "$CONFIG_FILE"
+        fi
+    fi
+    # If the gate worked, CRAPI_DIR keeps its sentinel value.
+    [ "$CRAPI_DIR" = "(unset)" ] && exit 0 || exit 1
+)
+if [ $? -eq 0 ]; then
+    pass "teardown loader behavioral test: malformed config does NOT mutate CRAPI_DIR"
+else
+    fail "teardown loader behavioral test: malformed config WAS sourced (CRAPI_DIR mutated)"
+fi
+rm -rf "$TMP"
+
+# Iter-9 follow-up: behavioral test for the post-source CRAPI_DIR-existence
+# reset branch in setup-live-targets.sh teardown (lines ~132-137). When the
+# saved CRAPI_DIR from .live-test-config points to a directory that no
+# longer exists (operator deleted their --crapi-dir tree, or moved it),
+# the loader must clear CRAPI_DIR back to empty so the teardown falls
+# through to the default clone path. A regression that drops the reset
+# would silently target the missing path and leave both the missing dir's
+# `docker compose down` ineffective AND the default clone untouched.
+TMP=$(guard_mktemp_d)
+cat > "$TMP/.live-test-config" <<EOF
+CRAPI_DIR="$TMP/this/path/does/not/exist"
+EOF
+( # subshell mirroring the prod loader logic at setup-live-targets.sh:128-138
+    CONFIG_FILE="$TMP/.live-test-config"
+    CRAPI_DIR=""
+    if [ -f "$CONFIG_FILE" ]; then
+        if ! grep -qvE "$SAFE_REGEX" "$CONFIG_FILE"; then
+            # shellcheck source=/dev/null
+            . "$CONFIG_FILE"
+            if [ -n "${CRAPI_DIR:-}" ] && [ ! -d "$CRAPI_DIR" ]; then
+                CRAPI_DIR=""
+            fi
+        fi
+    fi
+    # If the reset branch fired, CRAPI_DIR is now empty.
+    [ -z "$CRAPI_DIR" ] && exit 0 || exit 1
+)
+if [ $? -eq 0 ]; then
+    pass "teardown loader CRAPI_DIR-existence reset: missing saved path is cleared to empty"
+else
+    fail "teardown loader does NOT reset CRAPI_DIR when saved path is missing — would target nonexistent dir"
+fi
+rm -rf "$TMP"
+
+# Iter-7 TEST-005 (extended in iter-8): pin SAFE_REGEX to ALL THREE prod
+# copies — run-live-tests.sh, test-llm-planner.sh, AND setup-live-targets.sh
+# (teardown reload). A divergence in any of the three locations would be
+# silently invisible to the harness without this triple check.
+PROD_REGEX_RUN=$(grep -oE "'[^']*\\^\[\[:space:\]\]\\*\(#\\.\\*\)\\?\\\$\\|[^']+'" test/run-live-tests.sh | head -1)
+PROD_REGEX_PLN=$(grep -oE "'[^']*\\^\[\[:space:\]\]\\*\(#\\.\\*\)\\?\\\$\\|[^']+'" test/test-llm-planner.sh | head -1)
+PROD_REGEX_SET=$(grep -oE "'[^']*\\^\[\[:space:\]\]\\*\(#\\.\\*\)\\?\\\$\\|[^']+'" test/setup-live-targets.sh | head -1)
+HARNESS_REGEX="'$SAFE_REGEX'"
+if [ -n "$PROD_REGEX_RUN" ] && [ "$PROD_REGEX_RUN" = "$HARNESS_REGEX" ] && \
+   [ -n "$PROD_REGEX_PLN" ] && [ "$PROD_REGEX_PLN" = "$HARNESS_REGEX" ] && \
+   [ -n "$PROD_REGEX_SET" ] && [ "$PROD_REGEX_SET" = "$HARNESS_REGEX" ]; then
+    pass "harness SAFE_REGEX byte-matches prod regex in run-live-tests.sh, test-llm-planner.sh, AND setup-live-targets.sh (teardown reload)"
+else
+    fail "SAFE_REGEX divergence: harness=[$HARNESS_REGEX] run=[$PROD_REGEX_RUN] planner=[$PROD_REGEX_PLN] setup=[$PROD_REGEX_SET]"
+fi
+
+# Iter-7 TEST-009: TEST-006 awk should explicitly terminate at the
+# function-call closing paren (not rely on later SPEC_CACHE_DIR
+# occurrences). Assert the awk script in our own harness contains the
+# literal `/^\)$/) { exit }` early-exit clause.
+if grep -qF 'if (line ~ /^\)$/) { exit }' test/regression/lab-2247-regression-tests.sh; then
+    pass "TEST-006 awk has explicit closing-paren termination (no scan past patcher call)"
+else
+    fail "TEST-006 awk lacks explicit termination — fragile to later SPEC_CACHE_DIR occurrences"
+fi
+
+echo
+echo "=== Summary ==="
+echo "Tests run:    $TESTS_RUN"
+echo "Tests failed: $TESTS_FAIL"
+exit $TESTS_FAIL

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -40,22 +40,43 @@ HADRIAN_BIN="${HADRIAN_BIN:-${REPO_ROOT}/hadrian}"
 OUTPUT_DIR="${SCRIPT_DIR}/.results"
 CONFIG_FILE="${SCRIPT_DIR}/.live-test-config"
 
-# Load config from setup script if it exists (ports, paths)
+# Load config from setup script if it exists (ports, paths).
+# The regex requires every value to be double-quoted so `source` can't
+# word-split a path containing whitespace into a command (the previous
+# regex permitted unquoted values with spaces, which made
+# `--crapi-dir '/tmp/foo bar'` exec `bar`). Quoted form is what
+# setup-live-targets.sh writes; an old/loose config will be rejected
+# loudly — re-run setup to regenerate.
 if [ -f "$CONFIG_FILE" ]; then
-    # Validate config contains only comments, blank lines, or safe KEY=VALUE assignments
-    if grep -qvE '^[[:space:]]*(#.*)?$|^[A-Za-z_][A-Za-z0-9_]*=[A-Za-z0-9_./:@,+" -]*$' "$CONFIG_FILE"; then
-        echo "ERROR: Config file $CONFIG_FILE contains unsafe content. Only KEY=VALUE lines are allowed." >&2
+    if grep -qvE '^[[:space:]]*(#.*)?$|^[A-Za-z_][A-Za-z0-9_]*="[A-Za-z0-9_./:@,+ -]*"$' "$CONFIG_FILE"; then
+        echo "ERROR: $CONFIG_FILE contains unsafe content. Expected only comments, blank lines, or KEY=\"VALUE\" assignments. Re-run setup-live-targets.sh to regenerate." >&2
         exit 1
     fi
     # shellcheck disable=SC1090
     . "$CONFIG_FILE"
 fi
 
+# Default ports — the single source of truth for "what port does target X
+# bind by default". Conditionals later in the script reference these
+# constants instead of hardcoded literals so a future port move only has
+# to touch one place per target.
+VULN_API_DEFAULT_PORT=9889
+DVGA_DEFAULT_PORT=5013
+GRPC_DEFAULT_PORT=50051
+# CRAPI default port comes from crapi-helpers.sh
+# (CRAPI_OPENAPI_SPEC_DEFAULT_PORT, sourced below).
+
 # Target ports (env vars > config file > defaults)
-VULN_API_PORT="${VULN_API_PORT:-8889}"
-DVGA_PORT="${DVGA_PORT:-5013}"
-GRPC_PORT="${GRPC_PORT:-50051}"
-CRAPI_PORT="${CRAPI_PORT:-8888}"
+VULN_API_PORT="${VULN_API_PORT:-$VULN_API_DEFAULT_PORT}"
+DVGA_PORT="${DVGA_PORT:-$DVGA_DEFAULT_PORT}"
+GRPC_PORT="${GRPC_PORT:-$GRPC_DEFAULT_PORT}"
+
+# Shared crAPI helpers (canonical users, signup/login, spec patcher).
+# shellcheck source=test/crapi/crapi-helpers.sh
+. "${SCRIPT_DIR}/crapi/crapi-helpers.sh"
+
+# CRAPI_PORT default tracks the helper's CRAPI_OPENAPI_SPEC_DEFAULT_PORT.
+CRAPI_PORT="${CRAPI_PORT:-$CRAPI_OPENAPI_SPEC_DEFAULT_PORT}"
 
 # Require Bash 4+ for associative arrays
 if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
@@ -132,28 +153,19 @@ get_duration() { echo "${DURATION[$1]:-0}"; }
 
 # ==== Helper functions ====
 
+# All log_* helpers write to stderr so they don't collide with values
+# captured from `$(...)`. Same convention as setup-live-targets.sh.
 log_header() {
-    echo ""
-    echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════════════════${NC}"
-    echo -e "${BOLD}${BLUE}  $1${NC}"
-    echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════════════════${NC}"
+    echo "" >&2
+    echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════════════════${NC}" >&2
+    echo -e "${BOLD}${BLUE}  $1${NC}" >&2
+    echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════════════════${NC}" >&2
 }
 
-log_info() {
-    echo -e "${CYAN}[INFO]${NC} $1"
-}
-
-log_ok() {
-    echo -e "${GREEN}[OK]${NC} $1"
-}
-
-log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_fail() {
-    echo -e "${RED}[FAIL]${NC} $1"
-}
+log_info() { echo -e "${CYAN}[INFO]${NC} $1" >&2; }
+log_ok()   { echo -e "${GREEN}[OK]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1" >&2; }
 
 wait_for_http() {
     local url=$1
@@ -291,11 +303,13 @@ if echo "$TARGETS" | grep -q "vulnerable-api"; then
     VULN_API_AUTH_METHODS="bearer api_key basic cookie"
     VULN_API_SKIP_ALL=false
 
-    # If using a non-default port, patch the OpenAPI spec's server URL
+    # If using a non-default port, patch the OpenAPI spec's server URL.
+    # Default and the substitution target both come from
+    # VULN_API_DEFAULT_PORT so a future port move is a single-line edit.
     VULN_API_SPEC="${SCRIPT_DIR}/vulnerable-api/openapi.yaml"
-    if [ "$VULN_API_PORT" != "8889" ]; then
+    if [ "$VULN_API_PORT" != "$VULN_API_DEFAULT_PORT" ]; then
         VULN_API_SPEC="${OUTPUT_DIR}/vulnerable-api-openapi.yaml"
-        sed "s|http://localhost:8889|http://localhost:${VULN_API_PORT}|g" \
+        sed "s|http://localhost:${VULN_API_DEFAULT_PORT}|http://localhost:${VULN_API_PORT}|g" \
             "${SCRIPT_DIR}/vulnerable-api/openapi.yaml" > "$VULN_API_SPEC"
         log_info "Patched OpenAPI spec to use port $VULN_API_PORT"
     fi
@@ -634,52 +648,35 @@ if echo "$TARGETS" | grep -q "crapi"; then
 
     if [ "$(get_status crapi)" != "SKIP" ]; then
         # ---- Setup: Auto-create users and acquire tokens ----
+        # Canonical user identities, signup, and login come from
+        # crapi-helpers.sh (sourced at the top of this script). That file
+        # is the single source of truth for credentials so this script and
+        # test-llm-planner.sh can't drift.
         log_info "Setting up crapi test users and tokens..."
 
-        crapi_signup() {
-            local email="$1" name="$2" number="$3" password="$4"
-            printf '{"email":"%s","name":"%s","number":"%s","password":"%s"}' "$email" "$name" "$number" "$password" | \
-                curl -sf -X POST "${CRAPI_URL}/identity/api/auth/signup" \
-                    -H "Content-Type: application/json" \
-                    --data-binary @- 2>/dev/null || true
-        }
+        if ! crapi_setup_users "$CRAPI_URL"; then
+            log_fail "crapi user provisioning failed (see error above)"
+            set_status "crapi" "ERROR"
+        fi
+    fi
 
-        crapi_login() {
-            local email="$1" password="$2"
-            printf '{"email":"%s","password":"%s"}' "$email" "$password" | \
-                curl -sf -X POST "${CRAPI_URL}/identity/api/auth/login" \
-                    -H "Content-Type: application/json" \
-                    --data-binary @- 2>/dev/null | \
-                python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo ""
-        }
-
-        crapi_mechanic_signup() {
-            local email="$1" name="$2" number="$3" password="$4" code="$5"
-            printf '{"email":"%s","name":"%s","number":"%s","password":"%s","mechanic_code":"%s"}' "$email" "$name" "$number" "$password" "$code" | \
-                curl -sf -X POST "${CRAPI_URL}/workshop/api/mechanic/signup" \
-                    -H "Content-Type: application/json" \
-                    --data-binary @- 2>/dev/null || true
-        }
-
-        CRAPI_ADMIN_EMAIL="hadrian-admin@test.com"
-        CRAPI_USER_EMAIL="hadrian-user1@test.com"
-        CRAPI_USER2_EMAIL="hadrian-user2@test.com"
-        CRAPI_MECHANIC_EMAIL="hadrian-mechanic@test.com"
-        CRAPI_PASSWORD="${CRAPI_PASSWORD:-HadrianTest123!}"
-
-        crapi_signup "$CRAPI_ADMIN_EMAIL" "Hadrian Admin" "1111111111" "$CRAPI_PASSWORD" >/dev/null
-        crapi_signup "$CRAPI_USER_EMAIL" "Hadrian User1" "2222222222" "$CRAPI_PASSWORD" >/dev/null
-        crapi_signup "$CRAPI_USER2_EMAIL" "Hadrian User2" "3333333333" "$CRAPI_PASSWORD" >/dev/null
-        crapi_mechanic_signup "$CRAPI_MECHANIC_EMAIL" "Hadrian Mechanic" "4444444444" "$CRAPI_PASSWORD" "TRAC_MECH1" >/dev/null
+    # Re-check status: skip the test phase if provisioning errored.
+    if [ "$(get_status crapi)" != "SKIP" ] && [ "$(get_status crapi)" != "ERROR" ]; then
         log_ok "crapi users created/verified"
 
-        CRAPI_ADMIN_TOKEN=$(crapi_login "$CRAPI_ADMIN_EMAIL" "$CRAPI_PASSWORD")
-        CRAPI_USER_TOKEN=$(crapi_login "$CRAPI_USER_EMAIL" "$CRAPI_PASSWORD")
-        CRAPI_USER2_TOKEN=$(crapi_login "$CRAPI_USER2_EMAIL" "$CRAPI_PASSWORD")
-        CRAPI_MECHANIC_TOKEN=$(crapi_login "$CRAPI_MECHANIC_EMAIL" "$CRAPI_PASSWORD")
+        CRAPI_ADMIN_TOKEN=$(crapi_login    "$CRAPI_URL" "$CRAPI_ADMIN_EMAIL"    "$CRAPI_PASSWORD")
+        CRAPI_USER_TOKEN=$(crapi_login     "$CRAPI_URL" "$CRAPI_USER_EMAIL"     "$CRAPI_PASSWORD")
+        CRAPI_USER2_TOKEN=$(crapi_login    "$CRAPI_URL" "$CRAPI_USER2_EMAIL"    "$CRAPI_PASSWORD")
+        CRAPI_MECHANIC_TOKEN=$(crapi_login "$CRAPI_URL" "$CRAPI_MECHANIC_EMAIL" "$CRAPI_PASSWORD")
 
-        if [ -z "$CRAPI_USER_TOKEN" ] || [ -z "$CRAPI_USER2_TOKEN" ]; then
-            log_fail "Failed to acquire crapi tokens"
+        # All four tokens must be acquired — admin and mechanic are used by
+        # role-specific templates (BFLA admin-video-delete, mechanic
+        # workflows). A missing token here would silently produce
+        # `token: ""` in the auth file and degrade those tests to anonymous
+        # requests. Fail loudly instead.
+        if [ -z "$CRAPI_ADMIN_TOKEN" ] || [ -z "$CRAPI_USER_TOKEN" ] \
+                || [ -z "$CRAPI_USER2_TOKEN" ] || [ -z "$CRAPI_MECHANIC_TOKEN" ]; then
+            log_fail "Failed to acquire crapi tokens (admin/user1/user2/mechanic must all be non-empty)"
             set_status "crapi" "ERROR"
         else
             log_ok "crapi tokens acquired"
@@ -721,26 +718,56 @@ EOF
 
             RESULT_FILE="${OUTPUT_DIR}/crapi-results.json"
 
-            # If using a non-default port, patch the OpenAPI spec
-            CRAPI_SPEC="${SCRIPT_DIR}/crapi/crapi-openapi-spec.json"
-            if [ "$CRAPI_PORT" != "8888" ]; then
-                CRAPI_SPEC="${OUTPUT_DIR}/crapi-openapi-spec.json"
-                sed "s|http://localhost:8888|http://localhost:${CRAPI_PORT}|g" \
-                    "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" > "$CRAPI_SPEC"
-                log_info "Patched OpenAPI spec to use port $CRAPI_PORT"
+            # Prefer the spec patched at setup time (CRAPI_SPEC_FILE in
+            # .live-test-config), but only if its baked-in port matches
+            # the port we're about to test against. If the operator
+            # overrides CRAPI_PORT at runtime (e.g.
+            # `CRAPI_PORT=9999 ./run-live-tests.sh`), the cached spec
+            # will be pinned to the old port and silently mis-route
+            # every request — so re-patch in that case.
+            # When re-patching, write into the same SPEC_CACHE_DIR
+            # setup-live-targets.sh uses so the artifact lives alongside
+            # the cache rather than mixed into the JSON results dir.
+            SPEC_CACHE_DIR="${SCRIPT_DIR}/.live-test-cache"
+            CRAPI_SPEC=""
+            # Anchor the port match on a non-digit / end-of-line boundary
+            # so CRAPI_PORT=889 doesn't accept a stale spec pinned to
+            # localhost:8895 (substring match).
+            if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "${CRAPI_SPEC_FILE}" ] \
+                    && grep -qE "localhost:${CRAPI_PORT}([^0-9]|\$)" "$CRAPI_SPEC_FILE"; then
+                CRAPI_SPEC="$CRAPI_SPEC_FILE"
+            else
+                if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "${CRAPI_SPEC_FILE}" ]; then
+                    log_info "Cached spec at ${CRAPI_SPEC_FILE} does not match CRAPI_PORT=${CRAPI_PORT}; re-patching."
+                fi
+                mkdir -p "$SPEC_CACHE_DIR"
+                CRAPI_SPEC=$(crapi_patch_openapi_spec \
+                    "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
+                    "$CRAPI_PORT" \
+                    "$SPEC_CACHE_DIR")
+                if [ "$CRAPI_PORT" != "$CRAPI_OPENAPI_SPEC_DEFAULT_PORT" ]; then
+                    log_info "Patched OpenAPI spec to use port $CRAPI_PORT"
+                fi
             fi
+            # Guard against silent failure of crapi_patch_openapi_spec —
+            # an empty path here would pass `--api ""` to hadrian and
+            # produce an opaque downstream error.
+            if [ -z "$CRAPI_SPEC" ] || [ ! -f "$CRAPI_SPEC" ]; then
+                log_fail "Could not resolve crAPI OpenAPI spec (empty path or missing file)"
+                set_status "crapi" "ERROR"
+            else
+                run_hadrian "crapi" test rest \
+                    --api "$CRAPI_SPEC" \
+                    --roles "${SCRIPT_DIR}/crapi/roles.yaml" \
+                    --auth "$CRAPI_AUTH_FILE" \
+                    --template-dir "${SCRIPT_DIR}/crapi/templates/owasp" \
+                    --output json \
+                    --output-file "$RESULT_FILE" \
+                    $VERBOSE
 
-            run_hadrian "crapi" test rest \
-                --api "$CRAPI_SPEC" \
-                --roles "${SCRIPT_DIR}/crapi/roles.yaml" \
-                --auth "$CRAPI_AUTH_FILE" \
-                --template-dir "${SCRIPT_DIR}/crapi/templates/owasp" \
-                --output json \
-                --output-file "$RESULT_FILE" \
-                $VERBOSE
-
-            set_findings "crapi" "$(extract_finding_count "$RESULT_FILE")"
-            log_ok "crapi: $(get_findings crapi) findings in $(get_duration crapi)s"
+                set_findings "crapi" "$(extract_finding_count "$RESULT_FILE")"
+                log_ok "crapi: $(get_findings crapi) findings in $(get_duration crapi)s"
+            fi
         fi
     fi
 fi

--- a/test/setup-live-targets.sh
+++ b/test/setup-live-targets.sh
@@ -14,8 +14,16 @@
 #                      Valid: vulnerable-api,dvga,grpc,crapi
 #   --crapi-dir <dir>  Path to existing crAPI repo (skips clone)
 #   --skip-start       Only build/pull, don't start services
-#   --teardown         Stop and remove all running targets
+#   --no-build         Skip rebuilding hadrian and Go targets if binaries exist
+#   --teardown         Stop and remove all running targets (and their volumes)
+#   --purge            With --teardown, also remove the cached crAPI clone
 #   --help             Show this help message
+#
+# Environment overrides:
+#   VULN_API_PORT_OVERRIDE  Force a specific port for vulnerable-api
+#   DVGA_PORT_OVERRIDE      Force a specific port for dvga
+#   GRPC_PORT_OVERRIDE      Force a specific port for grpc-server
+#   CRAPI_PORT_OVERRIDE     Force a specific port for crAPI's web service
 # =============================================================================
 
 set -euo pipefail
@@ -23,18 +31,29 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CONFIG_FILE="${SCRIPT_DIR}/.live-test-config"
+SPEC_CACHE_DIR="${SCRIPT_DIR}/.live-test-cache"
 
-# Default ports
-VULN_API_PORT=8889
-DVGA_PORT=5013
-GRPC_PORT=50051
-CRAPI_PORT=8888
+# Default ports. The script will pick these unless they're already in use,
+# in which case find_available_port walks forward until it finds a free one
+# (skipping any ports already claimed earlier in the same run).
+# CRAPI default tracks crapi-helpers.sh's CRAPI_OPENAPI_SPEC_DEFAULT_PORT
+# (sourced below) so a future spec-port move flows through one place.
+DEFAULT_VULN_API_PORT=9889
+DEFAULT_DVGA_PORT=5013
+DEFAULT_GRPC_PORT=50051
+
+VULN_API_PORT=$DEFAULT_VULN_API_PORT
+DVGA_PORT=$DEFAULT_DVGA_PORT
+GRPC_PORT=$DEFAULT_GRPC_PORT
+CRAPI_READY=true
 
 # Defaults
 TARGETS="vulnerable-api,dvga,grpc,crapi"
 CRAPI_DIR=""
 SKIP_START=false
 TEARDOWN=false
+PURGE=false
+DO_BUILD=true
 
 # Colors
 RED='\033[0;31m'
@@ -45,16 +64,30 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+# All log_* helpers write to stderr. Several functions in this script
+# (find_available_port, resolve_target_port, crapi_patch_openapi_spec)
+# echo their result on stdout for capture via `$(...)`. If log_* wrote to
+# stdout, an error message during a port walk would silently end up
+# inside the captured port value — a real bug seen during code review.
 log_header() {
-    echo ""
-    echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════════════════${NC}"
-    echo -e "${BOLD}${BLUE}  $1${NC}"
-    echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════════════════${NC}"
+    echo "" >&2
+    echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════════════════${NC}" >&2
+    echo -e "${BOLD}${BLUE}  $1${NC}" >&2
+    echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════════════════${NC}" >&2
 }
-log_info()  { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_ok()    { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_fail()  { echo -e "${RED}[FAIL]${NC} $1"; }
+log_info()  { echo -e "${CYAN}[INFO]${NC} $1" >&2; }
+log_ok()    { echo -e "${GREEN}[OK]${NC} $1" >&2; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+log_fail()  { echo -e "${RED}[FAIL]${NC} $1" >&2; }
+
+# Load shared crAPI helpers (canonical users, signup/login, spec patcher).
+# shellcheck source=test/crapi/crapi-helpers.sh
+. "${SCRIPT_DIR}/crapi/crapi-helpers.sh"
+
+# crAPI default port comes from the helper's CRAPI_OPENAPI_SPEC_DEFAULT_PORT
+# so the spec-patch default and the setup default move together.
+DEFAULT_CRAPI_PORT="$CRAPI_OPENAPI_SPEC_DEFAULT_PORT"
+CRAPI_PORT=$DEFAULT_CRAPI_PORT
 
 # ==== Argument parsing ====
 while [ $# -gt 0 ]; do
@@ -62,7 +95,9 @@ while [ $# -gt 0 ]; do
         --targets)    TARGETS="$2"; shift 2 ;;
         --crapi-dir)  CRAPI_DIR="$2"; shift 2 ;;
         --skip-start) SKIP_START=true; shift ;;
+        --no-build)   DO_BUILD=false; shift ;;
         --teardown)   TEARDOWN=true; shift ;;
+        --purge)      PURGE=true; shift ;;
         --help)
             sed -n '2,/^# =====/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
             exit 0
@@ -71,6 +106,12 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# --purge only removes the cached crAPI clone inside the --teardown branch.
+# Warn loudly if the user passes --purge alone so it's not a silent no-op.
+if [ "$PURGE" = true ] && [ "$TEARDOWN" != true ]; then
+    log_warn "--purge requires --teardown to take effect; ignoring."
+fi
+
 # ==== Teardown ====
 if [ "$TEARDOWN" = true ]; then
     log_header "Tearing Down Live Targets"
@@ -78,52 +119,116 @@ if [ "$TEARDOWN" = true ]; then
     pkill -f "vulnerable-api$" 2>/dev/null && log_ok "Stopped vulnerable-api" || true
     pkill -f "grpc-server$" 2>/dev/null && log_ok "Stopped grpc-server" || true
 
+    # If the operator ran setup with `--crapi-dir /custom/path`, the saved
+    # path lives in .live-test-config. Without re-reading it here the
+    # teardown's docker compose down would target the wrong directory and
+    # leave the actual containers + volumes running (the very state this
+    # PR was trying to clean up reliably). Honor the saved value before
+    # falling back to the default clone path.
+    if [ -z "$CRAPI_DIR" ] && [ -f "$CONFIG_FILE" ]; then
+        if ! grep -qvE '^[[:space:]]*(#.*)?$|^[A-Za-z_][A-Za-z0-9_]*="[A-Za-z0-9_./:@,+ -]*"$' "$CONFIG_FILE"; then
+            # shellcheck disable=SC1090
+            . "$CONFIG_FILE"
+            if [ -n "${CRAPI_DIR:-}" ] && [ ! -d "$CRAPI_DIR" ]; then
+                log_warn "Saved CRAPI_DIR=${CRAPI_DIR} from .live-test-config does not exist; ignoring."
+                CRAPI_DIR=""
+            elif [ -n "${CRAPI_DIR:-}" ]; then
+                log_info "Using saved CRAPI_DIR=${CRAPI_DIR} from .live-test-config"
+            fi
+        fi
+    fi
+
     if command -v docker >/dev/null 2>&1; then
         docker rm -f hadrian-dvga 2>/dev/null && log_ok "Removed dvga container" || true
+
         CRAPI_COMPOSE="${CRAPI_DIR:-${SCRIPT_DIR}/.crapi-repo}/deploy/docker"
-        (cd "$CRAPI_COMPOSE" 2>/dev/null && \
-            docker compose down 2>/dev/null && log_ok "Stopped crapi containers") || true
+        if [ -d "$CRAPI_COMPOSE" ]; then
+            # `down -v --remove-orphans` is required: without `-v`, Postgres
+            # and Mongo named volumes survive teardown, so the next setup
+            # boots crAPI against a dirty DB (phone numbers already
+            # registered, mechanic codes collide, leftover users with
+            # unknown passwords). Stderr is intentionally NOT swallowed —
+            # if teardown fails we want to see why.
+            if (cd "$CRAPI_COMPOSE" && docker compose down -v --remove-orphans); then
+                log_ok "Stopped crapi containers (volumes removed)"
+            else
+                log_warn "crapi teardown returned non-zero; some containers/volumes may remain"
+            fi
+        fi
+
+        if [ "$PURGE" = true ]; then
+            CRAPI_REPO_DEFAULT="${SCRIPT_DIR}/.crapi-repo"
+            # Purge removes the default cached clone iff CRAPI_DIR is
+            # either unset OR explicitly equals the default path. The
+            # earlier `[ -z "$CRAPI_DIR" ]`-only guard pre-dates teardown
+            # reading CRAPI_DIR from .live-test-config — once that load
+            # populates CRAPI_DIR with the default, the empty-string
+            # check would silently skip the rm and `--teardown --purge`
+            # would no-op in the common case (CodeRabbit review
+            # 4258701255 CR-7-2). Operator-supplied --crapi-dir paths
+            # still survive.
+            if [ -d "$CRAPI_REPO_DEFAULT" ] && \
+               { [ -z "$CRAPI_DIR" ] || [ "$CRAPI_DIR" = "$CRAPI_REPO_DEFAULT" ]; }; then
+                rm -rf "$CRAPI_REPO_DEFAULT"
+                log_ok "Removed cached crAPI clone at $CRAPI_REPO_DEFAULT"
+            fi
+        fi
     fi
 
     rm -f "$CONFIG_FILE"
-    log_ok "Removed config file"
+    rm -rf "$SPEC_CACHE_DIR"
+    log_ok "Removed config file and spec cache"
     echo ""
     exit 0
 fi
 
 # ==== Port helpers ====
-port_in_use() {
-    if command -v lsof >/dev/null 2>&1; then
-        lsof -i :"$1" >/dev/null 2>&1
-    elif command -v ss >/dev/null 2>&1; then
-        ss -ltn | grep -q ":$1 "
-    else
-        # Fallback: try to connect
-        (echo >/dev/tcp/localhost/"$1") 2>/dev/null
-    fi
-}
-
-find_available_port() {
-    local base_port=$1
-    local port=$base_port
-    while port_in_use "$port"; do
-        port=$((port + 1))
-        if [ $((port - base_port)) -gt 20 ]; then
-            echo ""
-            return 1
-        fi
-    done
-    echo "$port"
-}
+# port_in_use, find_available_port, _port_excluded, resolve_target_port,
+# and patch_crapi_compose_port live in test/crapi/port-helpers.sh so the
+# regression harness can source the same definitions and any prod-source
+# change automatically affects what the harness asserts.
+# shellcheck source=test/crapi/port-helpers.sh
+. "${SCRIPT_DIR}/crapi/port-helpers.sh"
 
 # ==== Prerequisite checks ====
 log_header "Checking Prerequisites"
 
-if ! command -v go >/dev/null 2>&1; then
-    log_fail "Go is not installed. Install Go 1.21+ from https://go.dev/dl/"
-    exit 1
+# Go is required iff (a) we're going to build at least one Go binary in
+# this run (DO_BUILD=true and a Go target is selected), or (b) the user
+# already-built binary is missing for a Go target. Skip the check when
+# the user runs e.g. `--targets crapi --no-build` on a Docker-only box.
+need_go=false
+if [ "$DO_BUILD" = true ]; then
+    # Hadrian binary itself is always built unless --no-build (handled below).
+    need_go=true
+elif [ ! -x "${REPO_ROOT}/hadrian" ]; then
+    need_go=true
 fi
-log_ok "Go $(go version | awk '{print $3}')"
+# Split per Go-needing target so `--targets vulnerable-api --no-build`
+# doesn't require Go just because the grpc-server binary happens to be
+# missing (and vice versa). Only check the binary that's actually needed
+# for the selected target subset.
+if echo "$TARGETS" | grep -q "vulnerable-api" && \
+       { [ "$DO_BUILD" = true ] \
+         || [ ! -x "${SCRIPT_DIR}/vulnerable-api/vulnerable-api" ]; }; then
+    need_go=true
+fi
+if echo "$TARGETS" | grep -q "grpc" && \
+       { [ "$DO_BUILD" = true ] \
+         || [ ! -x "${SCRIPT_DIR}/grpc-server/grpc-server" ]; }; then
+    need_go=true
+fi
+
+if [ "$need_go" = true ]; then
+    if ! command -v go >/dev/null 2>&1; then
+        log_fail "Go is not installed. Install Go 1.21+ from https://go.dev/dl/"
+        log_info "Or re-run with --no-build if all target binaries already exist and you only need Docker-based targets."
+        exit 1
+    fi
+    log_ok "Go $(go version | awk '{print $3}')"
+else
+    log_ok "Go check skipped (no Go build required)"
+fi
 
 if echo "$TARGETS" | grep -qE "dvga|crapi"; then
     if ! command -v docker >/dev/null 2>&1; then
@@ -177,77 +282,92 @@ fi
 # ==== Find available ports ====
 log_header "Resolving Ports"
 
+# CLAIMED_PORTS tracks every port assigned in this run so subsequent
+# find_available_port calls won't hand out the same number to a different
+# target. Without this, two targets can both end up on (e.g.) 8889 when
+# 8888 is taken on the host: the OS still says 8889 is free between the
+# two assignments because nothing has actually bound it yet.
+CLAIMED_PORTS=()
+
 if echo "$TARGETS" | grep -q "vulnerable-api"; then
-    VULN_API_PORT=$(find_available_port 8889)
-    if [ -z "$VULN_API_PORT" ]; then
-        log_fail "No available port near 8889 for vulnerable-api"
-        exit 1
-    fi
+    VULN_API_PORT=$(resolve_target_port "${VULN_API_PORT_OVERRIDE:-}" \
+        "$DEFAULT_VULN_API_PORT" "vulnerable-api" \
+        "${CLAIMED_PORTS[@]+"${CLAIMED_PORTS[@]}"}") || exit 1
+    CLAIMED_PORTS+=("$VULN_API_PORT")
     log_ok "vulnerable-api -> port $VULN_API_PORT"
 fi
 
 if echo "$TARGETS" | grep -q "dvga"; then
-    DVGA_PORT=$(find_available_port 5013)
-    if [ -z "$DVGA_PORT" ]; then
-        log_fail "No available port near 5013 for dvga"
-        exit 1
-    fi
+    DVGA_PORT=$(resolve_target_port "${DVGA_PORT_OVERRIDE:-}" \
+        "$DEFAULT_DVGA_PORT" "dvga" \
+        "${CLAIMED_PORTS[@]+"${CLAIMED_PORTS[@]}"}") || exit 1
+    CLAIMED_PORTS+=("$DVGA_PORT")
     log_ok "dvga -> port $DVGA_PORT"
 fi
 
 if echo "$TARGETS" | grep -q "grpc"; then
-    GRPC_PORT=$(find_available_port 50051)
-    if [ -z "$GRPC_PORT" ]; then
-        log_fail "No available port near 50051 for grpc-server"
-        exit 1
-    fi
+    GRPC_PORT=$(resolve_target_port "${GRPC_PORT_OVERRIDE:-}" \
+        "$DEFAULT_GRPC_PORT" "grpc-server" \
+        "${CLAIMED_PORTS[@]+"${CLAIMED_PORTS[@]}"}") || exit 1
+    CLAIMED_PORTS+=("$GRPC_PORT")
     log_ok "grpc-server -> port $GRPC_PORT"
 fi
 
 if echo "$TARGETS" | grep -q "crapi"; then
-    CRAPI_PORT=$(find_available_port 8888)
-    if [ -z "$CRAPI_PORT" ]; then
-        log_fail "No available port near 8888 for crapi"
-        exit 1
-    fi
+    CRAPI_PORT=$(resolve_target_port "${CRAPI_PORT_OVERRIDE:-}" \
+        "$DEFAULT_CRAPI_PORT" "crapi" \
+        "${CLAIMED_PORTS[@]+"${CLAIMED_PORTS[@]}"}") || exit 1
+    CLAIMED_PORTS+=("$CRAPI_PORT")
     log_ok "crapi -> port $CRAPI_PORT"
 fi
 
 # ==== Build Go targets ====
 log_header "Building Hadrian and Go Targets"
 
-log_info "Building hadrian..."
-(cd "$REPO_ROOT" && go build -o hadrian ./cmd/hadrian)
-log_ok "hadrian built"
+if [ "$DO_BUILD" = true ] || [ ! -x "${REPO_ROOT}/hadrian" ]; then
+    log_info "Building hadrian..."
+    (cd "$REPO_ROOT" && go build -o hadrian ./cmd/hadrian)
+    log_ok "hadrian built"
+else
+    log_ok "hadrian binary exists (--no-build, skipping)"
+fi
 
 if echo "$TARGETS" | grep -q "vulnerable-api"; then
-    log_info "Building vulnerable-api..."
-    (cd "${SCRIPT_DIR}/vulnerable-api" && go build -o vulnerable-api .)
-    log_ok "vulnerable-api built"
+    if [ "$DO_BUILD" = true ] || [ ! -x "${SCRIPT_DIR}/vulnerable-api/vulnerable-api" ]; then
+        log_info "Building vulnerable-api..."
+        (cd "${SCRIPT_DIR}/vulnerable-api" && go build -o vulnerable-api .)
+        log_ok "vulnerable-api built"
+    else
+        log_ok "vulnerable-api binary exists (--no-build, skipping)"
+    fi
 fi
 
 if echo "$TARGETS" | grep -q "grpc"; then
-    log_info "Building grpc-server..."
-    (cd "${SCRIPT_DIR}/grpc-server" && {
-        # Check for actual generated files, not just directory existence
-        # This handles the case where pb/ exists but is empty from a failed run
-        if [ ! -f pb/service.pb.go ] || [ ! -f pb/service_grpc.pb.go ]; then
-            log_info "Generating protobuf code..."
-            # Clean up any empty/corrupted pb directory from previous failed runs
-            rm -rf pb
-            mkdir -p pb
-            if ! protoc --go_out=pb --go_opt=paths=source_relative \
-                --go-grpc_out=pb --go-grpc_opt=paths=source_relative \
-                service.proto; then
-                log_fail "protoc failed to generate Go code"
-                rm -rf pb  # Clean up on failure
-                exit 1
+    if [ "$DO_BUILD" = true ] || [ ! -x "${SCRIPT_DIR}/grpc-server/grpc-server" ]; then
+        log_info "Building grpc-server..."
+        (cd "${SCRIPT_DIR}/grpc-server" && {
+            # Check for actual generated files, not just directory existence
+            # This handles the case where pb/ exists but is empty from a failed run
+            if [ ! -f pb/service.pb.go ] || [ ! -f pb/service_grpc.pb.go ]; then
+                log_info "Generating protobuf code..."
+                # Clean up any empty/corrupted pb directory from previous failed runs
+                rm -rf pb
+                mkdir -p pb
+                if ! protoc --go_out=pb --go_opt=paths=source_relative \
+                    --go-grpc_out=pb --go-grpc_opt=paths=source_relative \
+                    service.proto; then
+                    log_fail "protoc failed to generate Go code"
+                    rm -rf pb  # Clean up on failure
+                    exit 1
+                fi
+                log_ok "Protobuf code generated"
             fi
-            log_ok "Protobuf code generated"
-        fi
-        go build -o grpc-server .
-    })
-    log_ok "grpc-server built"
+            go build -o grpc-server .
+        })
+        log_ok "grpc-server built"
+    else
+        log_ok "grpc-server binary exists (--no-build, skipping)"
+    fi
 fi
 
 # ==== Pull Docker images ====
@@ -275,21 +395,20 @@ if echo "$TARGETS" | grep -q "crapi"; then
     fi
 
     COMPOSE_DIR="${CRAPI_DIR}/deploy/docker"
+    COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 
     # Reset docker-compose.yml to original state (undo any previous sed patches)
     if [ -d "${CRAPI_DIR}/.git" ]; then
         (cd "$CRAPI_DIR" && git checkout -- deploy/docker/docker-compose.yml 2>/dev/null) || true
         log_info "Reset docker-compose.yml to original"
-    elif [ -f "${COMPOSE_DIR}/docker-compose.yml.bak" ]; then
-        cp "${COMPOSE_DIR}/docker-compose.yml.bak" "${COMPOSE_DIR}/docker-compose.yml"
+    elif [ -f "${COMPOSE_FILE}.bak" ]; then
+        cp "${COMPOSE_FILE}.bak" "$COMPOSE_FILE"
         log_info "Restored docker-compose.yml from backup"
     fi
 
-    # Patch docker-compose port if not default (crAPI hardcodes 8888)
-    if [ "$CRAPI_PORT" != "8888" ]; then
-        log_info "Patching crAPI docker-compose to use port $CRAPI_PORT..."
-        sed -i.bak "s/8888:80/${CRAPI_PORT}:80/g" "${COMPOSE_DIR}/docker-compose.yml"
-        log_ok "Patched crAPI to port $CRAPI_PORT"
+    # patch_crapi_compose_port is sourced from test/crapi/port-helpers.sh.
+    if ! patch_crapi_compose_port "$COMPOSE_FILE" "$CRAPI_PORT"; then
+        exit 1
     fi
 fi
 
@@ -332,18 +451,17 @@ if [ "$SKIP_START" = false ]; then
 
     if echo "$TARGETS" | grep -q "crapi"; then
         log_info "Waiting for crapi to be ready (may take up to 2 minutes)..."
-        CRAPI_READY=true
         elapsed=0
         while ! curl -s -o /dev/null -w "%{http_code}" "http://localhost:${CRAPI_PORT}/identity/api/auth/login" 2>/dev/null | grep -qE "^[2-4]"; do
             sleep 5
             elapsed=$((elapsed + 5))
             if [ $elapsed -ge 180 ]; then
-                log_warn "crapi did not respond within 180s"
+                log_fail "crapi did not respond within 180s"
                 log_warn "Container status:"
                 (cd "${CRAPI_DIR}/deploy/docker" && docker compose ps 2>&1) || true
                 log_warn "crapi-web logs:"
-                (cd "${CRAPI_DIR}/deploy/docker" && docker compose logs crapi-web 2>&1 | tail -10) || true
-                log_warn "crapi will be skipped during test run. Debug with:"
+                (cd "${CRAPI_DIR}/deploy/docker" && docker compose logs crapi-web 2>&1 | tail -20) || true
+                log_info "Debug with:"
                 log_info "  cd ${CRAPI_DIR}/deploy/docker && docker compose ps"
                 log_info "  docker compose logs <container-name>"
                 CRAPI_READY=false
@@ -358,18 +476,83 @@ if [ "$SKIP_START" = false ]; then
     fi
 fi
 
+# ==== Fail fast on crapi readiness ====
+# A failed readiness probe used to print warnings and continue, writing
+# .live-test-config and exiting 0. Downstream test scripts then assumed
+# crAPI was up, and CI treated the setup as successful. Now we exit
+# non-zero with crAPI in the target set so the failure is visible.
+if [ "$CRAPI_READY" != true ]; then
+    log_fail "crAPI did not become ready. Re-run setup or pass a different --targets list."
+    log_info "To run other targets without crapi: --targets vulnerable-api,dvga,grpc"
+    exit 1
+fi
+
+# ==== Sign up canonical crAPI users ====
+# crapi_setup_users verifies each signup by attempting a login and
+# retries on failure. If it still can't provision a user, that's a hard
+# fail — without users, every downstream test against crAPI is broken.
+if [ "$SKIP_START" = false ] && echo "$TARGETS" | grep -q "crapi"; then
+    log_header "Setting Up crAPI Users"
+    log_info "Signing up canonical users..."
+    if ! crapi_setup_users "http://localhost:${CRAPI_PORT}"; then
+        log_fail "crapi user provisioning failed (see error above)"
+        exit 1
+    fi
+    log_ok "crapi users created and verified"
+fi
+
+# ==== Build patched OpenAPI spec for crAPI ====
+# The spec hardcodes localhost:8888 in its servers[] entry and at least
+# one report_link example. When CRAPI_PORT differs, downstream scripts
+# that read the spec verbatim end up pointing hadrian at port 8888 even
+# though crAPI is listening elsewhere. Centralize the patch here so every
+# downstream script reads CRAPI_SPEC_FILE from .live-test-config.
+CRAPI_SPEC_FILE=""
+if echo "$TARGETS" | grep -q "crapi"; then
+    log_info "Preparing crAPI OpenAPI spec for port ${CRAPI_PORT}..."
+    CRAPI_SPEC_FILE=$(crapi_patch_openapi_spec \
+        "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
+        "$CRAPI_PORT" \
+        "$SPEC_CACHE_DIR")
+    # Under set -e, $(failing) usually exits — but $(false_at_exit_1) inside
+    # an assignment is one of bash's quietly-permissive corners across some
+    # versions, so check explicitly. An empty CRAPI_SPEC_FILE here would be
+    # a misleading "ready" log + an empty CRAPI_SPEC_FILE= line in the
+    # config that downstream consumers fail loudly on later.
+    if [ -z "$CRAPI_SPEC_FILE" ]; then
+        log_fail "crapi_patch_openapi_spec returned empty path; aborting."
+        exit 1
+    fi
+    log_ok "OpenAPI spec ready at $CRAPI_SPEC_FILE"
+fi
+
 # ==== Write config file ====
 log_header "Writing Configuration"
+
+# Path values are written quoted (KEY="VALUE") below, and the readers in
+# run-live-tests.sh and test-llm-planner.sh reject any line that doesn't
+# match `^[A-Za-z_][A-Za-z0-9_]*="[A-Za-z0-9_./:@,+ -]*"$` — quoted-only.
+# Inside double quotes, `source` does NOT word-split, so paths with
+# spaces (e.g. a repo cloned to `/Users/name/My Code/hadrian/`) round-
+# trip safely. The earlier whitespace-rejection loop here was redundant
+# defense and broke valid paths (CodeRabbit review 4258701255 CR-7-3).
 
 cat > "$CONFIG_FILE" <<EOF
 # Auto-generated by setup-live-targets.sh on $(date -Iseconds 2>/dev/null || date)
 # Source this or let run-live-tests.sh read it automatically.
-VULN_API_PORT=${VULN_API_PORT}
-DVGA_PORT=${DVGA_PORT}
-GRPC_PORT=${GRPC_PORT}
-CRAPI_PORT=${CRAPI_PORT}
-CRAPI_DIR=${CRAPI_DIR}
-TARGETS_SETUP=${TARGETS}
+# Values must match run-live-tests.sh's safety regex
+# (^[[:space:]]*(#.*)?\$|^[A-Za-z_][A-Za-z0-9_]*=\"[A-Za-z0-9_./:@,+ -]*\"\$).
+# All values are quoted so `source` won't word-split paths/values.
+# Canonical user identities and passwords are NOT written here — they
+# come from test/crapi/crapi-helpers.sh (sourced by every downstream
+# script) so we don't have to escape special chars like '!' through this
+# allowlisted format.
+VULN_API_PORT="${VULN_API_PORT}"
+DVGA_PORT="${DVGA_PORT}"
+GRPC_PORT="${GRPC_PORT}"
+CRAPI_PORT="${CRAPI_PORT}"
+CRAPI_DIR="${CRAPI_DIR}"
+CRAPI_SPEC_FILE="${CRAPI_SPEC_FILE}"
 EOF
 
 log_ok "Config written to ${CONFIG_FILE}"
@@ -389,16 +572,12 @@ if echo "$TARGETS" | grep -q "grpc"; then
     echo -e "  grpc-server     ${GREEN}built${NC}     (will start on port $GRPC_PORT)"
 fi
 if echo "$TARGETS" | grep -q "crapi"; then
-    if [ "$CRAPI_READY" = false ]; then
-        echo -e "  crapi           ${YELLOW}warning${NC}   may not be ready (check containers)"
-    else
-        echo -e "  crapi           ${GREEN}running${NC}   http://localhost:$CRAPI_PORT"
-    fi
+    echo -e "  crapi           ${GREEN}running${NC}   http://localhost:$CRAPI_PORT"
 fi
 echo ""
 echo -e "${BOLD}Next step:${NC}"
 echo -e "  ./test/run-live-tests.sh"
 echo ""
-echo -e "${BOLD}To tear down:${NC}"
+echo -e "${BOLD}To tear down (stops containers AND removes volumes):${NC}"
 echo -e "  ./test/setup-live-targets.sh --teardown"
 echo ""

--- a/test/test-llm-planner.sh
+++ b/test/test-llm-planner.sh
@@ -6,7 +6,10 @@
 # Verifies the planner generates a valid attack plan and executes it.
 #
 # Prerequisites:
-#   - crAPI running on localhost:8888
+#   - crAPI running on the port resolved by setup-live-targets.sh
+#     (default 8888 — see CRAPI_OPENAPI_SPEC_DEFAULT_PORT in
+#     test/crapi/crapi-helpers.sh; override via CRAPI_PORT env var or
+#     .live-test-config)
 #   - OPENAI_API_KEY or ANTHROPIC_API_KEY set
 #   - hadrian binary built
 #
@@ -20,7 +23,31 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 HADRIAN_BIN="${HADRIAN_BIN:-${REPO_ROOT}/hadrian}"
 OUTPUT_DIR="${SCRIPT_DIR}/.results"
-CRAPI_PORT="${CRAPI_PORT:-8888}"
+CONFIG_FILE="${SCRIPT_DIR}/.live-test-config"
+
+# Load setup config (CRAPI_PORT, CRAPI_SPEC_FILE, canonical creds) if it
+# exists. Without this, we'd reach for a different default port and
+# different user credentials than setup-live-targets.sh used.
+if [ -f "$CONFIG_FILE" ]; then
+    # Quoted-value-only regex; matches setup-live-targets.sh's heredoc
+    # format. See run-live-tests.sh for the rationale (path-with-space
+    # injection on source).
+    if grep -qvE '^[[:space:]]*(#.*)?$|^[A-Za-z_][A-Za-z0-9_]*="[A-Za-z0-9_./:@,+ -]*"$' "$CONFIG_FILE"; then
+        echo "ERROR: $CONFIG_FILE contains unsafe content. Expected only comments, blank lines, or KEY=\"VALUE\" assignments. Re-run setup-live-targets.sh to regenerate." >&2
+        exit 1
+    fi
+    # shellcheck disable=SC1090
+    . "$CONFIG_FILE"
+fi
+
+# Shared crAPI helpers (canonical users, signup/login, spec patcher).
+# Sourced BEFORE the CRAPI_PORT default so the default tracks
+# CRAPI_OPENAPI_SPEC_DEFAULT_PORT (single source of truth) instead of
+# duplicating the literal 8888.
+# shellcheck source=test/crapi/crapi-helpers.sh
+. "${SCRIPT_DIR}/crapi/crapi-helpers.sh"
+
+CRAPI_PORT="${CRAPI_PORT:-$CRAPI_OPENAPI_SPEC_DEFAULT_PORT}"
 CRAPI_URL="http://localhost:${CRAPI_PORT}"
 
 RED='\033[0;31m'
@@ -29,9 +56,11 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_ok()   { echo -e "${GREEN}[OK]${NC} $1"; }
-log_fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+# All log_* helpers write to stderr so they don't pollute the stdout
+# values of `$(...)` callers (consistent with setup-live-targets.sh).
+log_info() { echo -e "${CYAN}[INFO]${NC} $1" >&2; }
+log_ok()   { echo -e "${GREEN}[OK]${NC} $1" >&2; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1" >&2; }
 
 # Parse provider argument
 PROVIDER="${1:-openai}"
@@ -61,35 +90,78 @@ if ! curl -s -o /dev/null -w '%{http_code}' "${CRAPI_URL}/identity/api/auth/sign
     exit 1
 fi
 
-# Setup crAPI tokens
-log_info "Setting up crAPI tokens..."
+# Setup crAPI users + tokens.
+# Sign up the canonical roster — this is idempotent against an existing DB
+# but required against a freshly torn-down one. Previous versions of this
+# script assumed users already existed (with credentials that didn't match
+# what setup-live-targets.sh registered) and failed silently against a
+# clean volume.
+log_info "Setting up crAPI users and tokens..."
+# Wrap with `if !` so a provisioning failure produces a coherent diagnostic
+# instead of a raw set-e abort with no context (matches the pattern in
+# run-live-tests.sh and setup-live-targets.sh).
+if ! crapi_setup_users "$CRAPI_URL"; then
+    log_fail "crAPI user provisioning failed (see error above)"
+    exit 1
+fi
 
-crapi_login() {
-    printf '{"email":"%s","password":"%s"}' "$1" "$2" | \
-        curl -sf -X POST "${CRAPI_URL}/identity/api/auth/login" \
-            -H "Content-Type: application/json" \
-            --data-binary @- 2>/dev/null | \
-        python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo ""
-}
+ADMIN_TOKEN=$(crapi_login "$CRAPI_URL" "$CRAPI_ADMIN_EMAIL"    "$CRAPI_PASSWORD")
+USER_TOKEN=$(crapi_login  "$CRAPI_URL" "$CRAPI_USER_EMAIL"     "$CRAPI_PASSWORD")
+USER2_TOKEN=$(crapi_login "$CRAPI_URL" "$CRAPI_USER2_EMAIL"    "$CRAPI_PASSWORD")
+MECH_TOKEN=$(crapi_login  "$CRAPI_URL" "$CRAPI_MECHANIC_EMAIL" "$CRAPI_PASSWORD")
 
-USER_TOKEN=$(crapi_login "user1@test.com" "Testpass123!")
-USER2_TOKEN=$(crapi_login "user2@test.com" "Testpass123!")
-MECH_TOKEN=$(crapi_login "mechanic1@test.com" "Testpass123!")
-
-if [ -z "$USER_TOKEN" ] || [ -z "$USER2_TOKEN" ] || [ -z "$MECH_TOKEN" ]; then
-    log_fail "Failed to get crAPI tokens"
+# All four tokens must be acquired so role-specific templates (BFLA
+# admin-video-delete, mechanic workflows) run with the correct identity.
+# Previously this script mapped admin -> USER_TOKEN, which silently
+# degraded admin-scoped templates in the planner test to regular-user
+# credentials.
+if [ -z "$ADMIN_TOKEN" ] || [ -z "$USER_TOKEN" ] \
+        || [ -z "$USER2_TOKEN" ] || [ -z "$MECH_TOKEN" ]; then
+    log_fail "Failed to get crAPI tokens (admin/user1/user2/mechanic must all be non-empty)"
     exit 1
 fi
 log_ok "Tokens acquired"
 
 mkdir -p "$OUTPUT_DIR"
+
+# Resolve the OpenAPI spec path. Prefer the patched copy that
+# setup-live-targets.sh wrote into .live-test-config, but only if its
+# baked-in port matches our current CRAPI_PORT — otherwise a runtime
+# CRAPI_PORT override against a stale config would silently mis-route.
+# When re-patching, write into the same SPEC_CACHE_DIR setup uses
+# (test/.live-test-cache/) so a planner-only run doesn't leave a cache
+# artifact in the .results directory.
+SPEC_CACHE_DIR="${SCRIPT_DIR}/.live-test-cache"
+# Anchor the port match on a non-digit / end-of-line boundary to avoid
+# substring false-matches (e.g. CRAPI_PORT=889 vs localhost:8895).
+if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "$CRAPI_SPEC_FILE" ] \
+        && grep -qE "localhost:${CRAPI_PORT}([^0-9]|\$)" "$CRAPI_SPEC_FILE"; then
+    CRAPI_SPEC="$CRAPI_SPEC_FILE"
+else
+    if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "$CRAPI_SPEC_FILE" ]; then
+        log_info "Cached spec at ${CRAPI_SPEC_FILE} does not match CRAPI_PORT=${CRAPI_PORT}; re-patching."
+    fi
+    mkdir -p "$SPEC_CACHE_DIR"
+    CRAPI_SPEC=$(crapi_patch_openapi_spec \
+        "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
+        "$CRAPI_PORT" \
+        "$SPEC_CACHE_DIR")
+fi
+# Guard against silent failure of crapi_patch_openapi_spec (validation
+# branch returns 1 + empty stdout). An unchecked empty $CRAPI_SPEC would
+# pass `--api ""` to hadrian and produce an opaque downstream error.
+if [ -z "$CRAPI_SPEC" ] || [ ! -f "$CRAPI_SPEC" ]; then
+    log_fail "Could not resolve crAPI OpenAPI spec (empty path or missing file)"
+    exit 1
+fi
+
 AUTH_FILE="${OUTPUT_DIR}/planner-auth.yaml"
 (umask 077; cat > "$AUTH_FILE" <<EOF
 method: bearer
 location: header
 roles:
   admin:
-    token: "${USER_TOKEN}"
+    token: "${ADMIN_TOKEN}"
   mechanic:
     token: "${MECH_TOKEN}"
   user:
@@ -122,7 +194,7 @@ RESULT_FILE="${OUTPUT_DIR}/planner-${PROVIDER}-results.json"
 log_info "Running planner with --planner-provider ${PROVIDER}..."
 run_test "planner generates plan" \
     "$HADRIAN_BIN" test rest \
-        --api "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
+        --api "$CRAPI_SPEC" \
         --roles "${SCRIPT_DIR}/crapi/roles.yaml" \
         --auth "$AUTH_FILE" \
         --template-dir "${SCRIPT_DIR}/crapi/templates/owasp" \
@@ -133,7 +205,7 @@ run_test "planner generates plan" \
 RESULT_FILE_ONLY="${OUTPUT_DIR}/planner-only-${PROVIDER}-results.json"
 run_test "planner-only mode runs" \
     "$HADRIAN_BIN" test rest \
-        --api "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
+        --api "$CRAPI_SPEC" \
         --roles "${SCRIPT_DIR}/crapi/roles.yaml" \
         --auth "$AUTH_FILE" \
         --template-dir "${SCRIPT_DIR}/crapi/templates/owasp" \
@@ -144,7 +216,7 @@ run_test "planner-only mode runs" \
 RESULT_FILE_CTX="${OUTPUT_DIR}/planner-context-${PROVIDER}-results.json"
 run_test "planner-context steers plan" \
     "$HADRIAN_BIN" test rest \
-        --api "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
+        --api "$CRAPI_SPEC" \
         --roles "${SCRIPT_DIR}/crapi/roles.yaml" \
         --auth "$AUTH_FILE" \
         --template-dir "${SCRIPT_DIR}/crapi/templates/owasp" \

--- a/test/vulnerable-api/IMPLEMENTATION.md
+++ b/test/vulnerable-api/IMPLEMENTATION.md
@@ -178,7 +178,7 @@ make run-basic
 ### Run Hadrian Tests
 
 ```bash
-hadrian test owasp-api http://localhost:8889 \
+hadrian test owasp-api http://localhost:9889 \
   --auth-username user1 \
   --auth-password user1pass
 ```
@@ -234,7 +234,7 @@ make build
 
 ## Port Configuration
 
-Default: 8889
+Default: 9889
 Override: `PORT=9000 go run main.go`
 
 ## Architecture Notes

--- a/test/vulnerable-api/Makefile
+++ b/test/vulnerable-api/Makefile
@@ -1,5 +1,8 @@
 .PHONY: help build run run-apikey run-basic test test-all test-bearer test-apikey test-basic clean reset
 
+API_PORT ?= 9889
+API_URL  ?= http://localhost:$(API_PORT)
+
 help: ## Show this help message
 	@echo "Vulnerable API - BOLA Testing"
 	@echo ""
@@ -33,7 +36,7 @@ tidy: ## Tidy Go dependencies
 	go mod tidy
 
 reset: ## Reset API data to initial state (requires running API)
-	curl -s -X POST http://localhost:8889/api/reset | jq .
+	curl -s -X POST $(API_URL)/api/reset | jq .
 
 test-all: build ## Run Hadrian tests with all auth methods
 	./run-all-auth-tests.sh --verbose

--- a/test/vulnerable-api/README.md
+++ b/test/vulnerable-api/README.md
@@ -20,7 +20,7 @@ The API implements authentication but deliberately **omits authorization checks*
 # Install dependencies
 go mod download
 
-# Run with default settings (Bearer JWT auth, port 8889)
+# Run with default settings (Bearer JWT auth, port 9889)
 go run main.go
 
 # Run with API key authentication
@@ -41,7 +41,7 @@ Configure via `AUTH_METHOD` environment variable:
 
 ```bash
 # Login
-curl -X POST http://localhost:8889/api/auth/login \
+curl -X POST http://localhost:9889/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"user1","password":"user1pass"}'
 
@@ -50,7 +50,7 @@ curl -X POST http://localhost:8889/api/auth/login \
 
 # Use token in requests
 curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIs..." \
-  http://localhost:8889/api/users/1
+  http://localhost:9889/api/users/1
 ```
 
 ### 2. API Key
@@ -59,7 +59,7 @@ curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIs..." \
 AUTH_METHOD=api_key go run main.go
 
 # Login returns API key
-curl -X POST http://localhost:8889/api/auth/login \
+curl -X POST http://localhost:9889/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"user1","password":"user1pass"}'
 
@@ -68,7 +68,7 @@ curl -X POST http://localhost:8889/api/auth/login \
 
 # Use API key in requests
 curl -H "X-API-Key: user1-api-key-67890" \
-  http://localhost:8889/api/users/1
+  http://localhost:9889/api/users/1
 ```
 
 ### 3. Basic Authentication
@@ -77,7 +77,7 @@ curl -H "X-API-Key: user1-api-key-67890" \
 AUTH_METHOD=basic go run main.go
 
 # Use Basic Auth in requests (no login needed)
-curl -u user1:user1pass http://localhost:8889/api/users/1
+curl -u user1:user1pass http://localhost:9889/api/users/1
 ```
 
 ## Test Users
@@ -136,13 +136,13 @@ curl -u user1:user1pass http://localhost:8889/api/users/1
 
 ```bash
 # Login as user1 (ID: 2)
-TOKEN=$(curl -s -X POST http://localhost:8889/api/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:9889/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"user1","password":"user1pass"}' | jq -r '.token')
 
 # VULNERABILITY: user1 can access user2's profile (ID: 3)
 curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:8889/api/profiles/3
+  http://localhost:9889/api/profiles/3
 
 # Response includes SSN!
 {
@@ -159,13 +159,13 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 ```bash
 # Login as user2 (ID: 3)
-TOKEN=$(curl -s -X POST http://localhost:8889/api/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:9889/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"user2","password":"user2pass"}' | jq -r '.token')
 
 # VULNERABILITY: user2 can delete user1's order (order ID: 2 belongs to user1)
 curl -X DELETE -H "Authorization: Bearer $TOKEN" \
-  http://localhost:8889/api/orders/2
+  http://localhost:9889/api/orders/2
 
 # Returns 204 No Content - order deleted!
 ```
@@ -174,13 +174,13 @@ curl -X DELETE -H "Authorization: Bearer $TOKEN" \
 
 ```bash
 # Login as user2
-TOKEN=$(curl -s -X POST http://localhost:8889/api/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:9889/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"user2","password":"user2pass"}' | jq -r '.token')
 
 # VULNERABILITY: user2 can read user1's private document (ID: 4)
 curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:8889/api/documents/4
+  http://localhost:9889/api/documents/4
 
 # Response includes private content!
 {
@@ -242,7 +242,7 @@ HADRIAN_TEMPLATES=./templates/rest hadrian test \
   --verbose
 
 # Reset data after tests
-curl -X POST http://localhost:8889/api/reset
+curl -X POST http://localhost:9889/api/reset
 ```
 
 ### Template Execution Order

--- a/test/vulnerable-api/get-tokens.sh
+++ b/test/vulnerable-api/get-tokens.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-API_URL="${API_URL:-http://localhost:8889}"
+API_URL="${API_URL:-http://localhost:9889}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "=== Hadrian Token Generator ==="

--- a/test/vulnerable-api/main.go
+++ b/test/vulnerable-api/main.go
@@ -771,7 +771,7 @@ func main() {
 	// Load configuration
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8889"
+		port = "9889"
 	}
 
 	authMethodEnv := os.Getenv("AUTH_METHOD")

--- a/test/vulnerable-api/openapi.yaml
+++ b/test/vulnerable-api/openapi.yaml
@@ -10,7 +10,7 @@ info:
     name: Hadrian Security Testing
 
 servers:
-  - url: http://localhost:8889
+  - url: http://localhost:9889
     description: Local development server
 
 tags:

--- a/test/vulnerable-api/run-all-auth-tests.sh
+++ b/test/vulnerable-api/run-all-auth-tests.sh
@@ -24,7 +24,7 @@ set -e
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-API_PORT="${API_PORT:-8889}"
+API_PORT="${API_PORT:-9889}"
 API_URL="http://localhost:${API_PORT}"
 HADRIAN_BIN="${HADRIAN_BIN:-hadrian}"
 TEMPLATES_DIR="${SCRIPT_DIR}/templates/owasp"

--- a/test/vulnerable-api/templates/owasp/README.md
+++ b/test/vulnerable-api/templates/owasp/README.md
@@ -47,7 +47,7 @@ After running destructive tests, reset the API data:
 
 ```bash
 # Option 1: Call the reset endpoint
-curl -X POST http://localhost:8889/api/reset
+curl -X POST http://localhost:9889/api/reset
 
 # Option 2: Restart the API
 # Stop the API (Ctrl+C) and restart it
@@ -72,7 +72,7 @@ HADRIAN_TEMPLATES=./templates/owasp hadrian test \
   --template "0[1-9]-*" --template "1[0-3]-*"
 
 # Run and then reset
-hadrian test ... && curl -X POST http://localhost:8889/api/reset
+hadrian test ... && curl -X POST http://localhost:9889/api/reset
 ```
 
 ## Template Categories

--- a/test/vulnerable-api/test-bola.sh
+++ b/test/vulnerable-api/test-bola.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-API_URL="${API_URL:-http://localhost:8889}"
+API_URL="${API_URL:-http://localhost:9889}"
 
 echo "=========================================="
 echo "BOLA Vulnerability Test Script"


### PR DESCRIPTION
## Summary

Closes [LAB-2247](https://linear.app/praetorianlabs/issue/LAB-2247/bugs-in-hadriantestsetup-live-targetssh). Eleven defects were preventing repeatable live testing against crAPI; this PR fixes them all and adds user-provisioning retry to handle a transient signup race that surfaced during validation.

## Bugs fixed

- **#1, #6** — `--teardown` now runs `docker compose down -v --remove-orphans` and surfaces stderr instead of swallowing it. Postgres/Mongo volumes are dropped, so the next setup boots against a clean DB.
- **#2** — OpenAPI spec patching is centralized: setup writes a port-patched copy to `test/.live-test-cache/` and emits `CRAPI_SPEC_FILE` in `.live-test-config`. `run-live-tests.sh` and `test-llm-planner.sh` consume it.
- **#3** — Failed crAPI readiness probe now exits 1 (was: warn and exit 0, marking CI green on a broken setup).
- **#4, #11** — Replaced literal `s/8888:80/.../g` sed with `patch_crapi_compose_port`, which auto-detects the current upstream port (excluding the 30080 redirector) and validates the patch landed via grep. Tested against 8888, 8889 (current upstream), and a hypothetical future port.
- **#5** — Extracted `test/crapi/crapi-helpers.sh` as the single source of truth for canonical user identities, signup/login wrappers, and the OpenAPI spec patcher. Sourced by all three test scripts so they can't drift.
- **#7** — Added `--no-build` flag to skip rebuilds when binaries exist.
- **#8** — Added `--purge` flag (with `--teardown`) to remove the cached `.crapi-repo` clone.
- **#9** — `find_available_port` now accepts an excluded list. Setup tracks `CLAIMED_PORTS` so two targets can't be handed the same port.
- **#10** — Introduced `*_PORT_OVERRIDE` env vars (`VULN_API_PORT_OVERRIDE`, `CRAPI_PORT_OVERRIDE`, etc.). The previous `CRAPI_PORT` env var was silently clobbered by `find_available_port`.
- **#11** — Moved `vulnerable-api` from default port 8889 → 9889 to escape the upstream-crAPI port collision. `main.go`, `openapi.yaml`, helper scripts, Makefile, and docs updated for consistency.

## Robustness fix surfaced during validation

`crapi_setup_users` now verifies each signup by attempting a login and retries up to 5× with linear backoff if the user isn't loginnable. crAPI's identity and workshop services intermittently 4xx during the first few seconds after boot — the previous fire-and-forget signup swallowed those failures and downstream tests blew up later with empty tokens. Idempotent: a pre-existing user passes verification on the first try.

## Test plan

- [x] `bash -n` clean on all four scripts
- [x] `shellcheck -x` clean on new code (only pre-existing SC2015 warnings in untouched lines remain)
- [x] `go vet ./...` and `go build ./...` clean
- [x] `crapi_patch_openapi_spec` substitutes both `localhost:8888` occurrences (servers + report_link)
- [x] `find_available_port` with excluded list demonstrably prevents the bug-#9 collision
- [x] `patch_crapi_compose_port` tested against three compose shapes; 30080 redirector untouched
- [x] 101-assertion regression harness at `test/regression/lab-2247-regression-tests.sh` covers all 11 bugs without booting Docker; documented in `test/README.md` as a CI-runnable pre-check for the end-to-end flow. Ran clean locally.
- [x] Reviewed twice by `capability-reviewer`; second pass approved after a regression fix removed credentials from `.live-test-config` (the `!` in the password failed the safety regex)
- [x] **End-to-end**: `./test/setup-live-targets.sh --teardown --purge && ./test/setup-live-targets.sh && ./test/run-live-tests.sh` → all 7 sub-targets PASS, 284 findings.

## Files

- New: `test/crapi/crapi-helpers.sh`
- Rewritten: `test/setup-live-targets.sh`
- Edited: `test/run-live-tests.sh`, `test/test-llm-planner.sh`, `test/README.md`, `test/crapi/README.md`, `test/vulnerable-api/main.go`, `test/vulnerable-api/openapi.yaml`, `test/vulnerable-api/Makefile`, four vulnerable-api helper scripts, three vulnerable-api docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
