### PR TITLE
fix(test): integrate test-llm-planner.sh with live-test harness and fix hygiene gaps (LAB-2303)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,8 @@ The `test/crapi/` directory contains a complete example for testing [OWASP crAPI
 
 # Optional: exercise the LLM planner against crAPI (opt-in target).
 # Auto-selects provider: OpenAI > Anthropic > ollama; SKIPs cleanly when none available.
-OPENAI_API_KEY=sk-... ./test/run-live-tests.sh --targets crapi,crapi-planner
+export OPENAI_API_KEY=sk-...    # set once in your shell
+./test/run-live-tests.sh --targets crapi,crapi-planner
 ```
 
 Note: upstream crAPI's compose default has shifted between 8888 and 8889 over time; `setup-live-targets.sh` auto-detects the current upstream port and patches the compose so hadrian's downstream code keeps using whatever you resolve. See `test/crapi/README.md` for the canonical user credentials, port-override env vars, and a manual fallback flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,10 @@ The `test/crapi/` directory contains a complete example for testing [OWASP crAPI
 
 # Tear down (volumes too — required for repeatable runs).
 ./test/setup-live-targets.sh --teardown
+
+# Optional: exercise the LLM planner against crAPI (opt-in target).
+# Auto-selects provider: OpenAI > Anthropic > ollama; SKIPs cleanly when none available.
+OPENAI_API_KEY=sk-... ./test/run-live-tests.sh --targets crapi,crapi-planner
 ```
 
 Note: upstream crAPI's compose default has shifted between 8888 and 8889 over time; `setup-live-targets.sh` auto-detects the current upstream port and patches the compose so hadrian's downstream code keeps using whatever you resolve. See `test/crapi/README.md` for the canonical user credentials, port-override env vars, and a manual fallback flow.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -133,7 +133,7 @@ func Load(filePath string) (*AuthConfig, error) {
 
 		// Detect hardcoded secrets (credential security) — check the
 		// PRE-expansion value so a YAML containing "${TOKEN_VAR}" is
-		// recognised as a safe env-var ref instead of being flagged
+		// recognized as a safe env-var ref instead of being flagged
 		// after expansion resolves it to a literal JWT.
 		if detectHardcodedSecret(origToken) {
 			log.Warn("SECURITY: Role '%s' has hardcoded token. Use environment variables: ${TOKEN_VAR}", roleName)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -198,6 +198,11 @@ func detectHardcodedSecret(value string) bool {
 	// it resolves to a hardcoded JWT, so it must NOT short-circuit — match
 	// the patterns against the stripped remainder to catch it.
 	stripped := envBraceRE.ReplaceAllString(value, "")
+	// HasPrefix("${") AND stripped=="" together mean "non-empty AND made up
+	// entirely of ${VAR} refs" — the HasPrefix term excludes the empty string
+	// (for which stripped=="" is trivially true) and any value whose literal
+	// part precedes the first ref, both of which must fall through to the
+	// pattern check below.
 	if strings.HasPrefix(value, "${") && stripped == "" {
 		return false // pure environment variable reference
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -190,11 +190,19 @@ var hardcodedSecretPatterns = []*regexp.Regexp{
 
 // detectHardcodedSecret identifies JWT, API keys, etc. (credential security)
 func detectHardcodedSecret(value string) bool {
-	if strings.HasPrefix(value, "${") {
-		return false // Environment variable reference
+	// Strip every ${VAR} reference. A value composed ENTIRELY of env-var
+	// references (e.g. "${TOKEN_VAR}" or "${A}${B}") leaves an empty
+	// remainder and is the safe pattern we want to allow without warning.
+	// A MIXED value such as "${UNSET}eyJ...jwt" leaves a literal secret
+	// behind once the refs are stripped; after expansion (${UNSET} -> "")
+	// it resolves to a hardcoded JWT, so it must NOT short-circuit — match
+	// the patterns against the stripped remainder to catch it.
+	stripped := envBraceRE.ReplaceAllString(value, "")
+	if strings.HasPrefix(value, "${") && stripped == "" {
+		return false // pure environment variable reference
 	}
 	for _, re := range hardcodedSecretPatterns {
-		if re.MatchString(value) {
+		if re.MatchString(value) || (stripped != value && re.MatchString(stripped)) {
 			return true
 		}
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -103,6 +103,19 @@ func Load(filePath string) (*AuthConfig, error) {
 	// Only expand values that look like env var references (contain ${...})
 	// to avoid corrupting values that contain literal $ characters
 	for roleName, roleAuth := range config.Roles {
+		// Capture pre-expansion values for the hardcoded-secret check below.
+		// expandEnvSafe rewrites ${VAR} refs to their resolved values, after
+		// which detectHardcodedSecret can no longer distinguish an env-var
+		// ref from a literal secret — the check must run on the original
+		// YAML value, before expansion, for the ${VAR} short-circuit to fire.
+		origToken := roleAuth.Token
+		origAPIKey := roleAuth.APIKey
+		origCookie := roleAuth.Cookie
+		var origCreds string
+		if roleAuth.Credentials != nil {
+			origCreds = *roleAuth.Credentials
+		}
+
 		roleAuth.Token = expandEnvSafe(roleAuth.Token)
 		roleAuth.APIKey = expandEnvSafe(roleAuth.APIKey)
 		roleAuth.Username = expandEnvSafe(roleAuth.Username)
@@ -118,17 +131,21 @@ func Load(filePath string) (*AuthConfig, error) {
 			return nil, fmt.Errorf("role '%s': cookie value contains invalid characters (CR, LF, or NUL)", roleName)
 		}
 
-		// Detect hardcoded secrets (credential security)
-		if detectHardcodedSecret(roleAuth.Token) {
+		// Detect hardcoded secrets (credential security) — check the
+		// PRE-expansion value so a YAML containing "${TOKEN_VAR}" is
+		// recognised as a safe env-var ref instead of being flagged
+		// after expansion resolves it to a literal JWT.
+		if detectHardcodedSecret(origToken) {
 			log.Warn("SECURITY: Role '%s' has hardcoded token. Use environment variables: ${TOKEN_VAR}", roleName)
 		}
-		if detectHardcodedSecret(roleAuth.APIKey) {
+		if detectHardcodedSecret(origAPIKey) {
 			log.Warn("SECURITY: Role '%s' has hardcoded API key. Use environment variables: ${KEY_VAR}", roleName)
 		}
-		if detectHardcodedSecret(roleAuth.Cookie) {
+		if detectHardcodedSecret(origCookie) {
 			log.Warn("SECURITY: Role '%s' has hardcoded cookie. Use environment variables: ${COOKIE_VAR}", roleName)
 		}
-		if roleAuth.Credentials != nil && detectHardcodedSecret(*roleAuth.Credentials) {
+		// origCreds is "" when Credentials was nil; detectHardcodedSecret("") returns false.
+		if detectHardcodedSecret(origCreds) {
 			log.Warn("SECURITY: Role '%s' has hardcoded credentials. Use environment variables: ${CREDS_VAR}", roleName)
 		}
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/base64"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -303,6 +304,7 @@ func TestDetectHardcodedSecret_EnvironmentVariable(t *testing.T) {
 
 const fixtureJWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
 
+// NOTE: mutates global os.Stderr; tests using this helper must not call t.Parallel().
 func captureAuthStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	old := os.Stderr
@@ -318,10 +320,9 @@ func captureAuthStderr(t *testing.T, fn func()) string {
 	if err := w.Close(); err != nil {
 		t.Fatalf("close pipe writer: %v", err)
 	}
-	var buf [4096]byte
-	n, _ := r.Read(buf[:])
+	out, _ := io.ReadAll(r)
 	_ = r.Close()
-	return string(buf[:n])
+	return string(out)
 }
 
 func writeTempAuthYAML(t *testing.T, body string) string {
@@ -333,54 +334,87 @@ func writeTempAuthYAML(t *testing.T, body string) string {
 	return p
 }
 
-// TestLoad_EnvVarTokenNoSecurityWarning is the regression guard for the bug
+// TestLoad_HardcodedSecretWarning is the regression guard for the bug
 // where detectHardcodedSecret ran on post-expansion values, causing every
 // ${VAR} env-var ref that resolved to a JWT-shaped string to trip the
-// hardcoded-token warning.
-func TestLoad_EnvVarTokenNoSecurityWarning(t *testing.T) {
-	t.Setenv("HADRIAN_TEST_TOKEN", fixtureJWT)
-	yamlBody := `method: bearer
-location: header
-roles:
-  admin:
-    token: "${HADRIAN_TEST_TOKEN}"
-`
-	path := writeTempAuthYAML(t, yamlBody)
-
-	var cfg *AuthConfig
-	stderr := captureAuthStderr(t, func() {
-		var err error
-		cfg, err = Load(path)
-		if err != nil {
-			t.Fatalf("Load returned error: %v", err)
-		}
-	})
-
-	if strings.Contains(stderr, "SECURITY: Role 'admin' has hardcoded token") {
-		t.Errorf("expected no hardcoded-token warning for ${VAR} ref; got stderr:\n%s", stderr)
+// hardcoded-secret warning. The test is parametrized over all four
+// credential fields (token, api_key, cookie, credentials) because auth.go
+// applies the same pre-expansion-capture fix to each of them.
+func TestLoad_HardcodedSecretWarning(t *testing.T) {
+	cases := []struct {
+		name        string
+		yamlMethod  string
+		yamlField   string // YAML key under the role
+		envVarYAML  string // value that is a ${VAR} reference
+		inlineYAML  string // value that is an inline JWT literal
+		warnSnippet string // substring expected in the SECURITY warning
+	}{
+		{
+			name:        "token",
+			yamlMethod:  "bearer",
+			yamlField:   "token",
+			envVarYAML:  "${HADRIAN_TEST_TOKEN}",
+			inlineYAML:  fixtureJWT,
+			warnSnippet: "has hardcoded token",
+		},
+		{
+			name:        "api_key",
+			yamlMethod:  "api_key",
+			yamlField:   "api_key",
+			envVarYAML:  "${HADRIAN_TEST_TOKEN}",
+			inlineYAML:  fixtureJWT,
+			warnSnippet: "has hardcoded API key",
+		},
+		{
+			name:        "cookie",
+			yamlMethod:  "cookie",
+			yamlField:   "cookie",
+			envVarYAML:  "${HADRIAN_TEST_TOKEN}",
+			inlineYAML:  fixtureJWT,
+			warnSnippet: "has hardcoded cookie",
+		},
+		{
+			name:       "credentials",
+			yamlMethod: "basic",
+			yamlField:  "credentials",
+			// credentials is a *string; a ${VAR} ref is safe.
+			envVarYAML:  "${HADRIAN_TEST_TOKEN}",
+			inlineYAML:  fixtureJWT,
+			warnSnippet: "has hardcoded credentials",
+		},
 	}
-	if got := cfg.Roles["admin"].Token; got != fixtureJWT {
-		t.Errorf("expected token to expand to JWT; got %q", got)
-	}
-}
 
-func TestLoad_InlineJWTStillWarns(t *testing.T) {
-	yamlBody := `method: bearer
-location: header
-roles:
-  admin:
-    token: "` + fixtureJWT + `"
-`
-	path := writeTempAuthYAML(t, yamlBody)
+	for _, tc := range cases {
+		t.Run(tc.name+"/env_var_no_warning", func(t *testing.T) {
+			t.Setenv("HADRIAN_TEST_TOKEN", fixtureJWT)
+			yamlBody := "method: " + tc.yamlMethod + "\nlocation: header\nroles:\n  admin:\n    " + tc.yamlField + ": \"" + tc.envVarYAML + "\"\n"
+			path := writeTempAuthYAML(t, yamlBody)
 
-	stderr := captureAuthStderr(t, func() {
-		if _, err := Load(path); err != nil {
-			t.Fatalf("Load returned error: %v", err)
-		}
-	})
+			stderr := captureAuthStderr(t, func() {
+				if _, err := Load(path); err != nil {
+					t.Fatalf("Load returned error: %v", err)
+				}
+			})
 
-	if !strings.Contains(stderr, "SECURITY: Role 'admin' has hardcoded token") {
-		t.Errorf("expected hardcoded-token warning for inline JWT; got stderr:\n%s", stderr)
+			if strings.Contains(stderr, "SECURITY: Role 'admin' "+tc.warnSnippet) {
+				t.Errorf("expected no %s warning for ${VAR} ref; got stderr:\n%s", tc.name, stderr)
+			}
+		})
+
+		t.Run(tc.name+"/inline_literal_warns", func(t *testing.T) {
+			yamlBody := "method: " + tc.yamlMethod + "\nlocation: header\nroles:\n  admin:\n    " + tc.yamlField + ": \"" + tc.inlineYAML + "\"\n"
+			path := writeTempAuthYAML(t, yamlBody)
+
+			stderr := captureAuthStderr(t, func() {
+				if _, err := Load(path); err != nil {
+					t.Fatalf("Load returned error: %v", err)
+				}
+			})
+
+			if !strings.Contains(stderr, "SECURITY: Role 'admin' "+tc.warnSnippet) {
+				t.Errorf("expected %s warning for inline literal; got stderr:\n%s", tc.name, stderr)
+			}
+		})
 	}
 }
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -301,6 +301,89 @@ func TestDetectHardcodedSecret_EnvironmentVariable(t *testing.T) {
 	}
 }
 
+const fixtureJWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+
+func captureAuthStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	_ = r.Close()
+	return string(buf[:n])
+}
+
+func writeTempAuthYAML(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "auth.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp auth.yaml: %v", err)
+	}
+	return p
+}
+
+// TestLoad_EnvVarTokenNoSecurityWarning is the regression guard for the bug
+// where detectHardcodedSecret ran on post-expansion values, causing every
+// ${VAR} env-var ref that resolved to a JWT-shaped string to trip the
+// hardcoded-token warning.
+func TestLoad_EnvVarTokenNoSecurityWarning(t *testing.T) {
+	t.Setenv("HADRIAN_TEST_TOKEN", fixtureJWT)
+	yamlBody := `method: bearer
+location: header
+roles:
+  admin:
+    token: "${HADRIAN_TEST_TOKEN}"
+`
+	path := writeTempAuthYAML(t, yamlBody)
+
+	var cfg *AuthConfig
+	stderr := captureAuthStderr(t, func() {
+		var err error
+		cfg, err = Load(path)
+		if err != nil {
+			t.Fatalf("Load returned error: %v", err)
+		}
+	})
+
+	if strings.Contains(stderr, "SECURITY: Role 'admin' has hardcoded token") {
+		t.Errorf("expected no hardcoded-token warning for ${VAR} ref; got stderr:\n%s", stderr)
+	}
+	if got := cfg.Roles["admin"].Token; got != fixtureJWT {
+		t.Errorf("expected token to expand to JWT; got %q", got)
+	}
+}
+
+func TestLoad_InlineJWTStillWarns(t *testing.T) {
+	yamlBody := `method: bearer
+location: header
+roles:
+  admin:
+    token: "` + fixtureJWT + `"
+`
+	path := writeTempAuthYAML(t, yamlBody)
+
+	stderr := captureAuthStderr(t, func() {
+		if _, err := Load(path); err != nil {
+			t.Fatalf("Load returned error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "SECURITY: Role 'admin' has hardcoded token") {
+		t.Errorf("expected hardcoded-token warning for inline JWT; got stderr:\n%s", stderr)
+	}
+}
+
 func TestGetAuth_Bearer(t *testing.T) {
 	config := &AuthConfig{
 		Method: "bearer",

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -384,10 +385,12 @@ func TestLoad_HardcodedSecretWarning(t *testing.T) {
 		},
 	}
 
+	const yamlTmpl = "method: %s\nlocation: header\nroles:\n  admin:\n    %s: %q\n"
+
 	for _, tc := range cases {
 		t.Run(tc.name+"/env_var_no_warning", func(t *testing.T) {
 			t.Setenv("HADRIAN_TEST_TOKEN", fixtureJWT)
-			yamlBody := "method: " + tc.yamlMethod + "\nlocation: header\nroles:\n  admin:\n    " + tc.yamlField + ": \"" + tc.envVarYAML + "\"\n"
+			yamlBody := fmt.Sprintf(yamlTmpl, tc.yamlMethod, tc.yamlField, tc.envVarYAML)
 			path := writeTempAuthYAML(t, yamlBody)
 
 			stderr := captureAuthStderr(t, func() {
@@ -402,7 +405,7 @@ func TestLoad_HardcodedSecretWarning(t *testing.T) {
 		})
 
 		t.Run(tc.name+"/inline_literal_warns", func(t *testing.T) {
-			yamlBody := "method: " + tc.yamlMethod + "\nlocation: header\nroles:\n  admin:\n    " + tc.yamlField + ": \"" + tc.inlineYAML + "\"\n"
+			yamlBody := fmt.Sprintf(yamlTmpl, tc.yamlMethod, tc.yamlField, tc.inlineYAML)
 			path := writeTempAuthYAML(t, yamlBody)
 
 			stderr := captureAuthStderr(t, func() {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -303,11 +304,47 @@ func TestDetectHardcodedSecret_EnvironmentVariable(t *testing.T) {
 	}
 }
 
+// TestDetectHardcodedSecret_MixedEnvVarPrefix guards the bug where a value
+// that merely STARTS with "${" short-circuited the check. A mixed value like
+// "${UNSET}<jwt>" expands to a literal JWT once the unset ref resolves to "",
+// so it must still be flagged. Pure refs (single or concatenated) must not.
+func TestDetectHardcodedSecret_MixedEnvVarPrefix(t *testing.T) {
+	cases := []struct {
+		name   string
+		value  string
+		expect bool
+	}{
+		{"pure ref", "${TOKEN_VAR}", false},
+		{"concatenated pure refs", "${A}${B}", false},
+		{"env-var prefix then literal JWT", "${UNSET}" + fixtureJWT, true},
+		{"literal JWT then env-var suffix", fixtureJWT + "${UNSET}", true},
+		{"plain literal JWT", fixtureJWT, true},
+		{"literal dollar password (not a ref)", "pa$$word", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectHardcodedSecret(tc.value); got != tc.expect {
+				t.Errorf("detectHardcodedSecret(%q) = %v, want %v", tc.value, got, tc.expect)
+			}
+		})
+	}
+}
+
 const fixtureJWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
 
-// NOTE: mutates global os.Stderr; tests using this helper must not call t.Parallel().
+// stderrCaptureMu serializes captureAuthStderr calls. The helper swaps the
+// process-global os.Stderr, so two concurrent callers would clobber each
+// other's pipe. The mutex makes the helper safe even if a caller forgets the
+// "no t.Parallel()" rule below.
+var stderrCaptureMu sync.Mutex
+
+// NOTE: mutates global os.Stderr. Callers should not call t.Parallel(); the
+// stderrCaptureMu mutex serializes overlapping calls as a backstop.
 func captureAuthStderr(t *testing.T, fn func()) string {
 	t.Helper()
+	stderrCaptureMu.Lock()
+	defer stderrCaptureMu.Unlock()
 	old := os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/test/README.md
+++ b/test/README.md
@@ -101,7 +101,7 @@ For each target, `run-live-tests.sh` automatically:
 
 | Target | Auth Setup |
 |--------|-----------|
-| vulnerable-api | Tests all 3 auth methods sequentially (see below) |
+| vulnerable-api | Tests all 4 auth methods sequentially (see below) |
 | dvga | Logs in as admin, creates private pastes for BOLA testing |
 | grpc-server | Uses pre-configured static tokens |
 | crapi | Creates 4 users (admin, user1, user2, mechanic), gets tokens, uploads test videos |
@@ -115,13 +115,14 @@ test paths share the same accounts and spec-patching logic.
 
 ### vulnerable-api Multi-Auth Testing
 
-The vulnerable-api is tested three times, once per authentication method:
+The vulnerable-api is tested four times, once per authentication method:
 
 | Sub-target | Auth Method | How It Works |
 |------------|------------|--------------|
 | vulnerable-api-bearer | Bearer JWT | Logs in as admin/user1/user2 to get JWT tokens, writes dynamic auth config |
 | vulnerable-api-apikey | API Key | Uses static API keys (`X-API-Key` header) |
 | vulnerable-api-basic | Basic Auth | Uses username/password (HTTP Basic) |
+| vulnerable-api-cookie | Cookie | Uses cookie session identifiers (configurable cookie name) |
 
 The server is restarted with each `AUTH_METHOD` and API data is reset between runs to ensure consistent results.
 

--- a/test/README.md
+++ b/test/README.md
@@ -55,6 +55,10 @@ The setup script handles:
 ./test/run-live-tests.sh --targets dvga
 ./test/run-live-tests.sh --targets crapi
 
+# Run crAPI + LLM planner (opt-in; requires OPENAI_API_KEY, ANTHROPIC_API_KEY,
+# or a running ollama instance — SKIPped cleanly when no provider is available).
+OPENAI_API_KEY=sk-... ./test/run-live-tests.sh --targets crapi,crapi-planner
+
 # Verbose output
 ./test/run-live-tests.sh --verbose
 

--- a/test/README.md
+++ b/test/README.md
@@ -260,6 +260,8 @@ test/
   run-live-tests.sh        # End-to-end test runner
   test-llm-planner.sh      # LLM-planner regression tests
   test_detect_planner_provider.sh  # Unit test for detect_planner_provider
+  target-helpers.sh        # Target-selection helper (targets_contains)
+  test_targets_contains.sh # Unit test for targets_contains
   README.md                # This file
   .live-test-config        # Auto-generated port + path config (gitignored)
   .live-test-cache/        # Patched OpenAPI specs (gitignored)

--- a/test/README.md
+++ b/test/README.md
@@ -268,6 +268,7 @@ test/
   vulnerable-api/          # REST vulnerable API source + templates
   dvga/                    # GraphQL test config + templates
   grpc-server/             # gRPC server source + templates
+  llm-helpers.sh           # LLM provider detection helper
   crapi/                   # crAPI test config + templates
     crapi-helpers.sh       # Shared signup/login/spec-patch helpers
 ```
@@ -286,4 +287,5 @@ vulnerable-api-cookie     PASS       61           20s
 dvga                      PASS       6            3s
 grpc                      PASS       8            1s
 crapi                     PASS       26           37s
+crapi-planner             SKIP       0            0s
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -275,6 +275,7 @@ test/
     crapi-helpers.sh       # Shared signup/login/spec-patch helpers
     test_crapi_resolve_spec.sh        # Unit test for crapi_resolve_spec
     test_crapi_patch_openapi_spec.sh  # Unit test for crapi_patch_openapi_spec
+    test_crapi_planner_inputs.sh      # Unit test for crapi_planner_inputs_ready (crapi-planner SKIP gate)
 ```
 
 ## Expected result

--- a/test/README.md
+++ b/test/README.md
@@ -259,6 +259,7 @@ test/
   setup-live-targets.sh    # One-time setup
   run-live-tests.sh        # End-to-end test runner
   test-llm-planner.sh      # LLM-planner regression tests
+  test_detect_planner_provider.sh  # Unit test for detect_planner_provider
   README.md                # This file
   .live-test-config        # Auto-generated port + path config (gitignored)
   .live-test-cache/        # Patched OpenAPI specs (gitignored)
@@ -272,6 +273,8 @@ test/
   llm-helpers.sh           # LLM provider detection helper
   crapi/                   # crAPI test config + templates
     crapi-helpers.sh       # Shared signup/login/spec-patch helpers
+    test_crapi_resolve_spec.sh        # Unit test for crapi_resolve_spec
+    test_crapi_patch_openapi_spec.sh  # Unit test for crapi_patch_openapi_spec
 ```
 
 ## Expected result

--- a/test/crapi/crapi-helpers.sh
+++ b/test/crapi/crapi-helpers.sh
@@ -167,3 +167,38 @@ crapi_patch_openapi_spec() {
     fi
     echo "$dst"
 }
+
+# crapi_resolve_spec <src_spec> <port> <cache_dir>
+#
+# Resolves the OpenAPI spec path for hadrian. Preference order:
+#   1. If $CRAPI_SPEC_FILE (from .live-test-config) exists AND its baked-in
+#      port matches <port>, echo it unchanged.
+#   2. Otherwise, patch <src_spec> into <cache_dir> via
+#      crapi_patch_openapi_spec and echo the new path.
+#
+# Echoes the resolved path on stdout. Logs to stderr.
+# Returns non-zero if the resolved path is empty or does not exist.
+crapi_resolve_spec() {
+    local src_spec="$1" port="$2" cache_dir="$3"
+    local resolved=""
+
+    # Anchor the port match on a non-digit / end-of-line boundary so
+    # CRAPI_PORT=889 doesn't accept a stale spec pinned to localhost:8895
+    # (substring match).
+    if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "${CRAPI_SPEC_FILE}" ] \
+            && grep -qE "localhost:${port}([^0-9]|\$)" "$CRAPI_SPEC_FILE"; then
+        resolved="$CRAPI_SPEC_FILE"
+    else
+        if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "${CRAPI_SPEC_FILE}" ]; then
+            echo "[INFO] Cached spec at ${CRAPI_SPEC_FILE} does not match CRAPI_PORT=${port}; re-patching." >&2
+        fi
+        mkdir -p "$cache_dir"
+        resolved=$(crapi_patch_openapi_spec "$src_spec" "$port" "$cache_dir")
+    fi
+
+    if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
+        echo "crapi_resolve_spec: could not resolve spec (empty path or missing file)" >&2
+        return 1
+    fi
+    echo "$resolved"
+}

--- a/test/crapi/crapi-helpers.sh
+++ b/test/crapi/crapi-helpers.sh
@@ -190,7 +190,7 @@ crapi_resolve_spec() {
         resolved="$CRAPI_SPEC_FILE"
     else
         if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "${CRAPI_SPEC_FILE}" ]; then
-            echo "[INFO] Cached spec at ${CRAPI_SPEC_FILE} does not match port=${port}; re-patching." >&2
+            echo "crapi_resolve_spec: cached spec at ${CRAPI_SPEC_FILE} does not match port=${port}; re-patching." >&2
         fi
         mkdir -p "$cache_dir"
         resolved=$(crapi_patch_openapi_spec "$src_spec" "$port" "$cache_dir")
@@ -201,4 +201,21 @@ crapi_resolve_spec() {
         return 1
     fi
     echo "$resolved"
+}
+
+# crapi_planner_inputs_ready <crapi_status> <auth_file> <spec_file>
+#
+# Pure predicate for the crapi-planner SKIP gate in run-live-tests.sh. The
+# planner can only run if the crapi target PASSed and produced a usable auth
+# file and OpenAPI spec on disk. All inputs are arguments so the decision is
+# unit-testable without Docker, crAPI, or an LLM provider.
+#
+# Returns 0 (ready) iff crapi_status == "PASS" AND both files are non-empty
+# paths that exist; returns 1 otherwise.
+crapi_planner_inputs_ready() {
+    local crapi_status="$1" auth_file="$2" spec_file="$3"
+    [ "$crapi_status" = "PASS" ] || return 1
+    [ -n "$auth_file" ] && [ -f "$auth_file" ] || return 1
+    [ -n "$spec_file" ] && [ -f "$spec_file" ] || return 1
+    return 0
 }

--- a/test/crapi/crapi-helpers.sh
+++ b/test/crapi/crapi-helpers.sh
@@ -190,7 +190,7 @@ crapi_resolve_spec() {
         resolved="$CRAPI_SPEC_FILE"
     else
         if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "${CRAPI_SPEC_FILE}" ]; then
-            echo "[INFO] Cached spec at ${CRAPI_SPEC_FILE} does not match CRAPI_PORT=${port}; re-patching." >&2
+            echo "[INFO] Cached spec at ${CRAPI_SPEC_FILE} does not match port=${port}; re-patching." >&2
         fi
         mkdir -p "$cache_dir"
         resolved=$(crapi_patch_openapi_spec "$src_spec" "$port" "$cache_dir")

--- a/test/crapi/test_crapi_patch_openapi_spec.sh
+++ b/test/crapi/test_crapi_patch_openapi_spec.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Unit test for crapi_patch_openapi_spec. Sources the helper directly; no framework.
+# Run with: ./test/crapi/test_crapi_patch_openapi_spec.sh
+#
+# Covers four scenarios for crapi_patch_openapi_spec:
+#   A1: target_port == default port → echoes src path unchanged, no copy written
+#   A2: target_port != default port → writes patched copy at dest_dir/crapi-openapi-spec.json
+#       with localhost:<default> replaced by localhost:<target>
+#   A3: source spec missing the localhost:<default> token → returns non-zero
+#       AND removes the partial copy
+#   A4: source spec file does not exist → returns non-zero (early guard)
+set -u  # NOT -e: we want to catch failed assertions and keep going.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=crapi-helpers.sh
+. "${SCRIPT_DIR}/crapi-helpers.sh"
+
+TMPDIR_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/test_crapi_patch_openapi_spec.XXXXXX")
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+pass=0; fail=0
+
+assert_eq() {  # assert_eq <label> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  PASS: $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $1 — expected [$2], got [$3]"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_nonzero() {  # assert_nonzero <label> <exit_code>
+    if [ "$2" -ne 0 ]; then
+        echo "  PASS: $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $1 — expected non-zero exit, got 0"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_file_absent() {  # assert_file_absent <label> <path>
+    if [ ! -f "$2" ]; then
+        echo "  PASS: $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $1 — expected file to be absent: $2"
+        fail=$((fail + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+DEFAULT_PORT="$CRAPI_OPENAPI_SPEC_DEFAULT_PORT"  # 8888
+NONDEFAULT_PORT="9999"
+
+# Spec containing the default port token (normal case).
+SRC_DEFAULT="${TMPDIR_ROOT}/spec-default.json"
+printf '{"servers":[{"url":"http://localhost:%s"}]}' "$DEFAULT_PORT" > "$SRC_DEFAULT"
+
+# Spec that does NOT contain the default port token (broken upstream case).
+SRC_NO_TOKEN="${TMPDIR_ROOT}/spec-no-token.json"
+printf '{"servers":[{"url":"http://example.com"}]}' > "$SRC_NO_TOKEN"
+
+# ---------------------------------------------------------------------------
+# A1: target_port == default → echoes src path unchanged, no copy
+# ---------------------------------------------------------------------------
+echo "A1: target_port == default → echo src unchanged, no dest written"
+dest_a1="${TMPDIR_ROOT}/dest-a1"
+out=$(crapi_patch_openapi_spec "$SRC_DEFAULT" "$DEFAULT_PORT" "$dest_a1" 2>/dev/null); rc=$?
+assert_eq    "A1 exit 0"          "0"          "$rc"
+assert_eq    "A1 echoes src path" "$SRC_DEFAULT" "$out"
+assert_file_absent "A1 no copy written" "${dest_a1}/crapi-openapi-spec.json"
+
+# ---------------------------------------------------------------------------
+# A2: target_port != default → patched copy at dest_dir/crapi-openapi-spec.json
+#     with the substitution applied
+# ---------------------------------------------------------------------------
+echo "A2: target_port != default → write patched copy with correct port"
+dest_a2="${TMPDIR_ROOT}/dest-a2"
+out=$(crapi_patch_openapi_spec "$SRC_DEFAULT" "$NONDEFAULT_PORT" "$dest_a2" 2>/dev/null); rc=$?
+expected_dst="${dest_a2}/crapi-openapi-spec.json"
+assert_eq "A2 exit 0"              "0"            "$rc"
+assert_eq "A2 echoes dest path"    "$expected_dst" "$out"
+# Confirm the substitution landed in the file.
+if grep -q "localhost:${NONDEFAULT_PORT}" "$expected_dst" 2>/dev/null; then
+    echo "  PASS: A2 patched port present in dest"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: A2 patched port NOT found in dest"
+    fail=$((fail + 1))
+fi
+# Confirm the old port is gone.
+if ! grep -q "localhost:${DEFAULT_PORT}" "$expected_dst" 2>/dev/null; then
+    echo "  PASS: A2 default port absent from dest"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: A2 default port still present in dest"
+    fail=$((fail + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# A3: source spec missing localhost:<default> token → non-zero AND no partial copy
+# ---------------------------------------------------------------------------
+echo "A3: source spec missing default-port token → non-zero, partial copy removed"
+dest_a3="${TMPDIR_ROOT}/dest-a3"
+out=$(crapi_patch_openapi_spec "$SRC_NO_TOKEN" "$NONDEFAULT_PORT" "$dest_a3" 2>/dev/null); rc=$?
+assert_nonzero "A3 returns non-zero"          "$rc"
+assert_file_absent "A3 partial copy removed" "${dest_a3}/crapi-openapi-spec.json"
+
+# ---------------------------------------------------------------------------
+# A4: source spec file does not exist → non-zero (early guard)
+# ---------------------------------------------------------------------------
+echo "A4: source spec does not exist → non-zero"
+dest_a4="${TMPDIR_ROOT}/dest-a4"
+out=$(crapi_patch_openapi_spec "${TMPDIR_ROOT}/nonexistent.json" "$NONDEFAULT_PORT" "$dest_a4" 2>/dev/null); rc=$?
+assert_nonzero "A4 missing src returns non-zero" "$rc"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+exit $(( fail > 0 ? 1 : 0 ))

--- a/test/crapi/test_crapi_patch_openapi_spec.sh
+++ b/test/crapi/test_crapi_patch_openapi_spec.sh
@@ -73,6 +73,7 @@ out=$(crapi_patch_openapi_spec "$SRC_DEFAULT" "$DEFAULT_PORT" "$dest_a1" 2>/dev/
 assert_eq    "A1 exit 0"          "0"          "$rc"
 assert_eq    "A1 echoes src path" "$SRC_DEFAULT" "$out"
 assert_file_absent "A1 no copy written" "${dest_a1}/crapi-openapi-spec.json"
+assert_eq "A1 no dest_dir created" "false" "$([ -e "$dest_a1" ] && echo true || echo false)"
 
 # ---------------------------------------------------------------------------
 # A2: target_port != default → patched copy at dest_dir/crapi-openapi-spec.json

--- a/test/crapi/test_crapi_planner_inputs.sh
+++ b/test/crapi/test_crapi_planner_inputs.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Unit test for crapi_planner_inputs_ready. Sources the helper directly; no
+# framework. Run with: ./test/crapi/test_crapi_planner_inputs.sh
+#
+# crapi_planner_inputs_ready gates the crapi-planner SKIP decision in
+# run-live-tests.sh. It returns 0 (ready) iff the crapi target PASSed AND both
+# the auth file and the spec file exist on disk. Covers every branch:
+#   G1: PASS + both files exist            → ready (0)
+#   G2: status != PASS (SKIP)              → not ready (1)
+#   G3: status != PASS (ERROR)             → not ready (1)
+#   G4: PASS but auth file empty path      → not ready (1)
+#   G5: PASS but auth file missing on disk → not ready (1)
+#   G6: PASS but spec file empty path      → not ready (1)
+#   G7: PASS but spec file missing on disk → not ready (1)
+set -u  # NOT -e: we want to catch failed assertions and keep going.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=crapi-helpers.sh
+. "${SCRIPT_DIR}/crapi-helpers.sh"
+
+TMPDIR_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/test_crapi_planner_inputs.XXXXXX")
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+pass=0; fail=0
+
+assert_ready() {  # assert_ready <label> — expects the following call to return 0
+    if "$@"; then
+        echo "  PASS: $LABEL"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $LABEL — expected ready (exit 0), got $?"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_not_ready() {  # runs the predicate, expects non-zero
+    if "$@"; then
+        echo "  FAIL: $LABEL — expected not-ready (non-zero), got 0"
+        fail=$((fail + 1))
+    else
+        echo "  PASS: $LABEL"
+        pass=$((pass + 1))
+    fi
+}
+
+# Fixtures: a real auth file and spec file on disk.
+AUTH="${TMPDIR_ROOT}/auth.yaml"; : > "$AUTH"
+SPEC="${TMPDIR_ROOT}/spec.json"; : > "$SPEC"
+MISSING="${TMPDIR_ROOT}/nope.json"
+
+echo "G1: PASS + both files exist → ready"
+LABEL="G1 ready when crapi PASSed and files present"
+assert_ready     crapi_planner_inputs_ready "PASS" "$AUTH" "$SPEC"
+
+echo "G2: status SKIP → not ready"
+LABEL="G2 not ready when crapi SKIPped"
+assert_not_ready crapi_planner_inputs_ready "SKIP" "$AUTH" "$SPEC"
+
+echo "G3: status ERROR → not ready"
+LABEL="G3 not ready when crapi ERRORed"
+assert_not_ready crapi_planner_inputs_ready "ERROR" "$AUTH" "$SPEC"
+
+echo "G4: PASS but empty auth path → not ready"
+LABEL="G4 not ready when auth path empty"
+assert_not_ready crapi_planner_inputs_ready "PASS" "" "$SPEC"
+
+echo "G5: PASS but auth file missing → not ready"
+LABEL="G5 not ready when auth file missing on disk"
+assert_not_ready crapi_planner_inputs_ready "PASS" "$MISSING" "$SPEC"
+
+echo "G6: PASS but empty spec path → not ready"
+LABEL="G6 not ready when spec path empty"
+assert_not_ready crapi_planner_inputs_ready "PASS" "$AUTH" ""
+
+echo "G7: PASS but spec file missing → not ready"
+LABEL="G7 not ready when spec file missing on disk"
+assert_not_ready crapi_planner_inputs_ready "PASS" "$AUTH" "$MISSING"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+exit $(( fail > 0 ? 1 : 0 ))

--- a/test/crapi/test_crapi_resolve_spec.sh
+++ b/test/crapi/test_crapi_resolve_spec.sh
@@ -60,6 +60,9 @@ unset CRAPI_SPEC_FILE
 out=$(crapi_resolve_spec "$SRC_SPEC" 9999 "${TMPDIR_ROOT}/cache-s1" 2>/dev/null); rc=$?
 assert_eq    "S1 exit 0"             "0"                                          "$rc"
 assert_eq    "S1 echoes patched path" "${TMPDIR_ROOT}/cache-s1/crapi-openapi-spec.json" "$out"
+# Path-only assertions can't catch a resolver that returns the right path but a
+# wrongly-patched (or unpatched) file — assert the spec content carries the port.
+assert_eq    "S1 spec patched to port 9999" "localhost:9999" "$(grep -oE 'localhost:[0-9]+' "$out" | head -1)"
 
 # ---------------------------------------------------------------------------
 # S2: CRAPI_SPEC_FILE set but file missing → must re-patch
@@ -69,6 +72,7 @@ export CRAPI_SPEC_FILE="${TMPDIR_ROOT}/does-not-exist.json"
 out=$(crapi_resolve_spec "$SRC_SPEC" 9999 "${TMPDIR_ROOT}/cache-s2" 2>/dev/null); rc=$?
 assert_eq    "S2 exit 0"             "0"                                          "$rc"
 assert_eq    "S2 echoes patched path" "${TMPDIR_ROOT}/cache-s2/crapi-openapi-spec.json" "$out"
+assert_eq    "S2 spec patched to port 9999" "localhost:9999" "$(grep -oE 'localhost:[0-9]+' "$out" | head -1)"
 
 # ---------------------------------------------------------------------------
 # S3: cached spec exists and port matches exactly → echo cached path unchanged
@@ -88,6 +92,8 @@ export CRAPI_SPEC_FILE="$CACHED_8895"
 out=$(crapi_resolve_spec "$SRC_SPEC" 889 "${TMPDIR_ROOT}/cache-s4" 2>/dev/null); rc=$?
 assert_eq    "S4 exit 0"             "0"            "$rc"
 assert_eq    "S4 echoes patched path" "${TMPDIR_ROOT}/cache-s4/crapi-openapi-spec.json" "$out"
+# Re-patched to 889 from the SRC spec (8888), NOT the stale cached 8895.
+assert_eq    "S4 spec patched to port 889" "localhost:889" "$(grep -oE 'localhost:[0-9]+' "$out" | head -1)"
 
 # ---------------------------------------------------------------------------
 # S5: cached spec, port matches → idempotent (call twice, same path returned)

--- a/test/crapi/test_crapi_resolve_spec.sh
+++ b/test/crapi/test_crapi_resolve_spec.sh
@@ -40,15 +40,6 @@ assert_nonzero() {  # assert_nonzero <label> <exit_code>
     fi
 }
 
-assert_neq() {  # assert_neq <label> <unexpected> <actual>
-    if [ "$2" != "$3" ]; then
-        echo "  PASS: $1"
-        pass=$((pass + 1))
-    else
-        echo "  FAIL: $1 — expected value to differ from [$2], but got same"
-        fail=$((fail + 1))
-    fi
-}
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/test/crapi/test_crapi_resolve_spec.sh
+++ b/test/crapi/test_crapi_resolve_spec.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Unit test for crapi_resolve_spec. Sources the helper directly; no framework.
+# Run with: ./test/crapi/test_crapi_resolve_spec.sh
+#
+# Covers six scenarios for the three branches of crapi_resolve_spec:
+#   S1: CRAPI_SPEC_FILE unset           → must re-patch
+#   S2: CRAPI_SPEC_FILE set but missing → must re-patch
+#   S3: cached spec, port matches       → echo cached path (no copy)
+#   S4: substring-match guard: port=889 must NOT accept localhost:8895
+#   S5: cached spec, port matches (idempotent: call twice, same path)
+#   S6: crapi_patch_openapi_spec fails (missing source) → non-zero exit
+set -u  # NOT -e: we want to catch failed assertions and keep going.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=crapi-helpers.sh
+. "${SCRIPT_DIR}/crapi-helpers.sh"
+
+TMPDIR_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/test_crapi_resolve_spec.XXXXXX")
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+pass=0; fail=0
+
+assert_eq() {  # assert_eq <label> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  PASS: $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $1 — expected [$2], got [$3]"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_nonzero() {  # assert_nonzero <label> <exit_code>
+    if [ "$2" -ne 0 ]; then
+        echo "  PASS: $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $1 — expected non-zero exit, got 0"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_neq() {  # assert_neq <label> <unexpected> <actual>
+    if [ "$2" != "$3" ]; then
+        echo "  PASS: $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $1 — expected value to differ from [$2], but got same"
+        fail=$((fail + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+SRC_SPEC="${TMPDIR_ROOT}/spec-default.json"
+CACHED_8888="${TMPDIR_ROOT}/cached-8888.json"
+CACHED_8895="${TMPDIR_ROOT}/cached-8895.json"
+
+printf '{"servers":[{"url":"http://localhost:8888"}]}' > "$SRC_SPEC"
+printf '{"servers":[{"url":"http://localhost:8888"}]}' > "$CACHED_8888"
+printf '{"servers":[{"url":"http://localhost:8895"}]}' > "$CACHED_8895"
+
+# ---------------------------------------------------------------------------
+# S1: CRAPI_SPEC_FILE unset → must re-patch into cache
+# ---------------------------------------------------------------------------
+echo "S1: CRAPI_SPEC_FILE unset → re-patch"
+unset CRAPI_SPEC_FILE
+out=$(crapi_resolve_spec "$SRC_SPEC" 9999 "${TMPDIR_ROOT}/cache-s1" 2>/dev/null); rc=$?
+assert_eq    "S1 exit 0"             "0"                                          "$rc"
+assert_eq    "S1 echoes patched path" "${TMPDIR_ROOT}/cache-s1/crapi-openapi-spec.json" "$out"
+
+# ---------------------------------------------------------------------------
+# S2: CRAPI_SPEC_FILE set but file missing → must re-patch
+# ---------------------------------------------------------------------------
+echo "S2: CRAPI_SPEC_FILE set but missing on disk → re-patch"
+export CRAPI_SPEC_FILE="${TMPDIR_ROOT}/does-not-exist.json"
+out=$(crapi_resolve_spec "$SRC_SPEC" 9999 "${TMPDIR_ROOT}/cache-s2" 2>/dev/null); rc=$?
+assert_eq    "S2 exit 0"             "0"                                          "$rc"
+assert_eq    "S2 echoes patched path" "${TMPDIR_ROOT}/cache-s2/crapi-openapi-spec.json" "$out"
+
+# ---------------------------------------------------------------------------
+# S3: cached spec exists and port matches exactly → echo cached path unchanged
+# ---------------------------------------------------------------------------
+echo "S3: cached spec matches port → echo cached path (no copy)"
+export CRAPI_SPEC_FILE="$CACHED_8888"
+out=$(crapi_resolve_spec "$SRC_SPEC" 8888 "${TMPDIR_ROOT}/cache-s3" 2>/dev/null); rc=$?
+assert_eq    "S3 exit 0"             "0"             "$rc"
+assert_eq    "S3 echoes cached path" "$CACHED_8888"  "$out"
+
+# ---------------------------------------------------------------------------
+# S4: port=889 must NOT accept a stale spec pinned to localhost:8895
+#     This is the ([^0-9]|$) anchor regression test.
+# ---------------------------------------------------------------------------
+echo "S4: substring guard — port=889 must not accept localhost:8895"
+export CRAPI_SPEC_FILE="$CACHED_8895"
+out=$(crapi_resolve_spec "$SRC_SPEC" 889 "${TMPDIR_ROOT}/cache-s4" 2>/dev/null); rc=$?
+assert_eq    "S4 exit 0"             "0"            "$rc"
+assert_neq   "S4 rejects stale cache" "$CACHED_8895" "$out"
+
+# ---------------------------------------------------------------------------
+# S5: cached spec, port matches → idempotent (call twice, same path returned)
+# ---------------------------------------------------------------------------
+echo "S5: idempotent — call twice with matching port, same path each time"
+export CRAPI_SPEC_FILE="$CACHED_8888"
+out1=$(crapi_resolve_spec "$SRC_SPEC" 8888 "${TMPDIR_ROOT}/cache-s5" 2>/dev/null)
+out2=$(crapi_resolve_spec "$SRC_SPEC" 8888 "${TMPDIR_ROOT}/cache-s5" 2>/dev/null)
+assert_eq    "S5 first call echoes cached"  "$CACHED_8888" "$out1"
+assert_eq    "S5 second call same path"     "$out1"        "$out2"
+
+# ---------------------------------------------------------------------------
+# S6: crapi_patch_openapi_spec fails (missing source spec) → non-zero exit
+# ---------------------------------------------------------------------------
+echo "S6: missing source spec → non-zero exit"
+unset CRAPI_SPEC_FILE
+out=$(crapi_resolve_spec "${TMPDIR_ROOT}/nonexistent-src.json" 9999 "${TMPDIR_ROOT}/cache-s6" 2>/dev/null); rc=$?
+assert_nonzero "S6 missing source returns non-zero" "$rc"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+exit $(( fail > 0 ? 1 : 0 ))

--- a/test/crapi/test_crapi_resolve_spec.sh
+++ b/test/crapi/test_crapi_resolve_spec.sh
@@ -96,7 +96,7 @@ echo "S4: substring guard — port=889 must not accept localhost:8895"
 export CRAPI_SPEC_FILE="$CACHED_8895"
 out=$(crapi_resolve_spec "$SRC_SPEC" 889 "${TMPDIR_ROOT}/cache-s4" 2>/dev/null); rc=$?
 assert_eq    "S4 exit 0"             "0"            "$rc"
-assert_neq   "S4 rejects stale cache" "$CACHED_8895" "$out"
+assert_eq    "S4 echoes patched path" "${TMPDIR_ROOT}/cache-s4/crapi-openapi-spec.json" "$out"
 
 # ---------------------------------------------------------------------------
 # S5: cached spec, port matches → idempotent (call twice, same path returned)

--- a/test/llm-helpers.sh
+++ b/test/llm-helpers.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
-# =============================================================================
-# llm-helpers.sh
-#
-# Provider-agnostic LLM helpers for the live-test scripts. SOURCE THIS FILE —
-# do not execute it directly.
-#
-# Defines:
-#   detect_planner_provider — echoes the first available LLM provider
-#     (openai | anthropic | ollama) or empty string if none is reachable.
-#     Priority: OPENAI_API_KEY → ANTHROPIC_API_KEY → ollama probe → "".
-# =============================================================================
+# Provider-agnostic LLM helpers for the live-test scripts. SOURCE THIS FILE — do not execute directly.
 
 # detect_planner_provider — echoes the first available LLM provider
 # (openai | anthropic | ollama) or empty string if none is reachable.

--- a/test/llm-helpers.sh
+++ b/test/llm-helpers.sh
@@ -3,15 +3,43 @@
 
 # detect_planner_provider — echoes the first available LLM provider
 # (openai | anthropic | ollama) or empty string if none is reachable.
-# Priority: OPENAI_API_KEY → ANTHROPIC_API_KEY → ollama probe → "".
+# Priority: OPENAI_API_KEY → ANTHROPIC_API_KEY → ollama (reachable AND model
+# present) → "".
 detect_planner_provider() {
     if [ -n "${OPENAI_API_KEY:-}" ]; then
         echo "openai"
     elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
         echo "anthropic"
-    elif curl -sf -o /dev/null --max-time 2 "${OLLAMA_HOST:-http://localhost:11434}/api/tags"; then
+    elif _ollama_has_model; then
         echo "ollama"
     else
         echo ""
     fi
+}
+
+# _ollama_has_model — returns 0 iff ollama is reachable AND the model hadrian
+# will use (OLLAMA_MODEL, else llama3.2:latest) is present in /api/tags.
+#
+# Reachability alone is insufficient: a running ollama daemon with the model
+# NOT pulled would let detect_planner_provider report "ollama", but the
+# crapi-planner run uses --planner (not --planner-only), so hadrian silently
+# falls back to brute-force and the row reports PASS without exercising the
+# planner. Requiring the model present makes "ollama" mean "usable".
+# Couples to hadrian's default model string; override with OLLAMA_MODEL.
+_ollama_has_model() {
+    local host="${OLLAMA_HOST:-http://localhost:11434}"
+    local want="${OLLAMA_MODEL:-llama3.2:latest}"
+    local tags
+    tags=$(curl -sf --max-time 2 "${host}/api/tags" 2>/dev/null) || return 1
+    printf '%s' "$tags" | python3 -c '
+import json, sys
+want = sys.argv[1]
+try:
+    models = json.load(sys.stdin).get("models", [])
+except (ValueError, TypeError):
+    sys.exit(1)
+base = want.split(":")[0]
+names = {m.get("name", "") for m in models}
+sys.exit(0 if (want in names or any(n.split(":")[0] == base for n in names)) else 1)
+' "$want"
 }

--- a/test/llm-helpers.sh
+++ b/test/llm-helpers.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# =============================================================================
+# llm-helpers.sh
+#
+# Provider-agnostic LLM helpers for the live-test scripts. SOURCE THIS FILE —
+# do not execute it directly.
+#
+# Defines:
+#   detect_planner_provider — echoes the first available LLM provider
+#     (openai | anthropic | ollama) or empty string if none is reachable.
+#     Priority: OPENAI_API_KEY → ANTHROPIC_API_KEY → ollama probe → "".
+# =============================================================================
+
+# detect_planner_provider — echoes the first available LLM provider
+# (openai | anthropic | ollama) or empty string if none is reachable.
+# Priority: OPENAI_API_KEY → ANTHROPIC_API_KEY → ollama probe → "".
+detect_planner_provider() {
+    if [ -n "${OPENAI_API_KEY:-}" ]; then
+        echo "openai"
+    elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+        echo "anthropic"
+    elif curl -sf -o /dev/null --max-time 2 "${OLLAMA_HOST:-http://localhost:11434}/api/tags"; then
+        echo "ollama"
+    else
+        echo ""
+    fi
+}

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -217,7 +217,7 @@ extract_finding_count() {
 
 # detect_planner_provider — echoes the first available LLM provider
 # (openai | anthropic | ollama) or empty string if none is reachable.
-# Priority: OPENAI_API_KEY → anthropic → ollama probe → "".
+# Priority: OPENAI_API_KEY → ANTHROPIC_API_KEY → ollama probe → "".
 detect_planner_provider() {
     if [ -n "${OPENAI_API_KEY:-}" ]; then
         echo "openai"
@@ -765,6 +765,14 @@ fi
 # spec from the preceding `crapi` block — no signup, no spec patching,
 # no extra cleanup. Gated on LLM provider availability: OpenAI key wins,
 # Anthropic key next, local ollama as fallback, otherwise SKIP cleanly.
+#
+# Note on the crapi-prefix substring match: the crapi block gate above
+# uses `grep -q "crapi"`, which also matches "crapi-planner". That is
+# intentional — the planner depends on the crapi block having produced
+# CRAPI_AUTH_FILE and CRAPI_SPEC, so `--targets crapi-planner` implicitly
+# runs the crapi block too. The STATUS[crapi]=="PASS" check below is the
+# actual safety gate; the substring match is the desired pre-requisite
+# coupling.
 if echo "$TARGETS" | grep -q "crapi-planner"; then
     log_header "Target 5: crapi-planner (REST + LLM planner)"
 

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -82,6 +82,10 @@ GRPC_PORT="${GRPC_PORT:-$GRPC_DEFAULT_PORT}"
 # shellcheck source=test/llm-helpers.sh
 . "${SCRIPT_DIR}/llm-helpers.sh"
 
+# Target-selection helpers (targets_contains).
+# shellcheck source=test/target-helpers.sh
+. "${SCRIPT_DIR}/target-helpers.sh"
+
 # CRAPI_PORT default tracks the helper's CRAPI_OPENAPI_SPEC_DEFAULT_PORT.
 CRAPI_PORT="${CRAPI_PORT:-$CRAPI_OPENAPI_SPEC_DEFAULT_PORT}"
 
@@ -158,11 +162,7 @@ get_findings() { echo "${FINDINGS[$1]:-0}"; }
 set_duration() { DURATION["$1"]="$2"; }
 get_duration() { echo "${DURATION[$1]:-0}"; }
 
-# targets_contains <name> — exact comma-delimited membership test on $TARGETS.
-# Avoids the substring pitfall of `grep -q "crapi"` (which also matches
-# "crapi-planner"); the crapi → crapi-planner prerequisite coupling is now made
-# explicit at each call site instead of relying on a silent substring match.
-targets_contains() { case ",${TARGETS}," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }
+# targets_contains is sourced from target-helpers.sh (above).
 
 # ==== Helper functions ====
 

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -222,7 +222,6 @@ extract_finding_count() {
     fi
 }
 
-
 run_hadrian() {
     local name=$1
     shift
@@ -380,7 +379,12 @@ if echo "$TARGETS" | grep -q "vulnerable-api"; then
             fi
             log_ok "Tokens acquired for admin, user1, user2"
 
-            (umask 077; cat > "$AUTH_FILE" <<EOF
+            # Emit ${VAR} env-var refs (single-quoted heredoc) rather than
+            # inline JWTs so hadrian's expandEnvSafe resolves them at load
+            # and detectHardcodedSecret does not flag them — same pattern as
+            # the crapi block. Keeps the harness free of SECURITY warnings.
+            export ADMIN_TOKEN USER1_TOKEN USER2_TOKEN
+            (umask 077; cat > "$AUTH_FILE" <<'EOF'
 method: bearer
 location: header
 key_name: Authorization
@@ -556,7 +560,12 @@ if echo "$TARGETS" | grep -q "dvga"; then
                 log_ok "Created victim PII paste" || log_warn "Failed to create victim paste"
 
             DVGA_AUTH_FILE="${OUTPUT_DIR}/dvga-auth.yaml"
-            (umask 077; cat > "$DVGA_AUTH_FILE" <<EOF
+            # Emit ${VAR} env-var refs (single-quoted heredoc) rather than
+            # inline JWTs so hadrian's expandEnvSafe resolves them at load and
+            # detectHardcodedSecret does not flag them — same pattern as the
+            # crapi block. Keeps the harness free of SECURITY warnings.
+            export DVGA_ADMIN_TOKEN DVGA_OPERATOR_TOKEN
+            (umask 077; cat > "$DVGA_AUTH_FILE" <<'EOF'
 method: bearer
 location: header
 key_name: Authorization

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -698,7 +698,10 @@ if echo "$TARGETS" | grep -q "crapi"; then
             log_ok "crapi test videos uploaded"
 
             CRAPI_AUTH_FILE="${OUTPUT_DIR}/crapi-auth.yaml"
-            (umask 077; cat > "$CRAPI_AUTH_FILE" <<EOF
+            # See test-llm-planner.sh for the env-var-rather-than-inline-token
+            # rationale. Same fix applies here.
+            export CRAPI_ADMIN_TOKEN CRAPI_MECHANIC_TOKEN CRAPI_USER_TOKEN CRAPI_USER2_TOKEN
+            (umask 077; cat > "$CRAPI_AUTH_FILE" <<'EOF'
 method: bearer
 location: header
 key_name: Authorization

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -721,42 +721,12 @@ EOF
 
             RESULT_FILE="${OUTPUT_DIR}/crapi-results.json"
 
-            # Prefer the spec patched at setup time (CRAPI_SPEC_FILE in
-            # .live-test-config), but only if its baked-in port matches
-            # the port we're about to test against. If the operator
-            # overrides CRAPI_PORT at runtime (e.g.
-            # `CRAPI_PORT=9999 ./run-live-tests.sh`), the cached spec
-            # will be pinned to the old port and silently mis-route
-            # every request — so re-patch in that case.
-            # When re-patching, write into the same SPEC_CACHE_DIR
-            # setup-live-targets.sh uses so the artifact lives alongside
-            # the cache rather than mixed into the JSON results dir.
             SPEC_CACHE_DIR="${SCRIPT_DIR}/.live-test-cache"
-            CRAPI_SPEC=""
-            # Anchor the port match on a non-digit / end-of-line boundary
-            # so CRAPI_PORT=889 doesn't accept a stale spec pinned to
-            # localhost:8895 (substring match).
-            if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "${CRAPI_SPEC_FILE}" ] \
-                    && grep -qE "localhost:${CRAPI_PORT}([^0-9]|\$)" "$CRAPI_SPEC_FILE"; then
-                CRAPI_SPEC="$CRAPI_SPEC_FILE"
-            else
-                if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "${CRAPI_SPEC_FILE}" ]; then
-                    log_info "Cached spec at ${CRAPI_SPEC_FILE} does not match CRAPI_PORT=${CRAPI_PORT}; re-patching."
-                fi
-                mkdir -p "$SPEC_CACHE_DIR"
-                CRAPI_SPEC=$(crapi_patch_openapi_spec \
+            if ! CRAPI_SPEC=$(crapi_resolve_spec \
                     "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
                     "$CRAPI_PORT" \
-                    "$SPEC_CACHE_DIR")
-                if [ "$CRAPI_PORT" != "$CRAPI_OPENAPI_SPEC_DEFAULT_PORT" ]; then
-                    log_info "Patched OpenAPI spec to use port $CRAPI_PORT"
-                fi
-            fi
-            # Guard against silent failure of crapi_patch_openapi_spec —
-            # an empty path here would pass `--api ""` to hadrian and
-            # produce an opaque downstream error.
-            if [ -z "$CRAPI_SPEC" ] || [ ! -f "$CRAPI_SPEC" ]; then
-                log_fail "Could not resolve crAPI OpenAPI spec (empty path or missing file)"
+                    "$SPEC_CACHE_DIR"); then
+                log_fail "Could not resolve crAPI OpenAPI spec"
                 set_status "crapi" "ERROR"
             else
                 run_hadrian "crapi" test rest \

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -17,7 +17,10 @@
 #
 # Options:
 #   --targets <list>      Comma-separated targets to test (default: all)
-#                         Valid: vulnerable-api,dvga,grpc,crapi
+#                         Valid: vulnerable-api,dvga,grpc,crapi,crapi-planner
+#                         crapi-planner is opt-in and requires an LLM credential
+#                         (OPENAI_API_KEY, ANTHROPIC_API_KEY, or running ollama);
+#                         it is SKIPped cleanly when no provider is available.
 #   --verbose             Enable verbose Hadrian output
 #   --no-build            Skip building hadrian and target binaries
 #   --no-start            Don't start/stop services (assume already running)

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -754,10 +754,13 @@ EOF
 fi
 
 # ==== Test: crapi-planner ====
-# Runs the LLM-assisted planner against crAPI. Reuses the auth file and
-# spec from the preceding `crapi` block — no signup, no spec patching,
-# no extra cleanup. Gated on LLM provider availability: OpenAI key wins,
-# Anthropic key next, local ollama as fallback, otherwise SKIP cleanly.
+# Runs the LLM-assisted planner against crAPI. The crapi block always runs
+# first when "crapi-planner" is in TARGETS (because the grep -q "crapi"
+# gate matches the "crapi" substring of "crapi-planner"), so by the time
+# this block executes, CRAPI_AUTH_FILE and CRAPI_SPEC have already been
+# produced by that prior block — no additional signup, spec patching, or
+# cleanup is needed here. Gated on LLM provider availability: OpenAI key
+# wins, Anthropic key next, local ollama as fallback, otherwise SKIP cleanly.
 #
 # Note on the crapi-prefix substring match: the crapi block gate above
 # uses `grep -q "crapi"`, which also matches "crapi-planner". That is

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -101,7 +101,7 @@ DO_START=true
 
 # Track results per target using associative arrays
 declare -A STATUS FINDINGS DURATION
-for _t in vulnerable-api-bearer vulnerable-api-apikey vulnerable-api-basic vulnerable-api-cookie dvga grpc crapi; do
+for _t in vulnerable-api-bearer vulnerable-api-apikey vulnerable-api-basic vulnerable-api-cookie dvga grpc crapi crapi-planner; do
     STATUS["$_t"]="NOT_RUN"
     FINDINGS["$_t"]="0"
     DURATION["$_t"]="0"
@@ -212,6 +212,21 @@ extract_finding_count() {
         python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('stats',{}).get('findings',len(d.get('findings',[]))))" "$json_file" 2>/dev/null || echo "?"
     else
         echo "?"
+    fi
+}
+
+# detect_planner_provider — echoes the first available LLM provider
+# (openai | anthropic | ollama) or empty string if none is reachable.
+# Priority: OPENAI_API_KEY → anthropic → ollama probe → "".
+detect_planner_provider() {
+    if [ -n "${OPENAI_API_KEY:-}" ]; then
+        echo "openai"
+    elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+        echo "anthropic"
+    elif curl -sf -o /dev/null --max-time 2 "${OLLAMA_HOST:-http://localhost:11434}/api/tags"; then
+        echo "ollama"
+    else
+        echo ""
     fi
 }
 
@@ -745,6 +760,48 @@ EOF
     fi
 fi
 
+# ==== Test: crapi-planner ====
+# Runs the LLM-assisted planner against crAPI. Reuses the auth file and
+# spec from the preceding `crapi` block — no signup, no spec patching,
+# no extra cleanup. Gated on LLM provider availability: OpenAI key wins,
+# Anthropic key next, local ollama as fallback, otherwise SKIP cleanly.
+if echo "$TARGETS" | grep -q "crapi-planner"; then
+    log_header "Target 5: crapi-planner (REST + LLM planner)"
+
+    # Inherit crapi status — if crapi didn't produce CRAPI_AUTH_FILE /
+    # CRAPI_SPEC (because crapi wasn't in TARGETS, or it SKIPPED, or it
+    # ERRORED), we have nothing to plan against. SKIP rather than ERROR
+    # because the operator's choice of TARGETS, not a code fault, is the
+    # cause.
+    if [ "$(get_status crapi)" != "PASS" ] \
+            || [ -z "${CRAPI_AUTH_FILE:-}" ] || [ ! -f "${CRAPI_AUTH_FILE:-/nonexistent}" ] \
+            || [ -z "${CRAPI_SPEC:-}" ]      || [ ! -f "${CRAPI_SPEC:-/nonexistent}" ]; then
+        log_info "crapi-planner requires the crapi target to have run successfully first; skipping"
+        set_status "crapi-planner" "SKIP"
+    else
+        PLANNER_PROVIDER=$(detect_planner_provider)
+        if [ -z "$PLANNER_PROVIDER" ]; then
+            log_info "no LLM provider available (set OPENAI_API_KEY, ANTHROPIC_API_KEY, or run ollama), skipping crapi-planner"
+            set_status "crapi-planner" "SKIP"
+        else
+            log_info "Using LLM provider: ${PLANNER_PROVIDER}"
+            CRAPI_PLANNER_RESULT_FILE="${OUTPUT_DIR}/crapi-planner-${PLANNER_PROVIDER}-results.json"
+            run_hadrian "crapi-planner" test rest \
+                --api "$CRAPI_SPEC" \
+                --roles "${SCRIPT_DIR}/crapi/roles.yaml" \
+                --auth "$CRAPI_AUTH_FILE" \
+                --template-dir "${SCRIPT_DIR}/crapi/templates/owasp" \
+                --planner --planner-provider "$PLANNER_PROVIDER" \
+                --output json \
+                --output-file "$CRAPI_PLANNER_RESULT_FILE" \
+                $VERBOSE
+
+            set_findings "crapi-planner" "$(extract_finding_count "$CRAPI_PLANNER_RESULT_FILE")"
+            log_ok "crapi-planner: $(get_findings crapi-planner) findings in $(get_duration crapi-planner)s"
+        fi
+    fi
+fi
+
 # ==== Summary ====
 log_header "Test Summary"
 
@@ -761,7 +818,7 @@ ALL_TARGETS=""
 if echo "$TARGETS" | grep -q "vulnerable-api"; then
     ALL_TARGETS="vulnerable-api-bearer vulnerable-api-apikey vulnerable-api-basic vulnerable-api-cookie"
 fi
-for extra in dvga grpc crapi; do
+for extra in dvga grpc crapi crapi-planner; do
     if echo "$TARGETS" | grep -q "${extra}"; then
         ALL_TARGETS="$ALL_TARGETS $extra"
     fi

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -158,6 +158,12 @@ get_findings() { echo "${FINDINGS[$1]:-0}"; }
 set_duration() { DURATION["$1"]="$2"; }
 get_duration() { echo "${DURATION[$1]:-0}"; }
 
+# targets_contains <name> — exact comma-delimited membership test on $TARGETS.
+# Avoids the substring pitfall of `grep -q "crapi"` (which also matches
+# "crapi-planner"); the crapi → crapi-planner prerequisite coupling is now made
+# explicit at each call site instead of relying on a silent substring match.
+targets_contains() { case ",${TARGETS}," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }
+
 # ==== Helper functions ====
 
 # All log_* helpers write to stderr so they don't collide with values
@@ -650,8 +656,18 @@ if echo "$TARGETS" | grep -q "grpc"; then
 fi
 
 # ==== Test: crapi ====
-if echo "$TARGETS" | grep -q "crapi"; then
+# crapi-planner depends on this block (it consumes CRAPI_AUTH_FILE / CRAPI_SPEC),
+# so requesting crapi-planner runs crapi as its prerequisite. The coupling is
+# explicit here rather than hidden in a `grep -q "crapi"` substring match.
+if targets_contains crapi || targets_contains crapi-planner; then
     log_header "Target 4: crapi (REST)"
+
+    # Tell the operator when crapi is running only as the crapi-planner
+    # prerequisite (they did not ask for crapi directly) so its setup work
+    # isn't a surprise.
+    if targets_contains crapi-planner && ! targets_contains crapi; then
+        log_info "crapi-planner requested: running the crapi target first as its prerequisite"
+    fi
 
     CRAPI_URL="http://localhost:${CRAPI_PORT}"
 
@@ -763,38 +779,29 @@ EOF
 fi
 
 # ==== Test: crapi-planner ====
-# Runs the LLM-assisted planner against crAPI. The crapi block always runs
-# first when "crapi-planner" is in TARGETS (because the grep -q "crapi"
-# gate matches the "crapi" substring of "crapi-planner"), so by the time
+# Runs the LLM-assisted planner against crAPI. The crapi block above runs
+# first whenever crapi-planner is requested (the gate there is the explicit
+# `targets_contains crapi || targets_contains crapi-planner`), so by the time
 # this block executes, CRAPI_AUTH_FILE and CRAPI_SPEC have already been
 # produced by that prior block — no additional signup, spec patching, or
 # cleanup is needed here. Gated on LLM provider availability: OpenAI key
 # wins, Anthropic key next, local ollama as fallback, otherwise SKIP cleanly.
-#
-# Note on the crapi-prefix substring match: the crapi block gate above
-# uses `grep -q "crapi"`, which also matches "crapi-planner". That is
-# intentional — the planner depends on the crapi block having produced
-# CRAPI_AUTH_FILE and CRAPI_SPEC, so `--targets crapi-planner` implicitly
-# runs the crapi block too. The STATUS[crapi]=="PASS" check below is the
-# actual safety gate; the substring match is the desired pre-requisite
-# coupling.
-if echo "$TARGETS" | grep -q "crapi-planner"; then
+if targets_contains crapi-planner; then
     log_header "Target 5: crapi-planner (REST + LLM planner)"
 
-    # Inherit crapi status — if crapi didn't produce CRAPI_AUTH_FILE /
-    # CRAPI_SPEC (because crapi wasn't in TARGETS, or it SKIPPED, or it
-    # ERRORED), we have nothing to plan against. SKIP rather than ERROR
-    # because the operator's choice of TARGETS, not a code fault, is the
-    # cause.
-    if [ "$(get_status crapi)" != "PASS" ] \
-            || [ -z "${CRAPI_AUTH_FILE:-}" ] || [ ! -f "${CRAPI_AUTH_FILE:-/nonexistent}" ] \
-            || [ -z "${CRAPI_SPEC:-}" ]      || [ ! -f "${CRAPI_SPEC:-/nonexistent}" ]; then
+    # Inherit crapi status — if crapi didn't produce a usable CRAPI_AUTH_FILE /
+    # CRAPI_SPEC (because crapi SKIPPED or ERRORED), we have nothing to plan
+    # against. The readiness predicate lives in crapi-helpers.sh so its branches
+    # are unit-tested (test/crapi/test_crapi_planner_inputs.sh) without Docker.
+    # SKIP rather than ERROR because the operator's environment, not a code
+    # fault, is the cause.
+    if ! crapi_planner_inputs_ready "$(get_status crapi)" "${CRAPI_AUTH_FILE:-}" "${CRAPI_SPEC:-}"; then
         log_info "crapi-planner requires the crapi target to have run successfully first; skipping"
         set_status "crapi-planner" "SKIP"
     else
         PLANNER_PROVIDER=$(detect_planner_provider)
         if [ -z "$PLANNER_PROVIDER" ]; then
-            log_info "no LLM provider available (set OPENAI_API_KEY, ANTHROPIC_API_KEY, or run ollama), skipping crapi-planner"
+            log_info "no LLM provider available (set OPENAI_API_KEY, ANTHROPIC_API_KEY, or run ollama with the model pulled), skipping crapi-planner"
             set_status "crapi-planner" "SKIP"
         else
             log_info "Using LLM provider: ${PLANNER_PROVIDER}"
@@ -828,14 +835,21 @@ TOTAL_FAIL=0
 TOTAL_SKIP=0
 
 ALL_TARGETS=""
-if echo "$TARGETS" | grep -q "vulnerable-api"; then
+if targets_contains vulnerable-api; then
     ALL_TARGETS="vulnerable-api-bearer vulnerable-api-apikey vulnerable-api-basic vulnerable-api-cookie"
 fi
+# Exact membership (targets_contains) so the substring overlap between "crapi"
+# and "crapi-planner" no longer adds phantom rows.
 for extra in dvga grpc crapi crapi-planner; do
-    if echo "$TARGETS" | grep -q "${extra}"; then
+    if targets_contains "$extra"; then
         ALL_TARGETS="$ALL_TARGETS $extra"
     fi
 done
+# crapi runs as a prerequisite of crapi-planner; surface its row even when the
+# operator asked only for crapi-planner, so its PASS/SKIP/ERROR is visible.
+if targets_contains crapi-planner && ! targets_contains crapi; then
+    ALL_TARGETS="$ALL_TARGETS crapi"
+fi
 
 for target in $ALL_TARGETS; do
 

--- a/test/run-live-tests.sh
+++ b/test/run-live-tests.sh
@@ -78,6 +78,10 @@ GRPC_PORT="${GRPC_PORT:-$GRPC_DEFAULT_PORT}"
 # shellcheck source=test/crapi/crapi-helpers.sh
 . "${SCRIPT_DIR}/crapi/crapi-helpers.sh"
 
+# Provider-agnostic LLM helpers (detect_planner_provider).
+# shellcheck source=test/llm-helpers.sh
+. "${SCRIPT_DIR}/llm-helpers.sh"
+
 # CRAPI_PORT default tracks the helper's CRAPI_OPENAPI_SPEC_DEFAULT_PORT.
 CRAPI_PORT="${CRAPI_PORT:-$CRAPI_OPENAPI_SPEC_DEFAULT_PORT}"
 
@@ -218,20 +222,6 @@ extract_finding_count() {
     fi
 }
 
-# detect_planner_provider — echoes the first available LLM provider
-# (openai | anthropic | ollama) or empty string if none is reachable.
-# Priority: OPENAI_API_KEY → ANTHROPIC_API_KEY → ollama probe → "".
-detect_planner_provider() {
-    if [ -n "${OPENAI_API_KEY:-}" ]; then
-        echo "openai"
-    elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-        echo "anthropic"
-    elif curl -sf -o /dev/null --max-time 2 "${OLLAMA_HOST:-http://localhost:11434}/api/tags"; then
-        echo "ollama"
-    else
-        echo ""
-    fi
-}
 
 run_hadrian() {
     local name=$1

--- a/test/target-helpers.sh
+++ b/test/target-helpers.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Target-selection helpers for run-live-tests.sh. SOURCE THIS FILE — do not
+# execute directly.
+
+# targets_contains <name> — exact comma-delimited membership test on $TARGETS.
+# Avoids the substring pitfall of `grep -q "crapi"` (which also matches
+# "crapi-planner"); the crapi → crapi-planner prerequisite coupling is made
+# explicit at each call site instead of relying on a silent substring match.
+# Reads the global $TARGETS (set from --targets) so call sites stay terse.
+targets_contains() { case ",${TARGETS:-}," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }

--- a/test/test-llm-planner.sh
+++ b/test/test-llm-planner.sh
@@ -105,18 +105,18 @@ if ! crapi_setup_users "$CRAPI_URL"; then
     exit 1
 fi
 
-ADMIN_TOKEN=$(crapi_login "$CRAPI_URL" "$CRAPI_ADMIN_EMAIL"    "$CRAPI_PASSWORD")
-USER_TOKEN=$(crapi_login  "$CRAPI_URL" "$CRAPI_USER_EMAIL"     "$CRAPI_PASSWORD")
-USER2_TOKEN=$(crapi_login "$CRAPI_URL" "$CRAPI_USER2_EMAIL"    "$CRAPI_PASSWORD")
-MECH_TOKEN=$(crapi_login  "$CRAPI_URL" "$CRAPI_MECHANIC_EMAIL" "$CRAPI_PASSWORD")
+CRAPI_ADMIN_TOKEN=$(crapi_login    "$CRAPI_URL" "$CRAPI_ADMIN_EMAIL"    "$CRAPI_PASSWORD")
+CRAPI_USER_TOKEN=$(crapi_login     "$CRAPI_URL" "$CRAPI_USER_EMAIL"     "$CRAPI_PASSWORD")
+CRAPI_USER2_TOKEN=$(crapi_login    "$CRAPI_URL" "$CRAPI_USER2_EMAIL"    "$CRAPI_PASSWORD")
+CRAPI_MECHANIC_TOKEN=$(crapi_login "$CRAPI_URL" "$CRAPI_MECHANIC_EMAIL" "$CRAPI_PASSWORD")
 
 # All four tokens must be acquired so role-specific templates (BFLA
 # admin-video-delete, mechanic workflows) run with the correct identity.
 # Previously this script mapped admin -> USER_TOKEN, which silently
 # degraded admin-scoped templates in the planner test to regular-user
 # credentials.
-if [ -z "$ADMIN_TOKEN" ] || [ -z "$USER_TOKEN" ] \
-        || [ -z "$USER2_TOKEN" ] || [ -z "$MECH_TOKEN" ]; then
+if [ -z "$CRAPI_ADMIN_TOKEN" ] || [ -z "$CRAPI_USER_TOKEN" ] \
+        || [ -z "$CRAPI_USER2_TOKEN" ] || [ -z "$CRAPI_MECHANIC_TOKEN" ]; then
     log_fail "Failed to get crAPI tokens (admin/user1/user2/mechanic must all be non-empty)"
     exit 1
 fi
@@ -156,18 +156,24 @@ if [ -z "$CRAPI_SPEC" ] || [ ! -f "$CRAPI_SPEC" ]; then
 fi
 
 AUTH_FILE="${OUTPUT_DIR}/planner-auth.yaml"
-(umask 077; cat > "$AUTH_FILE" <<EOF
+# Export tokens as env vars so the YAML can reference them by name. The
+# YAML is emitted with a QUOTED heredoc terminator (`<<'EOF'`) so bash
+# does NOT substitute the ${...} text — hadrian's pkg/auth/auth.go
+# expands them via expandEnvSafe before detectHardcodedSecret fires,
+# which suppresses the SECURITY warning that fires on inline tokens.
+export CRAPI_ADMIN_TOKEN CRAPI_MECHANIC_TOKEN CRAPI_USER_TOKEN CRAPI_USER2_TOKEN
+(umask 077; cat > "$AUTH_FILE" <<'EOF'
 method: bearer
 location: header
 roles:
   admin:
-    token: "${ADMIN_TOKEN}"
+    token: "${CRAPI_ADMIN_TOKEN}"
   mechanic:
-    token: "${MECH_TOKEN}"
+    token: "${CRAPI_MECHANIC_TOKEN}"
   user:
-    token: "${USER_TOKEN}"
+    token: "${CRAPI_USER_TOKEN}"
   user2:
-    token: "${USER2_TOKEN}"
+    token: "${CRAPI_USER2_TOKEN}"
   anonymous:
     token: ""
 EOF

--- a/test/test-llm-planner.sh
+++ b/test/test-llm-planner.sh
@@ -124,34 +124,14 @@ log_ok "Tokens acquired"
 
 mkdir -p "$OUTPUT_DIR"
 
-# Resolve the OpenAPI spec path. Prefer the patched copy that
-# setup-live-targets.sh wrote into .live-test-config, but only if its
-# baked-in port matches our current CRAPI_PORT — otherwise a runtime
-# CRAPI_PORT override against a stale config would silently mis-route.
-# When re-patching, write into the same SPEC_CACHE_DIR setup uses
-# (test/.live-test-cache/) so a planner-only run doesn't leave a cache
-# artifact in the .results directory.
+# Resolve the OpenAPI spec path. See crapi_resolve_spec for preference
+# rules (prefer cached if port matches, else re-patch).
 SPEC_CACHE_DIR="${SCRIPT_DIR}/.live-test-cache"
-# Anchor the port match on a non-digit / end-of-line boundary to avoid
-# substring false-matches (e.g. CRAPI_PORT=889 vs localhost:8895).
-if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "$CRAPI_SPEC_FILE" ] \
-        && grep -qE "localhost:${CRAPI_PORT}([^0-9]|\$)" "$CRAPI_SPEC_FILE"; then
-    CRAPI_SPEC="$CRAPI_SPEC_FILE"
-else
-    if [ -n "${CRAPI_SPEC_FILE:-}" ] && [ -f "$CRAPI_SPEC_FILE" ]; then
-        log_info "Cached spec at ${CRAPI_SPEC_FILE} does not match CRAPI_PORT=${CRAPI_PORT}; re-patching."
-    fi
-    mkdir -p "$SPEC_CACHE_DIR"
-    CRAPI_SPEC=$(crapi_patch_openapi_spec \
+if ! CRAPI_SPEC=$(crapi_resolve_spec \
         "${SCRIPT_DIR}/crapi/crapi-openapi-spec.json" \
         "$CRAPI_PORT" \
-        "$SPEC_CACHE_DIR")
-fi
-# Guard against silent failure of crapi_patch_openapi_spec (validation
-# branch returns 1 + empty stdout). An unchecked empty $CRAPI_SPEC would
-# pass `--api ""` to hadrian and produce an opaque downstream error.
-if [ -z "$CRAPI_SPEC" ] || [ ! -f "$CRAPI_SPEC" ]; then
-    log_fail "Could not resolve crAPI OpenAPI spec (empty path or missing file)"
+        "$SPEC_CACHE_DIR"); then
+    log_fail "Could not resolve crAPI OpenAPI spec"
     exit 1
 fi
 

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -1,24 +1,21 @@
 #!/usr/bin/env bash
-# Unit test for detect_planner_provider. Sources the helper directly from
-# run-live-tests.sh; no external framework required.
+# Unit test for detect_planner_provider. Sources llm-helpers.sh directly.
 # Run with: ./test/test_detect_planner_provider.sh
 #
-# Covers five scenarios for the four branches of detect_planner_provider:
+# Covers six scenarios for the four branches of detect_planner_provider:
 #   P1: only OPENAI_API_KEY set             → echoes "openai"
 #   P2: only ANTHROPIC_API_KEY set          → echoes "anthropic"
 #   P3: both OPENAI + ANTHROPIC set         → echoes "openai" (priority)
 #   P4: no keys, OLLAMA_HOST unreachable    → echoes "" (curl timeout path)
 #   P5: OLLAMA_HOST=http://127.0.0.1:1     → --max-time 2 fires → echoes ""
+#   P6: one-shot HTTP server on free port   → echoes "ollama" (reachable)
 set -u  # NOT -e: we want to catch failed assertions and keep going.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-RUN_LIVE="${SCRIPT_DIR}/run-live-tests.sh"
 
-# Extract and source only the detect_planner_provider function definition.
-# The sed range matches from the comment block through the closing brace so
-# we pick up the function body verbatim without sourcing the full script
-# (which would execute set -euo pipefail and attempt to run the test harness).
-source <(sed -n '/^detect_planner_provider() {/,/^}$/p' "$RUN_LIVE")
+# Source the helper directly — no sed extraction needed.
+# shellcheck source=test/llm-helpers.sh
+. "${SCRIPT_DIR}/llm-helpers.sh"
 
 pass=0; fail=0
 

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=test/llm-helpers.sh
 . "${SCRIPT_DIR}/llm-helpers.sh"
 
-pass=0; fail=0
+pass=0; fail=0; skip=0
 
 assert_eq() {  # assert_eq <label> <expected> <actual>
     if [ "$2" = "$3" ]; then
@@ -27,6 +27,11 @@ assert_eq() {  # assert_eq <label> <expected> <actual>
         echo "  FAIL: $1 — expected [${2}], got [${3}]"
         fail=$((fail + 1))
     fi
+}
+
+assert_skip() {  # assert_skip <label> <reason>
+    echo "  SKIP: $1 — $2"
+    skip=$((skip + 1))
 }
 
 # Save caller's env so we can restore it between scenarios.
@@ -86,13 +91,19 @@ restore_env
 # ---------------------------------------------------------------------------
 # P5: OLLAMA_HOST unset → helper uses default http://localhost:11434
 # Exercises the ${OLLAMA_HOST:-http://localhost:11434} default fallback.
-# Assumes no local ollama is running on the test host (valid for CI/dev
-# sandboxes; may be flaky on a developer's box with ollama running).
+# If a local ollama is actually running on the default port (common on
+# developer machines), SKIP — the assertion can't distinguish "default
+# expansion happened correctly" from "ollama is up and responded".
 # ---------------------------------------------------------------------------
 echo "P5: OLLAMA_HOST unset → falls back to default localhost:11434 → empty (no local ollama)"
 unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
-out=$(detect_planner_provider 2>/dev/null || true)
-assert_eq "P5 OLLAMA_HOST default fallback (assumes no local ollama)" "" "$out"
+if curl -sf -o /dev/null --max-time 2 http://localhost:11434/api/tags 2>/dev/null; then
+    assert_skip "P5 OLLAMA_HOST default fallback" \
+        "local ollama detected on localhost:11434; default-fallback path produces 'ollama' instead of empty"
+else
+    out=$(detect_planner_provider 2>/dev/null || true)
+    assert_eq "P5 OLLAMA_HOST default fallback" "" "$out"
+fi
 restore_env
 
 # ---------------------------------------------------------------------------
@@ -147,10 +158,12 @@ srv.serve_forever()
 _P6_SERVER_PID=$!
 
 # Wait for the server to bind (max ~500ms); avoids the timing-fragile sleep 0.1.
+# Subshell + outer 2>/dev/null is the only form that reliably suppresses bash's
+# "connect: Connection refused" diagnostic on failed /dev/tcp attempts — the
+# exec-line `2>/dev/null` form leaks the message on some bash builds.
 OLLAMA_PORT="$FREE_PORT"
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-    if exec 3<>"/dev/tcp/127.0.0.1/${OLLAMA_PORT}" 2>/dev/null; then
-        exec 3<&-
+    if (exec 3<>"/dev/tcp/127.0.0.1/${OLLAMA_PORT}") 2>/dev/null; then
         break
     fi
     sleep 0.05
@@ -169,5 +182,9 @@ restore_env
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
-echo "=== Results: $pass passed, $fail failed ==="
+if [ "$skip" -gt 0 ]; then
+    echo "=== Results: $pass passed, $fail failed, $skip skipped ==="
+else
+    echo "=== Results: $pass passed, $fail failed ==="
+fi
 exit $(( fail > 0 ? 1 : 0 ))

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -84,17 +84,29 @@ assert_eq "P4 echoes empty on curl failure" "" "$out"
 restore_env
 
 # ---------------------------------------------------------------------------
-# P5: OLLAMA_HOST=http://127.0.0.1:1, explicit --max-time 2 guard
-# Same as P4 but documents the --max-time timeout scenario explicitly.
-# Port 1 is guaranteed closed so connection is refused immediately (not
-# after 2 seconds), exercising the "curl returns non-zero" code path that
-# the --max-time guard is designed to handle.
+# P5: OLLAMA_HOST unset → helper uses default http://localhost:11434
+# Exercises the ${OLLAMA_HOST:-http://localhost:11434} default fallback.
+# Assumes no local ollama is running on the test host (valid for CI/dev
+# sandboxes; may be flaky on a developer's box with ollama running).
 # ---------------------------------------------------------------------------
-echo "P5: OLLAMA_HOST unreachable (port 1) → --max-time 2 guard fires → empty"
+echo "P5: OLLAMA_HOST unset → falls back to default localhost:11434 → empty (no local ollama)"
 unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
-export OLLAMA_HOST="http://127.0.0.1:1"
-out=$(detect_planner_provider)
-assert_eq "P5 echoes empty on timeout/refusal" "" "$out"
+out=$(detect_planner_provider 2>/dev/null || true)
+assert_eq "P5 OLLAMA_HOST default fallback (assumes no local ollama)" "" "$out"
+restore_env
+
+# ---------------------------------------------------------------------------
+# PE: empty-but-set OPENAI_API_KEY treated as not set (regression guard)
+# The helper uses [ -n "${OPENAI_API_KEY:-}" ] which treats both unset and
+# empty as "not set". This test guards against regressions where someone
+# changes to [ -n "${OPENAI_API_KEY-}" ] (no colon), which would silently
+# match empty-but-set.
+# ---------------------------------------------------------------------------
+echo "PE: empty-but-set OPENAI_API_KEY treated as not set → empty"
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+OPENAI_API_KEY="" ANTHROPIC_API_KEY="" OLLAMA_HOST="http://127.0.0.1:1" \
+    out=$(detect_planner_provider 2>/dev/null || true)
+assert_eq "PE empty-but-set OPENAI_API_KEY falls through" "" "$out"
 restore_env
 
 # ---------------------------------------------------------------------------
@@ -117,7 +129,10 @@ print(s.getsockname()[1])
 s.close()
 ")
 
-# Start a one-request HTTP server in the background that serves 200 on any path.
+# Start a persistent HTTP server in the background that serves 200 on any path.
+# Uses serve_forever() (not handle_request()) so the /dev/tcp readiness probe
+# and the curl from detect_planner_provider can both be served without racing.
+# The process is explicitly killed after the assertion.
 python3 -c "
 import http.server, sys
 class H(http.server.BaseHTTPRequestHandler):
@@ -127,17 +142,27 @@ class H(http.server.BaseHTTPRequestHandler):
         self.wfile.write(b'{}')
     def log_message(self, *a): pass
 srv = http.server.HTTPServer(('127.0.0.1', int(sys.argv[1])), H)
-srv.handle_request()
+srv.serve_forever()
 " "$FREE_PORT" &
 _P6_SERVER_PID=$!
-trap 'kill "$_P6_SERVER_PID" 2>/dev/null; wait "$_P6_SERVER_PID" 2>/dev/null' EXIT
 
-# Give the server a moment to start.
-sleep 0.1
+# Wait for the server to bind (max ~500ms); avoids the timing-fragile sleep 0.1.
+OLLAMA_PORT="$FREE_PORT"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if exec 3<>"/dev/tcp/127.0.0.1/${OLLAMA_PORT}" 2>/dev/null; then
+        exec 3<&-
+        break
+    fi
+    sleep 0.05
+done
 
 export OLLAMA_HOST="http://127.0.0.1:${FREE_PORT}"
 out=$(detect_planner_provider)
 assert_eq "P6 echoes ollama when server reachable" "ollama" "$out"
+
+# Explicit cleanup — do NOT use trap here to avoid clobbering any outer trap chain.
+kill "$_P6_SERVER_PID" 2>/dev/null
+wait "$_P6_SERVER_PID" 2>/dev/null || true
 restore_env
 
 # ---------------------------------------------------------------------------

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Unit test for detect_planner_provider. Sources the helper directly from
+# run-live-tests.sh; no external framework required.
+# Run with: ./test/test_detect_planner_provider.sh
+#
+# Covers five scenarios for the four branches of detect_planner_provider:
+#   P1: only OPENAI_API_KEY set             → echoes "openai"
+#   P2: only ANTHROPIC_API_KEY set          → echoes "anthropic"
+#   P3: both OPENAI + ANTHROPIC set         → echoes "openai" (priority)
+#   P4: no keys, OLLAMA_HOST unreachable    → echoes "" (curl timeout path)
+#   P5: OLLAMA_HOST=http://127.0.0.1:1     → --max-time 2 fires → echoes ""
+set -u  # NOT -e: we want to catch failed assertions and keep going.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+RUN_LIVE="${SCRIPT_DIR}/run-live-tests.sh"
+
+# Extract and source only the detect_planner_provider function definition.
+# The sed range matches from the comment block through the closing brace so
+# we pick up the function body verbatim without sourcing the full script
+# (which would execute set -euo pipefail and attempt to run the test harness).
+source <(sed -n '/^detect_planner_provider() {/,/^}$/p' "$RUN_LIVE")
+
+pass=0; fail=0
+
+assert_eq() {  # assert_eq <label> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  PASS: $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $1 — expected [${2}], got [${3}]"
+        fail=$((fail + 1))
+    fi
+}
+
+# Save caller's env so we can restore it between scenarios.
+_SAVED_OPENAI="${OPENAI_API_KEY:-}"
+_SAVED_ANTHROPIC="${ANTHROPIC_API_KEY:-}"
+_SAVED_OLLAMA="${OLLAMA_HOST:-}"
+
+restore_env() {
+    if [ -n "$_SAVED_OPENAI" ];    then export OPENAI_API_KEY="$_SAVED_OPENAI";    else unset OPENAI_API_KEY;    fi
+    if [ -n "$_SAVED_ANTHROPIC" ]; then export ANTHROPIC_API_KEY="$_SAVED_ANTHROPIC"; else unset ANTHROPIC_API_KEY; fi
+    if [ -n "$_SAVED_OLLAMA" ];    then export OLLAMA_HOST="$_SAVED_OLLAMA";        else unset OLLAMA_HOST;        fi
+}
+
+# ---------------------------------------------------------------------------
+# P1: only OPENAI_API_KEY set → should echo "openai"
+# ---------------------------------------------------------------------------
+echo "P1: only OPENAI_API_KEY set → openai"
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+export OPENAI_API_KEY="sk-test-key-openai"
+out=$(detect_planner_provider)
+assert_eq "P1 echoes openai" "openai" "$out"
+restore_env
+
+# ---------------------------------------------------------------------------
+# P2: only ANTHROPIC_API_KEY set → should echo "anthropic"
+# ---------------------------------------------------------------------------
+echo "P2: only ANTHROPIC_API_KEY set → anthropic"
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+export ANTHROPIC_API_KEY="sk-ant-test-key"
+out=$(detect_planner_provider)
+assert_eq "P2 echoes anthropic" "anthropic" "$out"
+restore_env
+
+# ---------------------------------------------------------------------------
+# P3: both OPENAI and ANTHROPIC set → OpenAI wins (priority)
+# ---------------------------------------------------------------------------
+echo "P3: both OPENAI_API_KEY and ANTHROPIC_API_KEY set → openai wins"
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+export OPENAI_API_KEY="sk-test-openai-priority"
+export ANTHROPIC_API_KEY="sk-ant-test-priority"
+out=$(detect_planner_provider)
+assert_eq "P3 openai wins priority" "openai" "$out"
+restore_env
+
+# ---------------------------------------------------------------------------
+# P4: no keys, OLLAMA_HOST points at black-hole IP/port → curl fails → ""
+# Using 127.0.0.1:1 (port 1 is always closed; connection refused fires
+# immediately, so --max-time 2 still returns promptly).
+# ---------------------------------------------------------------------------
+echo "P4: no keys, OLLAMA_HOST=http://127.0.0.1:1 → curl fails → empty"
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+export OLLAMA_HOST="http://127.0.0.1:1"
+out=$(detect_planner_provider)
+assert_eq "P4 echoes empty on curl failure" "" "$out"
+restore_env
+
+# ---------------------------------------------------------------------------
+# P5: OLLAMA_HOST=http://127.0.0.1:1, explicit --max-time 2 guard
+# Same as P4 but documents the --max-time timeout scenario explicitly.
+# Port 1 is guaranteed closed so connection is refused immediately (not
+# after 2 seconds), exercising the "curl returns non-zero" code path that
+# the --max-time guard is designed to handle.
+# ---------------------------------------------------------------------------
+echo "P5: OLLAMA_HOST unreachable (port 1) → --max-time 2 guard fires → empty"
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+export OLLAMA_HOST="http://127.0.0.1:1"
+out=$(detect_planner_provider)
+assert_eq "P5 echoes empty on timeout/refusal" "" "$out"
+restore_env
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+exit $(( fail > 0 ? 1 : 0 ))

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -36,15 +36,20 @@ assert_skip() {  # assert_skip <label> <reason>
     skip=$((skip + 1))
 }
 
-# Save caller's env so we can restore it between scenarios.
+# Save caller's env so we can restore it between scenarios. OLLAMA_MODEL is
+# saved too: detect_planner_provider's model check (_ollama_has_model) reads it,
+# so a developer with OLLAMA_MODEL exported would otherwise make P6 (which
+# serves llama3.2:latest) non-deterministic.
 _SAVED_OPENAI="${OPENAI_API_KEY:-}"
 _SAVED_ANTHROPIC="${ANTHROPIC_API_KEY:-}"
 _SAVED_OLLAMA="${OLLAMA_HOST:-}"
+_SAVED_OLLAMA_MODEL="${OLLAMA_MODEL:-}"
 
 restore_env() {
     if [ -n "$_SAVED_OPENAI" ];    then export OPENAI_API_KEY="$_SAVED_OPENAI";    else unset OPENAI_API_KEY;    fi
     if [ -n "$_SAVED_ANTHROPIC" ]; then export ANTHROPIC_API_KEY="$_SAVED_ANTHROPIC"; else unset ANTHROPIC_API_KEY; fi
     if [ -n "$_SAVED_OLLAMA" ];    then export OLLAMA_HOST="$_SAVED_OLLAMA";        else unset OLLAMA_HOST;        fi
+    if [ -n "$_SAVED_OLLAMA_MODEL" ]; then export OLLAMA_MODEL="$_SAVED_OLLAMA_MODEL"; else unset OLLAMA_MODEL; fi
 }
 
 # _start_tags_server <body_json> — starts a background HTTP server on an
@@ -156,7 +161,7 @@ restore_env
 # expansion happened correctly" from "ollama is up and responded".
 # ---------------------------------------------------------------------------
 echo "P5: OLLAMA_HOST unset → falls back to default localhost:11434 → empty (no local ollama with the model)"
-unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST OLLAMA_MODEL
 if _ollama_has_model 2>/dev/null; then
     assert_skip "P5 OLLAMA_HOST default fallback" \
         "local ollama on localhost:11434 has the model; default-fallback path produces 'ollama' instead of empty"
@@ -190,7 +195,7 @@ restore_env
 #     Exercises the reachable-AND-model-present path of _ollama_has_model.
 # ---------------------------------------------------------------------------
 echo "P6: /api/tags lists llama3.2:latest → echoes ollama"
-unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST OLLAMA_MODEL
 _start_tags_server '{"models":[{"name":"llama3.2:latest"}]}'
 export OLLAMA_HOST="http://127.0.0.1:${_TAGS_PORT}"
 out=$(detect_planner_provider)
@@ -204,7 +209,7 @@ restore_env
 #     running ollama without the model pulled must NOT be reported usable.
 # ---------------------------------------------------------------------------
 echo "P7: /api/tags omits the model → echoes empty (reachable but model absent)"
-unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST OLLAMA_MODEL
 _start_tags_server '{"models":[{"name":"some-other-model:latest"}]}'
 export OLLAMA_HOST="http://127.0.0.1:${_TAGS_PORT}"
 out=$(detect_planner_provider)

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -98,6 +98,49 @@ assert_eq "P5 echoes empty on timeout/refusal" "" "$out"
 restore_env
 
 # ---------------------------------------------------------------------------
+# P6: one-shot HTTP server on a free local port → detect_planner_provider
+#     should succeed on the ollama curl probe and echo "ollama".
+#
+# Strategy: use python3 to bind to port 0 (OS assigns a free port), record
+# the assigned port, then start a minimal HTTP server that returns 200 OK on
+# GET /api/tags. A trap kills the server PID on exit.
+# ---------------------------------------------------------------------------
+echo "P6: local HTTP server returns 200 on /api/tags → echoes ollama"
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+
+# Find a free port by binding to :0 and reading back getsockname.
+FREE_PORT=$(python3 -c "
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+")
+
+# Start a one-request HTTP server in the background that serves 200 on any path.
+python3 -c "
+import http.server, sys
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'{}')
+    def log_message(self, *a): pass
+srv = http.server.HTTPServer(('127.0.0.1', int(sys.argv[1])), H)
+srv.handle_request()
+" "$FREE_PORT" &
+_P6_SERVER_PID=$!
+trap 'kill "$_P6_SERVER_PID" 2>/dev/null; wait "$_P6_SERVER_PID" 2>/dev/null' EXIT
+
+# Give the server a moment to start.
+sleep 0.1
+
+export OLLAMA_HOST="http://127.0.0.1:${FREE_PORT}"
+out=$(detect_planner_provider)
+assert_eq "P6 echoes ollama when server reachable" "ollama" "$out"
+restore_env
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -107,11 +107,14 @@ fi
 restore_env
 
 # ---------------------------------------------------------------------------
-# PE: empty-but-set OPENAI_API_KEY treated as not set (regression guard)
-# The helper uses [ -n "${OPENAI_API_KEY:-}" ] which treats both unset and
-# empty as "not set". This test guards against regressions where someone
-# changes to [ -n "${OPENAI_API_KEY-}" ] (no colon), which would silently
-# match empty-but-set.
+# PE: empty-but-set OPENAI_API_KEY / ANTHROPIC_API_KEY treated as no-credential.
+# The helper uses [ -n "${VAR:-}" ] (emptiness check) so empty strings are
+# rejected. This test guards against a future regression where the helper is
+# switched to a set-presence check ([ -v VAR ] or [ -n "${VAR+set}" ]) which
+# would incorrectly accept an exported-but-empty key as a valid credential.
+# Note: this scenario does NOT distinguish `${VAR:-}` from `${VAR-}`, since
+# both expand to "" when VAR is empty-but-set — the regression guard is
+# specifically against set-presence semantics, not against dropping the colon.
 # ---------------------------------------------------------------------------
 echo "PE: empty-but-set OPENAI_API_KEY treated as not set → empty"
 unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -129,46 +129,48 @@ restore_env
 # P6: one-shot HTTP server on a free local port → detect_planner_provider
 #     should succeed on the ollama curl probe and echo "ollama".
 #
-# Strategy: use python3 to bind to port 0 (OS assigns a free port), record
-# the assigned port, then start a minimal HTTP server that returns 200 OK on
-# GET /api/tags. A trap kills the server PID on exit.
+# Strategy: start a minimal HTTP server bound to port 0 (OS-assigned); the
+# server itself publishes its bound port to a tmpfile. Binding and port
+# publication happen in the SAME process, so there is no TOCTOU window
+# where another process could steal the port between discovery and bind.
 # ---------------------------------------------------------------------------
 echo "P6: local HTTP server returns 200 on /api/tags → echoes ollama"
 unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
 
-# Find a free port by binding to :0 and reading back getsockname.
-FREE_PORT=$(python3 -c "
-import socket
-s = socket.socket()
-s.bind(('127.0.0.1', 0))
-print(s.getsockname()[1])
-s.close()
-")
+_P6_PORT_FILE="$(mktemp)"
 
 # Start a persistent HTTP server in the background that serves 200 on any path.
+# The server binds to port 0, writes its actual port to "$1", then serves.
 # Uses serve_forever() (not handle_request()) so the /dev/tcp readiness probe
 # and the curl from detect_planner_provider can both be served without racing.
 # The process is explicitly killed after the assertion.
 python3 -c "
-import http.server, sys
+import http.server, pathlib, sys
 class H(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
         self.end_headers()
         self.wfile.write(b'{}')
     def log_message(self, *a): pass
-srv = http.server.HTTPServer(('127.0.0.1', int(sys.argv[1])), H)
+srv = http.server.HTTPServer(('127.0.0.1', 0), H)
+pathlib.Path(sys.argv[1]).write_text(str(srv.server_port))
 srv.serve_forever()
-" "$FREE_PORT" &
+" "$_P6_PORT_FILE" &
 _P6_SERVER_PID=$!
 
-# Wait for the server to bind (max ~500ms); avoids the timing-fragile sleep 0.1.
+# Wait for the server to publish its port (max ~500ms).
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -s "$_P6_PORT_FILE" ] && break
+    sleep 0.05
+done
+FREE_PORT="$(cat "$_P6_PORT_FILE")"
+
+# Wait for the server to accept connections (max ~500ms).
 # Subshell + outer 2>/dev/null is the only form that reliably suppresses bash's
 # "connect: Connection refused" diagnostic on failed /dev/tcp attempts — the
 # exec-line `2>/dev/null` form leaks the message on some bash builds.
-OLLAMA_PORT="$FREE_PORT"
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-    if (exec 3<>"/dev/tcp/127.0.0.1/${OLLAMA_PORT}") 2>/dev/null; then
+    if (exec 3<>"/dev/tcp/127.0.0.1/${FREE_PORT}") 2>/dev/null; then
         break
     fi
     sleep 0.05
@@ -181,6 +183,7 @@ assert_eq "P6 echoes ollama when server reachable" "ollama" "$out"
 # Explicit cleanup — do NOT use trap here to avoid clobbering any outer trap chain.
 kill "$_P6_SERVER_PID" 2>/dev/null
 wait "$_P6_SERVER_PID" 2>/dev/null || true
+rm -f "$_P6_PORT_FILE"
 restore_env
 
 # ---------------------------------------------------------------------------

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -2,14 +2,15 @@
 # Unit test for detect_planner_provider. Sources llm-helpers.sh directly.
 # Run with: ./test/test_detect_planner_provider.sh
 #
-# Covers seven checks for detect_planner_provider behavior:
+# Covers eight checks for detect_planner_provider behavior:
 #   P1: only OPENAI_API_KEY set                                  → echoes "openai"
 #   P2: only ANTHROPIC_API_KEY set                               → echoes "anthropic"
 #   P3: both OPENAI + ANTHROPIC set                              → echoes "openai" (priority)
 #   P4: no keys, OLLAMA_HOST=http://127.0.0.1:1                  → echoes ""
-#   P5: OLLAMA_HOST unset (default localhost:11434)              → echoes "" (or SKIP if local ollama is running)
+#   P5: OLLAMA_HOST unset (default localhost:11434)              → echoes "" (or SKIP if local ollama has the model)
 #   PE: empty-but-set OPENAI/ANTHROPIC keys + unreachable ollama → echoes ""
-#   P6: one-shot HTTP server on free local port                  → echoes "ollama" (reachable)
+#   P6: HTTP server whose /api/tags lists the model              → echoes "ollama" (reachable AND model present)
+#   P7: HTTP server whose /api/tags omits the model              → echoes "" (reachable but model NOT pulled)
 set -u  # NOT -e: we want to catch failed assertions and keep going.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -44,6 +45,64 @@ restore_env() {
     if [ -n "$_SAVED_OPENAI" ];    then export OPENAI_API_KEY="$_SAVED_OPENAI";    else unset OPENAI_API_KEY;    fi
     if [ -n "$_SAVED_ANTHROPIC" ]; then export ANTHROPIC_API_KEY="$_SAVED_ANTHROPIC"; else unset ANTHROPIC_API_KEY; fi
     if [ -n "$_SAVED_OLLAMA" ];    then export OLLAMA_HOST="$_SAVED_OLLAMA";        else unset OLLAMA_HOST;        fi
+}
+
+# _start_tags_server <body_json> — starts a background HTTP server on an
+# OS-assigned free port that returns <body_json> for every GET (so /api/tags
+# is served), waits until it accepts connections, and sets two globals:
+#   _TAGS_PORT       — the bound port
+#   _TAGS_SERVER_PID — the server PID (for _stop_tags_server)
+# Binding and port publication happen in the SAME process (port written to a
+# tmpfile), so there is no TOCTOU window. The server's own stdout/stderr are
+# sent to /dev/null so callers can run this without a command-substitution
+# pipe staying open. Call this from the MAIN shell (not in $(...)) so the
+# globals propagate.
+_TAGS_SERVER_PID=""
+_TAGS_PORT=""
+_start_tags_server() {
+    local body="$1"
+    local port_file; port_file="$(mktemp)"
+    _TAGS_BODY="$body" python3 -c "
+import http.server, pathlib, sys, os
+payload = os.environ['_TAGS_BODY'].encode()
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(payload)
+    def log_message(self, *a): pass
+srv = http.server.HTTPServer(('127.0.0.1', 0), H)
+pathlib.Path(sys.argv[1]).write_text(str(srv.server_port))
+srv.serve_forever()
+" "$port_file" >/dev/null 2>&1 &
+    _TAGS_SERVER_PID=$!
+
+    # Wait for the server to publish its port (max ~500ms).
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        [ -s "$port_file" ] && break
+        sleep 0.05
+    done
+    _TAGS_PORT="$(cat "$port_file")"
+    rm -f "$port_file"
+
+    # Wait for the server to accept connections (max ~500ms). Subshell + outer
+    # 2>/dev/null reliably suppresses bash's "connect: Connection refused"
+    # diagnostic on failed /dev/tcp attempts.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if (exec 3<>"/dev/tcp/127.0.0.1/${_TAGS_PORT}") 2>/dev/null; then
+            break
+        fi
+        sleep 0.05
+    done
+}
+
+# _stop_tags_server — kill the server started by _start_tags_server. No trap,
+# to avoid clobbering any outer trap chain.
+_stop_tags_server() {
+    [ -n "$_TAGS_SERVER_PID" ] || return 0
+    kill "$_TAGS_SERVER_PID" 2>/dev/null
+    wait "$_TAGS_SERVER_PID" 2>/dev/null || true
+    _TAGS_SERVER_PID=""
 }
 
 # ---------------------------------------------------------------------------
@@ -96,11 +155,11 @@ restore_env
 # developer machines), SKIP — the assertion can't distinguish "default
 # expansion happened correctly" from "ollama is up and responded".
 # ---------------------------------------------------------------------------
-echo "P5: OLLAMA_HOST unset → falls back to default localhost:11434 → empty (no local ollama)"
+echo "P5: OLLAMA_HOST unset → falls back to default localhost:11434 → empty (no local ollama with the model)"
 unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
-if curl -sf -o /dev/null --max-time 2 http://localhost:11434/api/tags 2>/dev/null; then
+if _ollama_has_model 2>/dev/null; then
     assert_skip "P5 OLLAMA_HOST default fallback" \
-        "local ollama detected on localhost:11434; default-fallback path produces 'ollama' instead of empty"
+        "local ollama on localhost:11434 has the model; default-fallback path produces 'ollama' instead of empty"
 else
     out=$(detect_planner_provider 2>/dev/null || true)
     assert_eq "P5 OLLAMA_HOST default fallback" "" "$out"
@@ -127,64 +186,30 @@ assert_eq "PE empty-but-set OPENAI_API_KEY falls through" "" "$out"
 restore_env
 
 # ---------------------------------------------------------------------------
-# P6: one-shot HTTP server on a free local port → detect_planner_provider
-#     should succeed on the ollama curl probe and echo "ollama".
-#
-# Strategy: start a minimal HTTP server bound to port 0 (OS-assigned); the
-# server itself publishes its bound port to a tmpfile. Binding and port
-# publication happen in the SAME process, so there is no TOCTOU window
-# where another process could steal the port between discovery and bind.
+# P6: HTTP server whose /api/tags lists the wanted model → echoes "ollama".
+#     Exercises the reachable-AND-model-present path of _ollama_has_model.
 # ---------------------------------------------------------------------------
-echo "P6: local HTTP server returns 200 on /api/tags → echoes ollama"
+echo "P6: /api/tags lists llama3.2:latest → echoes ollama"
 unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
-
-_P6_PORT_FILE="$(mktemp)"
-
-# Start a persistent HTTP server in the background that serves 200 on any path.
-# The server binds to port 0, writes its actual port to "$1", then serves.
-# Uses serve_forever() (not handle_request()) so the /dev/tcp readiness probe
-# and the curl from detect_planner_provider can both be served without racing.
-# The process is explicitly killed after the assertion.
-python3 -c "
-import http.server, pathlib, sys
-class H(http.server.BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200)
-        self.end_headers()
-        self.wfile.write(b'{}')
-    def log_message(self, *a): pass
-srv = http.server.HTTPServer(('127.0.0.1', 0), H)
-pathlib.Path(sys.argv[1]).write_text(str(srv.server_port))
-srv.serve_forever()
-" "$_P6_PORT_FILE" &
-_P6_SERVER_PID=$!
-
-# Wait for the server to publish its port (max ~500ms).
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-    [ -s "$_P6_PORT_FILE" ] && break
-    sleep 0.05
-done
-FREE_PORT="$(cat "$_P6_PORT_FILE")"
-
-# Wait for the server to accept connections (max ~500ms).
-# Subshell + outer 2>/dev/null is the only form that reliably suppresses bash's
-# "connect: Connection refused" diagnostic on failed /dev/tcp attempts — the
-# exec-line `2>/dev/null` form leaks the message on some bash builds.
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-    if (exec 3<>"/dev/tcp/127.0.0.1/${FREE_PORT}") 2>/dev/null; then
-        break
-    fi
-    sleep 0.05
-done
-
-export OLLAMA_HOST="http://127.0.0.1:${FREE_PORT}"
+_start_tags_server '{"models":[{"name":"llama3.2:latest"}]}'
+export OLLAMA_HOST="http://127.0.0.1:${_TAGS_PORT}"
 out=$(detect_planner_provider)
-assert_eq "P6 echoes ollama when server reachable" "ollama" "$out"
+assert_eq "P6 echoes ollama when model present" "ollama" "$out"
+_stop_tags_server
+restore_env
 
-# Explicit cleanup — do NOT use trap here to avoid clobbering any outer trap chain.
-kill "$_P6_SERVER_PID" 2>/dev/null
-wait "$_P6_SERVER_PID" 2>/dev/null || true
-rm -f "$_P6_PORT_FILE"
+# ---------------------------------------------------------------------------
+# P7: HTTP server whose /api/tags omits the wanted model → echoes "".
+#     This is the regression guard for the reachability-vs-usability fix: a
+#     running ollama without the model pulled must NOT be reported usable.
+# ---------------------------------------------------------------------------
+echo "P7: /api/tags omits the model → echoes empty (reachable but model absent)"
+unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
+_start_tags_server '{"models":[{"name":"some-other-model:latest"}]}'
+export OLLAMA_HOST="http://127.0.0.1:${_TAGS_PORT}"
+out=$(detect_planner_provider)
+assert_eq "P7 echoes empty when model absent" "" "$out"
+_stop_tags_server
 restore_env
 
 # ---------------------------------------------------------------------------

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -2,13 +2,14 @@
 # Unit test for detect_planner_provider. Sources llm-helpers.sh directly.
 # Run with: ./test/test_detect_planner_provider.sh
 #
-# Covers six scenarios for the four branches of detect_planner_provider:
-#   P1: only OPENAI_API_KEY set             → echoes "openai"
-#   P2: only ANTHROPIC_API_KEY set          → echoes "anthropic"
-#   P3: both OPENAI + ANTHROPIC set         → echoes "openai" (priority)
-#   P4: no keys, OLLAMA_HOST unreachable    → echoes "" (curl timeout path)
-#   P5: OLLAMA_HOST=http://127.0.0.1:1     → --max-time 2 fires → echoes ""
-#   P6: one-shot HTTP server on free port   → echoes "ollama" (reachable)
+# Covers seven checks for detect_planner_provider behavior:
+#   P1: only OPENAI_API_KEY set                                  → echoes "openai"
+#   P2: only ANTHROPIC_API_KEY set                               → echoes "anthropic"
+#   P3: both OPENAI + ANTHROPIC set                              → echoes "openai" (priority)
+#   P4: no keys, OLLAMA_HOST=http://127.0.0.1:1                  → echoes ""
+#   P5: OLLAMA_HOST unset (default localhost:11434)              → echoes "" (or SKIP if local ollama is running)
+#   PE: empty-but-set OPENAI/ANTHROPIC keys + unreachable ollama → echoes ""
+#   P6: one-shot HTTP server on free local port                  → echoes "ollama" (reachable)
 set -u  # NOT -e: we want to catch failed assertions and keep going.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"

--- a/test/test_detect_planner_provider.sh
+++ b/test/test_detect_planner_provider.sh
@@ -115,8 +115,10 @@ restore_env
 # ---------------------------------------------------------------------------
 echo "PE: empty-but-set OPENAI_API_KEY treated as not set → empty"
 unset OPENAI_API_KEY ANTHROPIC_API_KEY OLLAMA_HOST
-OPENAI_API_KEY="" ANTHROPIC_API_KEY="" OLLAMA_HOST="http://127.0.0.1:1" \
-    out=$(detect_planner_provider 2>/dev/null || true)
+export OPENAI_API_KEY=""
+export ANTHROPIC_API_KEY=""
+export OLLAMA_HOST="http://127.0.0.1:1"
+out=$(detect_planner_provider 2>/dev/null || true)
 assert_eq "PE empty-but-set OPENAI_API_KEY falls through" "" "$out"
 restore_env
 

--- a/test/test_targets_contains.sh
+++ b/test/test_targets_contains.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Unit test for targets_contains. Sources the helper directly; no framework.
+# Run with: ./test/test_targets_contains.sh
+#
+# targets_contains does an EXACT comma-delimited membership test on $TARGETS.
+# The whole point is that "crapi" must NOT match "crapi-planner" (the substring
+# bug the helper replaced), and vice-versa. Covers:
+#   T1: member in the middle                 → match
+#   T2: member at the start                  → match
+#   T3: member at the end                    → match
+#   T4: single-element list                  → match
+#   T5: "crapi" must NOT match "crapi-planner" substring → no match
+#   T6: "crapi-planner" present              → match (exact)
+#   T7: absent member                        → no match
+#   T8: empty/unset TARGETS                   → no match
+set -u  # NOT -e: we want to catch failed assertions and keep going.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=target-helpers.sh
+. "${SCRIPT_DIR}/target-helpers.sh"
+
+pass=0; fail=0
+
+# assert_match <label> <targets_csv> <name>   — expects targets_contains to return 0
+assert_match() {
+    TARGETS="$2"
+    if targets_contains "$3"; then
+        echo "  PASS: $1"; pass=$((pass + 1))
+    else
+        echo "  FAIL: $1 — expected match for '$3' in TARGETS='$2'"; fail=$((fail + 1))
+    fi
+}
+
+# assert_no_match <label> <targets_csv> <name> — expects targets_contains to return non-zero
+assert_no_match() {
+    TARGETS="$2"
+    if targets_contains "$3"; then
+        echo "  FAIL: $1 — expected NO match for '$3' in TARGETS='$2'"; fail=$((fail + 1))
+    else
+        echo "  PASS: $1"; pass=$((pass + 1))
+    fi
+}
+
+echo "T1: member in the middle"
+assert_match    "T1 dvga in vulnerable-api,dvga,grpc" "vulnerable-api,dvga,grpc" "dvga"
+echo "T2: member at the start"
+assert_match    "T2 vulnerable-api at start" "vulnerable-api,dvga,grpc" "vulnerable-api"
+echo "T3: member at the end"
+assert_match    "T3 grpc at end" "vulnerable-api,dvga,grpc" "grpc"
+echo "T4: single-element list"
+assert_match    "T4 single crapi" "crapi" "crapi"
+echo "T5: crapi must NOT match crapi-planner substring"
+assert_no_match "T5 crapi does not match crapi-planner-only list" "crapi-planner" "crapi"
+echo "T6: crapi-planner present → exact match"
+assert_match    "T6 crapi-planner exact" "crapi,crapi-planner" "crapi-planner"
+echo "T7: absent member"
+assert_no_match "T7 grpc absent" "vulnerable-api,dvga" "grpc"
+echo "T8: empty/unset TARGETS"
+assert_no_match "T8 empty TARGETS" "" "crapi"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+exit $(( fail > 0 ? 1 : 0 ))

--- a/test/test_targets_contains.sh
+++ b/test/test_targets_contains.sh
@@ -23,6 +23,7 @@ pass=0; fail=0
 
 # assert_match <label> <targets_csv> <name>   — expects targets_contains to return 0
 assert_match() {
+    # shellcheck disable=SC2034  # read by targets_contains (sourced) via the global $TARGETS
     TARGETS="$2"
     if targets_contains "$3"; then
         echo "  PASS: $1"; pass=$((pass + 1))
@@ -33,6 +34,7 @@ assert_match() {
 
 # assert_no_match <label> <targets_csv> <name> — expects targets_contains to return non-zero
 assert_no_match() {
+    # shellcheck disable=SC2034  # read by targets_contains (sourced) via the global $TARGETS
     TARGETS="$2"
     if targets_contains "$3"; then
         echo "  FAIL: $1 — expected NO match for '$3' in TARGETS='$2'"; fail=$((fail + 1))


### PR DESCRIPTION
## Summary

Fixes the three remaining items from [LAB-2303](https://linear.app/praetorianlabs/issue/LAB-2303/integrate-testtest-llm-plannersh-with-live-test-harness-and-fix) (P2/P3/P4 were already addressed by [LAB-2247](https://linear.app/praetorianlabs/issue/LAB-2247/bugs-in-hadriantestsetup-live-targetssh) / PR #102):

- **P6** — `test-llm-planner.sh` and `run-live-tests.sh` no longer write inline bearer tokens into auth YAML. Both scripts now emit `${CRAPI_*_TOKEN}` env-var refs via single-quoted heredocs (`<<'EOF'`) and `export` the matching variables before invoking hadrian. Eliminates 4 × `[WARN] SECURITY: Role 'X' has hardcoded token. Use environment variables: ${TOKEN_VAR}` warnings per run — the scripts now model the pattern the product recommends.
- **P5** — The ~30-line spec-resolve-or-repatch block duplicated in `run-live-tests.sh` and `test-llm-planner.sh` is extracted into a new `crapi_resolve_spec` helper in `test/crapi/crapi-helpers.sh`. The substring-guard regex `localhost:${port}([^0-9]|$)` now lives in exactly one place.
- **P1** — `crapi-planner` is integrated as an opt-in target in `run-live-tests.sh`. Pass `--targets crapi-planner` (or `--targets crapi,crapi-planner`) to exercise the planner against crAPI as part of the standard suite. Provider auto-selected from environment (`OPENAI_API_KEY` → openai, else `ANTHROPIC_API_KEY` → anthropic, else local ollama probe, else clean SKIP).

Default `--targets` value is **unchanged** (`vulnerable-api,dvga,grpc,crapi`); the planner is opt-in so CI without LLM credentials doesn't ship a noisy SKIP row.

## Scope expansion: `pkg/auth/auth.go` env-var detection fix

Operator pre-merge testing surfaced that the YAML-producer fix above (P6) was not sufficient on its own — `hadrian` still printed 4 × `SECURITY: Role 'X' has hardcoded token` warnings on the canonical crAPI auth file, violating LAB-2303 AC1 (zero SECURITY warnings).

Root cause was in `pkg/auth/auth.go`: `expandEnvSafe` resolved every `${VAR}` ref in-place **before** `detectHardcodedSecret` ran, so values that resolved to JWT-shaped strings were being flagged as hardcoded even though the YAML clearly used the env-var pattern. The `${VAR}`-prefix short-circuit inside `detectHardcodedSecret` was never reached.

The fix captures pre-expansion originals for all four credential fields (`Token`, `APIKey`, `Cookie`, `Credentials`) and feeds those into `detectHardcodedSecret`. Cookie-CRLF validation continues to run on the post-expansion value (defense against env-var-controlled CRLF injection). A table-driven regression test covers all four fields × `${VAR}` / inline-literal branches.

## Commits

| SHA | What |
|-----|------|
| 317a249 | fix(test): emit auth YAML with env-var tokens instead of inline secrets |
| cf0dce5 | refactor(test): extract `crapi_resolve_spec` helper to dedupe spec resolution |
| 47db530 | feat(test): add `crapi-planner` target to `run-live-tests.sh` |
| 05bd02b | docs(test): clarify `detect_planner_provider` comment and crapi substring coupling |
| 85af42a | test(crapi): add unit test for `crapi_resolve_spec` |
| 6f108f8 | fix(auth): run hardcoded-secret check on pre-expansion values |
| 54479fd | fix(test): address PR #107 review findings |

## Test plan

- [x] `bash -n` on all changed scripts
- [x] `shellcheck` introduces zero new warnings
- [x] `go test -race ./pkg/auth/...` — passes, including 8 subtests of `TestLoad_HardcodedSecretWarning` covering token/api_key/cookie/credentials × env-var/inline branches
- [x] `test/crapi/test_crapi_resolve_spec.sh` — 11/11 assertions pass
- [x] `test/test_detect_planner_provider.sh` — 7/7 assertions pass (after fixing a vacuous PE assertion)
- [x] Default `TARGETS` unchanged
- [ ] **Operator pre-merge live smoke** (Docker + crAPI + LLM creds) — see the runbook in the `.capability-development/live-smoke.md` (untracked, in worktree) for exact steps. Validates AC1 (no SECURITY warnings on real run), AC2 (planner row in summary), AC3 (clean SKIP with no creds), AC6 (literal `${VAR}` in generated YAML), AC7 (crapi finding count unchanged within noise)

## Out of scope

- `test/test-llm-triage.sh` — sibling LLM script with the same anti-pattern; explicitly excluded from this ticket. Worth a follow-up.
- LAB-2247 work (already merged in #102).

Refs [LAB-2303](https://linear.app/praetorianlabs/issue/LAB-2303/integrate-testtest-llm-plannersh-with-live-test-harness-and-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
