### PR TITLE
feat(reporter): add SARIF v2.1.0 output format (LAB-2747)

### DIFF
--- a/.github/workflows/example-sarif-upload.yml
+++ b/.github/workflows/example-sarif-upload.yml
@@ -6,6 +6,14 @@
 # `partialFingerprints` keep alerts stable across runs so re-running the scan
 # does not produce duplicates.
 #
+# IMPORTANT — templates are NOT embedded in the binary. `go install` ships only
+# the `hadrian` executable; the YAML templates that drive every test live in the
+# Hadrian repo under templates/{rest,graphql,grpc}/. This workflow therefore
+# checks out the Hadrian repo and points `--template-dir` at it. Pin both the
+# install version and the checkout ref to the SAME release so the templates
+# match the binary (drift between the two silently changes which tests run).
+# `$HADRIAN_TEMPLATES` is an equivalent alternative to `--template-dir`.
+#
 # Required:
 #   - permissions.security-events: write   (to upload SARIF results)
 #   - github/codeql-action/upload-sarif@v3 (or a newer version)
@@ -47,7 +55,19 @@ jobs:
           go-version: "stable"
 
       - name: Install Hadrian
+        # Pin @VERSION to a Hadrian release tag and use the SAME tag for the
+        # template checkout below so the binary and templates stay in sync.
         run: go install github.com/praetorian-inc/hadrian/cmd/hadrian@latest
+
+      - name: Fetch Hadrian templates
+        # The binary does not embed templates, so check out the Hadrian repo to
+        # get templates/{rest,graphql,grpc}/. Pin `ref` to the release that
+        # matches the version installed above.
+        uses: actions/checkout@v4
+        with:
+          repository: praetorian-inc/hadrian
+          path: .hadrian-src
+          ref: main # pin to a release tag in production, e.g. v1.2.3
 
       - name: Run Hadrian (SARIF output)
         env:
@@ -60,6 +80,7 @@ jobs:
             --api ./openapi.yaml \
             --roles ./hadrian/roles.yaml \
             --auth  ./hadrian/auth.yaml \
+            --template-dir .hadrian-src/templates/rest \
             --output sarif \
             --output-file hadrian-report.sarif
         continue-on-error: true # don't fail the workflow on findings — Code Scanning surfaces them

--- a/.github/workflows/example-sarif-upload.yml
+++ b/.github/workflows/example-sarif-upload.yml
@@ -1,0 +1,76 @@
+# Example workflow: run Hadrian against an API and publish the findings to
+# GitHub Code Scanning via SARIF upload.
+#
+# Copy this file into your own repository under .github/workflows/ and adjust
+# the API spec / target / credentials to match your environment. Hadrian's
+# `partialFingerprints` keep alerts stable across runs so re-running the scan
+# does not produce duplicates.
+#
+# Required:
+#   - permissions.security-events: write   (to upload SARIF results)
+#   - github/codeql-action/upload-sarif@v3 (or a newer version)
+#
+# Re-run cadence: schedule a daily run plus a workflow_dispatch trigger so
+# new findings appear and resolved findings auto-close.
+
+name: Hadrian Security Scan
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily at 06:00 UTC
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "openapi.yaml"
+      - "openapi.json"
+      - "schema.graphql"
+      - "**/*.proto"
+
+permissions:
+  contents: read
+  security-events: write # required to upload SARIF to Code Scanning
+
+jobs:
+  hadrian-rest:
+    name: Hadrian REST scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Install Hadrian
+        run: go install github.com/praetorian-inc/hadrian/cmd/hadrian@latest
+
+      - name: Run Hadrian (SARIF output)
+        env:
+          # Stash test credentials in repository / org secrets. Hadrian's roles
+          # and auth files reference these via templating in your config.
+          HADRIAN_ADMIN_TOKEN: ${{ secrets.HADRIAN_ADMIN_TOKEN }}
+          HADRIAN_USER_TOKEN: ${{ secrets.HADRIAN_USER_TOKEN }}
+        run: |
+          hadrian test rest \
+            --api ./openapi.yaml \
+            --roles ./hadrian/roles.yaml \
+            --auth  ./hadrian/auth.yaml \
+            --output sarif \
+            --output-file hadrian-report.sarif
+        continue-on-error: true # don't fail the workflow on findings — Code Scanning surfaces them
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: hadrian-report.sarif
+          category: hadrian # keeps Hadrian results separate from other scanners
+
+      - name: Upload SARIF as build artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hadrian-sarif
+          path: hadrian-report.sarif

--- a/.github/workflows/example-sarif-upload.yml
+++ b/.github/workflows/example-sarif-upload.yml
@@ -41,7 +41,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          # Match Hadrian's go.mod toolchain. `stable` follows the latest
+          # released Go minor (1.22+), which has consistently been the floor
+          # Hadrian compiles against.
+          go-version: "stable"
 
       - name: Install Hadrian
         run: go install github.com/praetorian-inc/hadrian/cmd/hadrian@latest

--- a/.github/workflows/example-sarif-upload.yml
+++ b/.github/workflows/example-sarif-upload.yml
@@ -42,6 +42,10 @@ jobs:
   hadrian-rest:
     name: Hadrian REST scan
     runs-on: ubuntu-latest
+    env:
+      # Single source of truth: the binary and the templates are both pinned to
+      # this Hadrian release so they never drift. Bump to the release you want.
+      HADRIAN_VERSION: v1.2.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,19 +59,19 @@ jobs:
           go-version: "stable"
 
       - name: Install Hadrian
-        # Pin @VERSION to a Hadrian release tag and use the SAME tag for the
-        # template checkout below so the binary and templates stay in sync.
-        run: go install github.com/praetorian-inc/hadrian/cmd/hadrian@latest
+        run: go install "github.com/praetorian-inc/hadrian/cmd/hadrian@${HADRIAN_VERSION}"
 
       - name: Fetch Hadrian templates
         # The binary does not embed templates, so check out the Hadrian repo to
-        # get templates/{rest,graphql,grpc}/. Pin `ref` to the release that
-        # matches the version installed above.
+        # get templates/{rest,graphql,grpc}/ at the SAME release as the binary.
         uses: actions/checkout@v4
         with:
           repository: praetorian-inc/hadrian
           path: .hadrian-src
-          ref: main # pin to a release tag in production, e.g. v1.2.3
+          ref: ${{ env.HADRIAN_VERSION }}
+          # This is a second repo's checkout; don't leave its credentials on the
+          # runner for later steps.
+          persist-credentials: false
 
       - name: Run Hadrian (SARIF output)
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The CLI (`cmd/hadrian`) delegates to `pkg/runner.Run()` which orchestrates:
    - Execute HTTP test using `templates.Executor`
    - Evaluate `Detection` rules to determine vulnerability
 5. Optionally triage findings with LLM
-6. Generate report (terminal/JSON/markdown)
+6. Generate report (terminal/JSON/markdown/SARIF)
 
 ### Key Packages
 
@@ -55,7 +55,7 @@ The CLI (`cmd/hadrian`) delegates to `pkg/runner.Run()` which orchestrates:
 - **pkg/roles**: Permission model with `<action>:<object>:<scope>` format and role-based filtering
 - **pkg/model**: Data structures for `Finding`, `Operation`, `Evidence`, `Severity`
 - **pkg/matchers**: Response matching (status codes, word/regex patterns)
-- **pkg/reporter**: Output formatters (terminal, JSON, markdown) with finding redaction
+- **pkg/reporter**: Output formatters (terminal, JSON, markdown) with finding redaction. SARIF v2.1.0 output lives at `pkg/runner/sarif.go` (it depends on the templates list, which is only available inside `pkg/runner`).
 - **pkg/llm**: LLM triage integration (Ollama, OpenAI, Anthropic)
 
 ### Template System

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Most API security scanners test for injection and configuration issues but miss 
 | **Mutation Testing** | Three-phase setup → attack → verify pattern proves write/delete vulnerabilities actually occurred |
 | **REST + GraphQL + gRPC** | Test any API protocol with protocol-specific security checks |
 | **Template-Driven** | YAML templates for customizable security tests — no code required |
-| **Multiple Output Formats** | Terminal, JSON, and Markdown reports for CI/CD integration |
+| **Multiple Output Formats** | Terminal, JSON, Markdown, and SARIF v2.1.0 (GitHub Code Scanning) reports |
 | **Adaptive Rate Limiting** | Proactive request throttling with reactive backoff on 429/503 responses |
 | **Proxy Support** | Route traffic through Burp Suite or other intercepting proxies |
 | **LLM-Powered Triage** | Optional AI analysis of findings via Ollama, OpenAI, or Anthropic to reduce false positives |
@@ -99,6 +99,9 @@ hadrian test rest --api api.yaml --roles roles.yaml --dry-run
 
 # Export findings as JSON
 hadrian test rest --api api.yaml --roles roles.yaml --output json --output-file report.json
+
+# Export findings as SARIF for GitHub Code Scanning upload
+hadrian test rest --api api.yaml --roles roles.yaml --output sarif --output-file report.sarif
 
 # AI-powered triage with Ollama (local)
 hadrian test rest --api api.yaml --roles roles.yaml \
@@ -187,7 +190,7 @@ Yes. Hadrian uses YAML templates that define endpoint selectors, role selectors,
 
 ### Does Hadrian integrate with CI/CD pipelines?
 
-Yes. Use `--output json --output-file report.json` to generate machine-readable reports. Hadrian returns a non-zero exit code when vulnerabilities are found, making it suitable for CI/CD gates.
+Yes. Use `--output json --output-file report.json` to generate machine-readable reports, or `--output sarif --output-file report.sarif` to publish findings to GitHub Code Scanning (a complete example workflow lives at [`.github/workflows/example-sarif-upload.yml`](.github/workflows/example-sarif-upload.yml)). Hadrian returns a non-zero exit code when vulnerabilities are found, making it suitable for CI/CD gates.
 
 ## Development
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -443,7 +443,7 @@ The output validates against [sarif-2.1.0.json](https://json.schemastore.org/sar
 - `level` — derived from severity: `CRITICAL`/`HIGH` → `error`, `MEDIUM` → `warning`, `LOW`/`INFO` → `note`
 - `locations[].physicalLocation.artifactLocation.uri` — the API endpoint path
 - `locations[].logicalLocations[].name` — `METHOD PATH` (e.g. `GET /api/users/{id}`)
-- `partialFingerprints["primaryLocationHash/v1"]` — SHA-256 of `templateID|method|endpoint|attackerRole|victimRole`, stable across runs
+- `partialFingerprints["primaryLocationHash/v1"]` — SHA-256 over `templateID`, `method`, `endpoint`, `attackerRole`, and `victimRole` (NUL-joined), stable across runs
 - `properties` — category, attackerRole, victimRole, confidence, LLM analysis
 
 Rules link to the source template via `helpUri`. For built-in templates this resolves to `https://github.com/praetorian-inc/hadrian/blob/main/templates/<protocol>/<file>.yaml`; for custom templates it falls back to the [Template System](https://github.com/praetorian-inc/hadrian/wiki/Template-System) wiki page.
@@ -458,6 +458,8 @@ To upload the report to GitHub Code Scanning, use the canonical upload action:
 ```
 
 A complete example workflow ships in [`.github/workflows/example-sarif-upload.yml`](../.github/workflows/example-sarif-upload.yml).
+
+> **Templates in CI:** the `hadrian` binary does not embed templates — `go install` ships only the executable. In a workflow you must make the templates available (check out the Hadrian repo or vendor them) and point `--template-dir`/`$HADRIAN_TEMPLATES` at `templates/<protocol>/`. Pin the template ref to the same release as the installed binary so they don't drift. The example workflow shows this.
 
 ### Output Flags
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -429,12 +429,42 @@ hadrian test rest --api api.yaml --roles roles.yaml --output json --output-file 
 hadrian test rest --api api.yaml --roles roles.yaml --output markdown --output-file report.md
 ```
 
+### SARIF (GitHub Code Scanning)
+
+[SARIF v2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) is the format GitHub Code Scanning consumes. Hadrian emits one SARIF rule per security template and one result per finding, with stable `partialFingerprints` so re-running the scan doesn't create duplicate alerts.
+
+```bash
+hadrian test rest --api api.yaml --roles roles.yaml --output sarif --output-file report.sarif
+```
+
+The output validates against [sarif-2.1.0.json](https://json.schemastore.org/sarif-2.1.0.json). For each finding Hadrian populates:
+
+- `ruleId` — the template ID that produced the finding (e.g. `01-api1-bola-read`)
+- `level` — derived from severity: `CRITICAL`/`HIGH` → `error`, `MEDIUM` → `warning`, `LOW`/`INFO` → `note`
+- `locations[].physicalLocation.artifactLocation.uri` — the API endpoint path
+- `locations[].logicalLocations[].name` — `METHOD PATH` (e.g. `GET /api/users/{id}`)
+- `partialFingerprints["primaryLocationHash/v1"]` — SHA-256 of `templateID|method|endpoint|attackerRole|victimRole`, stable across runs
+- `properties` — category, attackerRole, victimRole, confidence, LLM analysis
+
+Rules link to the source template via `helpUri`. For built-in templates this resolves to `https://github.com/praetorian-inc/hadrian/blob/main/templates/<protocol>/<file>.yaml`; for custom templates it falls back to the [Template System](https://github.com/praetorian-inc/hadrian/wiki/Template-System) wiki page.
+
+To upload the report to GitHub Code Scanning, use the canonical upload action:
+
+```yaml
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: report.sarif
+    category: hadrian
+```
+
+A complete example workflow ships in [`.github/workflows/example-sarif-upload.yml`](../.github/workflows/example-sarif-upload.yml).
+
 ### Output Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--output <format>` | terminal | Output format: `terminal`, `json`, `markdown` |
-| `--output-file <file>` | - | Write findings to file (stdout if omitted) |
+| `--output <format>` | terminal | Output format: `terminal`, `json`, `markdown`, `sarif` |
+| `--output-file <file>` | - | Write findings to file (stdout if omitted; **required for `sarif`**) |
 | `--request-ids <n>` | 1 | Number of request IDs per finding (0 = all) |
 
 ## Environment Variables

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -38,7 +38,7 @@ Flags:
       --insecure               Skip TLS verification
       --rate-limit float       Rate limit in requests per second (default 5.0)
       --timeout int            Request timeout in seconds (default 30)
-      --output string          Output format: terminal, json, markdown (default "terminal")
+      --output string          Output format: terminal, json, markdown, sarif (default "terminal")
       --output-file string     Output file path
       --verbose                Verbose output
       --dry-run                Show what would be tested without executing
@@ -300,6 +300,16 @@ hadrian test graphql --target http://localhost:5013 --output json --output-file 
 ```bash
 hadrian test graphql --target http://localhost:5013 --output markdown --output-file report.md
 ```
+
+### SARIF (GitHub Code Scanning)
+
+GraphQL findings can be published to GitHub Code Scanning via SARIF v2.1.0:
+
+```bash
+hadrian test graphql --target http://localhost:5013 --output sarif --output-file report.sarif
+```
+
+The output validates against the SARIF v2.1.0 schema and carries stable `partialFingerprints` so re-running the scan does not produce duplicate alerts. See [Configuration → SARIF](configuration.md#sarif-github-code-scanning) for the full schema, helpUri behaviour, and an example GitHub Actions workflow.
 
 ## Proxy Support
 

--- a/docs/grpc.md
+++ b/docs/grpc.md
@@ -741,6 +741,20 @@ hadrian grpc \
   --output-file results.json
 ```
 
+### Output to SARIF (GitHub Code Scanning)
+
+```bash
+hadrian grpc \
+  --server localhost:50051 \
+  --template-dir templates/grpc/ \
+  --auth auth.yaml \
+  --roles roles.yaml \
+  --output sarif \
+  --output-file results.sarif
+```
+
+The output validates against the SARIF v2.1.0 schema and carries stable `partialFingerprints` so re-running the scan does not produce duplicate alerts. See [Configuration → SARIF](configuration.md#sarif-github-code-scanning) for the full schema, helpUri behaviour, and an example GitHub Actions workflow.
+
 ### Dry Run (Show What Would Be Tested)
 
 ```bash

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -16,6 +16,9 @@ hadrian test rest --api api.yaml --roles roles.yaml --dry-run
 
 # Verbose output with JSON report
 hadrian test rest --api api.yaml --roles roles.yaml --verbose --output json --output-file report.json
+
+# SARIF output for GitHub Code Scanning
+hadrian test rest --api api.yaml --roles roles.yaml --output sarif --output-file report.sarif
 ```
 
 ## Command Options

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/bufbuild/protocompile v0.14.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vektah/gqlparser/v2 v2.5.33
 	golang.org/x/time v0.15.0
@@ -31,7 +32,6 @@ require (
 	github.com/oasdiff/yaml3 v0.0.13 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
 	golang.org/x/net v0.51.0 // indirect

--- a/pkg/graphql/security_scanner.go
+++ b/pkg/graphql/security_scanner.go
@@ -96,9 +96,12 @@ func generateID() string {
 }
 
 // newFinding creates a new security finding with common fields pre-populated.
+// The `name` argument is also used as TemplateID (a stable rule identifier such
+// as "introspection-disclosure" or "bola") for SARIF ruleId and cross-run dedup.
 func (s *SecurityScanner) newFinding(category, name, description string, severity model.Severity) *model.Finding {
 	return &model.Finding{
 		ID:              generateID(),
+		TemplateID:      name,
 		Category:        category,
 		Name:            name,
 		Description:     description,

--- a/pkg/graphql/security_scanner_test.go
+++ b/pkg/graphql/security_scanner_test.go
@@ -38,6 +38,11 @@ func TestSecurityScanner_CheckIntrospection(t *testing.T) {
 		// Assert finding exists with correct properties
 		assert.NotNil(t, finding)
 		assert.Equal(t, FindingTypeIntrospectionDisclosure.String(), finding.Name)
+		// TemplateID drives the SARIF ruleId; a regression in newFinding's
+		// `TemplateID: name` assignment would collapse every GraphQL
+		// non-template finding to rule "hadrian.unknown" and break GitHub
+		// Code Scanning dedup.
+		assert.Equal(t, FindingTypeIntrospectionDisclosure.String(), finding.TemplateID)
 		assert.Equal(t, model.SeverityMedium, finding.Severity)
 		assert.Equal(t, CategoryAPI8, finding.Category)
 	})

--- a/pkg/model/finding.go
+++ b/pkg/model/finding.go
@@ -5,7 +5,8 @@ import "time"
 // Finding represents a security issue discovered during testing
 type Finding struct {
 	ID              string   `json:"id"`
-	Category        string   `json:"category"` // API1, API2, etc.
+	TemplateID      string   `json:"template_id,omitempty"` // Stable identifier of the template/check that produced the finding (used for SARIF ruleId and cross-run dedup)
+	Category        string   `json:"category"`              // API1, API2, etc.
 	Name            string   `json:"name"`
 	Description     string   `json:"description"`
 	Severity        Severity `json:"severity"`

--- a/pkg/orchestrator/runner.go
+++ b/pkg/orchestrator/runner.go
@@ -162,6 +162,7 @@ func createFinding(
 ) *model.Finding {
 	return &model.Finding{
 		ID:              generateFindingID(tmpl.ID, operation, attacker.Name),
+		TemplateID:      tmpl.ID,
 		Category:        tmpl.Info.Category,
 		Name:            tmpl.Info.Name,
 		Description:     fmt.Sprintf("Potential %s vulnerability detected", tmpl.Info.Category),

--- a/pkg/orchestrator/runner_test.go
+++ b/pkg/orchestrator/runner_test.go
@@ -332,6 +332,7 @@ func TestCreateFinding(t *testing.T) {
 
 		// Assert
 		assert.NotEmpty(t, finding.ID)
+		assert.Equal(t, "api1-bola-read", finding.TemplateID, "TemplateID is the stable SARIF ruleId — a regression would silently collapse findings to hadrian.unknown")
 		assert.Equal(t, "API1:2023", finding.Category)
 		assert.Equal(t, "BOLA - Cross-User Resource Access", finding.Name)
 		assert.Equal(t, model.SeverityHigh, finding.Severity)

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -35,9 +35,9 @@ func (c *Config) Validate() error {
 	}
 
 	// Validate output format
-	validFormats := map[string]bool{"terminal": true, "json": true, "markdown": true}
+	validFormats := map[string]bool{"terminal": true, "json": true, "markdown": true, "sarif": true}
 	if !validFormats[c.Output] {
-		return fmt.Errorf("invalid output format: %s (valid: terminal, json, markdown)", c.Output)
+		return fmt.Errorf("invalid output format: %s (valid: terminal, json, markdown, sarif)", c.Output)
 	}
 
 	// Validate rate limit configuration

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -40,6 +40,14 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid output format: %s (valid: terminal, json, markdown, sarif)", c.Output)
 	}
 
+	// SARIF is a file-only format (it has no meaningful terminal rendering and
+	// GitHub Code Scanning consumes a file), so it requires --output-file.
+	// Validate the pairing here rather than deferring to reporter construction
+	// so the error surfaces alongside the other format checks.
+	if c.Output == "sarif" && c.OutputFile == "" {
+		return fmt.Errorf("--output sarif requires --output-file")
+	}
+
 	// Validate rate limit configuration
 	if c.RateLimit <= 0 {
 		return fmt.Errorf("rate limit must be > 0")

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -138,6 +138,41 @@ func TestValidate_InvalidOutputFormat(t *testing.T) {
 	}
 }
 
+// TestValidate_OutputFormats walks every value the runner promises to accept.
+// "sarif" was added by LAB-2747; a regression dropping it would surface as a
+// runtime error in user CI pipelines, so it is explicitly exercised here.
+func TestValidate_OutputFormats(t *testing.T) {
+	tmpDir := t.TempDir()
+	apiSpec := filepath.Join(tmpDir, "api.yaml")
+	rolesFile := filepath.Join(tmpDir, "roles.yaml")
+	if err := os.WriteFile(apiSpec, []byte("openapi: 3.0.0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rolesFile, []byte("roles: []"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rate, backoff, maxWait, maxRetries, statusCodes := validRateLimitDefaults()
+
+	for _, format := range []string{"terminal", "json", "markdown", "sarif"} {
+		format := format
+		t.Run(format, func(t *testing.T) {
+			c := &Config{
+				API:                  apiSpec,
+				Roles:                rolesFile,
+				Output:               format,
+				RateLimit:            rate,
+				RateLimitBackoff:     backoff,
+				RateLimitMaxWait:     maxWait,
+				RateLimitMaxRetries:  maxRetries,
+				RateLimitStatusCodes: statusCodes,
+			}
+			if err := c.Validate(); err != nil {
+				t.Errorf("Validate(Output=%q) = %v; want nil", format, err)
+			}
+		})
+	}
+}
+
 func TestToHTTPClientConfig(t *testing.T) {
 	config := &Config{
 		Proxy:    "http://localhost:8080",

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -166,10 +166,45 @@ func TestValidate_OutputFormats(t *testing.T) {
 				RateLimitMaxRetries:  maxRetries,
 				RateLimitStatusCodes: statusCodes,
 			}
+			// sarif is a file-only format and requires --output-file (see
+			// TestValidate_SARIFRequiresOutputFile for the negative case).
+			if format == "sarif" {
+				c.OutputFile = filepath.Join(tmpDir, "report.sarif")
+			}
 			if err := c.Validate(); err != nil {
 				t.Errorf("Validate(Output=%q) = %v; want nil", format, err)
 			}
 		})
+	}
+}
+
+// TestValidate_SARIFRequiresOutputFile asserts the --output sarif / --output-file
+// pairing is enforced at validation time (N3) rather than deferred to reporter
+// construction, so the error surfaces alongside the other format checks.
+func TestValidate_SARIFRequiresOutputFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	apiSpec := filepath.Join(tmpDir, "api.yaml")
+	rolesFile := filepath.Join(tmpDir, "roles.yaml")
+	if err := os.WriteFile(apiSpec, []byte("openapi: 3.0.0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rolesFile, []byte("roles: []"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rate, backoff, maxWait, maxRetries, statusCodes := validRateLimitDefaults()
+
+	c := &Config{
+		API:                  apiSpec,
+		Roles:                rolesFile,
+		Output:               "sarif",
+		RateLimit:            rate,
+		RateLimitBackoff:     backoff,
+		RateLimitMaxWait:     maxWait,
+		RateLimitMaxRetries:  maxRetries,
+		RateLimitStatusCodes: statusCodes,
+	}
+	if err := c.Validate(); err == nil {
+		t.Error("Validate(Output=sarif, OutputFile=\"\") = nil; want error")
 	}
 }
 

--- a/pkg/runner/execution.go
+++ b/pkg/runner/execution.go
@@ -44,6 +44,7 @@ func executeTemplate(
 		if result.Matched {
 			finding := &model.Finding{
 				ID:              fmt.Sprintf("%s-%s-%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-"), "anonymous", "no-victim"),
+				TemplateID:      tmpl.ID,
 				Category:        tmpl.Info.Category,
 				Name:            tmpl.Info.Name,
 				Severity:        model.Severity(tmpl.Info.Severity),
@@ -86,6 +87,7 @@ func executeTemplate(
 			}
 			finding := &model.Finding{
 				ID:              fmt.Sprintf("%s-%s-%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-"), "anonymous", "no-victim"),
+				TemplateID:      tmpl.ID,
 				Category:        tmpl.Info.Category,
 				Name:            tmpl.Info.Name,
 				Severity:        model.Severity(tmpl.Info.Severity),
@@ -172,6 +174,7 @@ func executeTemplate(
 				}
 				finding := &model.Finding{
 					ID:              fmt.Sprintf("%s-%s-%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-"), attackerRole.Name, victimName),
+					TemplateID:      tmpl.ID,
 					Category:        tmpl.Info.Category,
 					Name:            tmpl.Info.Name,
 					Severity:        model.Severity(tmpl.Info.Severity),
@@ -286,6 +289,7 @@ func executeMutationTemplate(
 			if result.Matched {
 				finding := &model.Finding{
 					ID:              fmt.Sprintf("%s-%s-%s-%s-%s", tmpl.ID, op.Method, strings.ReplaceAll(op.Path, "/", "-"), attackerRole.Name, victimRole.Name),
+					TemplateID:      tmpl.ID,
 					Category:        tmpl.Info.Category,
 					Name:            tmpl.Info.Name,
 					Severity:        model.Severity(tmpl.Info.Severity),

--- a/pkg/runner/execution_test.go
+++ b/pkg/runner/execution_test.go
@@ -561,6 +561,61 @@ func TestExecuteTemplate_NoneAttacker_NoVictim(t *testing.T) {
 	require.Len(t, findings, 1, "should produce exactly one finding with no victim role")
 	assert.Equal(t, "anonymous", findings[0].AttackerRole)
 	assert.Empty(t, findings[0].VictimRole)
+	assert.Equal(t, "none-attacker-no-victim", findings[0].TemplateID, "TemplateID must propagate from the 'none' attacker branch — SARIF dedup depends on it")
+}
+
+// TestExecuteTemplate_PropagatesTemplateID drives each finding-construction
+// branch in executeTemplate (unauthenticated, "none" attacker, authenticated
+// cross-role) and asserts Finding.TemplateID is populated. A regression that
+// drops `TemplateID: tmpl.ID` would silently collapse every SARIF result to
+// rule "hadrian.unknown" and break GitHub Code Scanning deduplication.
+func TestExecuteTemplate_PropagatesTemplateID(t *testing.T) {
+	t.Run("unauthenticated endpoint", func(t *testing.T) {
+		server := newTestServer(200, `{"data": "exposed"}`)
+		defer server.Close()
+
+		tmpl := makeCompiledTemplate("tmpl-unauth", false, []string{"GET"}, "lower", "", "simple")
+		op := &model.Operation{Method: "GET", Path: "/api/public"}
+		executor := templates.NewExecutor(server.Client(), nil)
+		mutationExecutor := orchestrator.NewMutationExecutor(server.Client(), nil)
+
+		findings, err := executeTemplate(context.Background(), executor, mutationExecutor, tmpl, op, makeTestRolesConfig(), nil, server.URL)
+		require.NoError(t, err)
+		require.NotEmpty(t, findings, "unauthenticated branch should produce at least one finding")
+		for _, f := range findings {
+			assert.Equal(t, "tmpl-unauth", f.TemplateID)
+		}
+	})
+
+	t.Run("authenticated cross-role", func(t *testing.T) {
+		server := newTestServer(200, `{"data": "vulnerable"}`)
+		defer server.Close()
+
+		tmpl := makeCompiledTemplate("tmpl-auth", true, []string{"GET"}, "lower", "higher", "simple")
+		op := &model.Operation{
+			Method:       "GET",
+			Path:         "/api/users/{id}",
+			RequiresAuth: true,
+			PathParams:   []model.Parameter{{Name: "id", Example: "42"}},
+		}
+		executor := templates.NewExecutor(server.Client(), nil)
+		mutationExecutor := orchestrator.NewMutationExecutor(server.Client(), nil)
+
+		authCfg := &auth.AuthConfig{
+			Method: "bearer",
+			Roles: map[string]*auth.RoleAuth{
+				"user":  {Token: "user-token"},
+				"admin": {Token: "admin-token"},
+			},
+		}
+
+		findings, err := executeTemplate(context.Background(), executor, mutationExecutor, tmpl, op, makeTestRolesConfig(), authCfg, server.URL)
+		require.NoError(t, err)
+		require.NotEmpty(t, findings, "authenticated branch should produce at least one finding")
+		for _, f := range findings {
+			assert.Equal(t, "tmpl-auth", f.TemplateID)
+		}
+	})
 }
 
 // =============================================================================

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -240,15 +240,26 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 
 	// Pre-load + compile templates for SARIF rule enrichment. runTemplateTests
 	// loads templates again on its own; double-loading is cheap and avoids
-	// reshaping the existing call structure.
+	// reshaping the existing call structure. The directory is resolved the same
+	// way runTemplateTests resolves it (via getTemplateDir), so a default-dir
+	// `--output sarif` run still produces enriched SARIF rules.
 	var sarifTemplates []*templates.CompiledTemplate
-	if config.Output == "sarif" && config.TemplateDir != "" {
-		if raw, lerr := loadGraphQLTemplates(config.TemplateDir); lerr == nil {
-			for _, t := range raw {
-				if c, cerr := templates.Compile(t); cerr == nil {
-					sarifTemplates = append(sarifTemplates, c)
-				}
+	if config.Output == "sarif" {
+		sarifDir := config.TemplateDir
+		if sarifDir == "" {
+			sarifDir = getTemplateDir("./templates/graphql")
+		}
+		raw, lerr := loadGraphQLTemplates(sarifDir)
+		if lerr != nil {
+			log.Warn("SARIF: failed to load templates from %s: %v — rules will use wiki fallback metadata", sarifDir, lerr)
+		}
+		for _, t := range raw {
+			c, cerr := templates.Compile(t)
+			if cerr != nil {
+				log.Warn("SARIF: failed to compile template %s: %v", t.ID, cerr)
+				continue
 			}
+			sarifTemplates = append(sarifTemplates, c)
 		}
 	}
 

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -76,6 +76,22 @@ type GraphQLConfig struct {
 	Headers         []string   // Custom HTTP headers (format: "Key: Value")
 }
 
+// Validate checks GraphQL output configuration before test execution, mirroring
+// the REST and gRPC runners: the output format must be supported and SARIF
+// requires --output-file. An empty Output is tolerated (REST's Config.Validate
+// defaults "" → "json" before validating, and the CLI flag defaults to
+// "terminal"), so tolerating "" here keeps the three protocols consistent.
+func (c *GraphQLConfig) Validate() error {
+	validFormats := map[string]bool{"terminal": true, "json": true, "markdown": true, "sarif": true}
+	if c.Output != "" && !validFormats[c.Output] {
+		return fmt.Errorf("invalid output format: %s (valid: terminal, json, markdown, sarif)", c.Output)
+	}
+	if c.Output == "sarif" && c.OutputFile == "" {
+		return fmt.Errorf("--output sarif requires --output-file")
+	}
+	return nil
+}
+
 // newTestGraphQLCmd creates the "test graphql" subcommand
 func newTestGraphQLCmd() *cobra.Command {
 	var config GraphQLConfig
@@ -186,6 +202,12 @@ func loadGraphQLTemplates(dir string) ([]*templates.Template, error) {
 // runGraphQLTest executes GraphQL security tests
 func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 	startTime := time.Now()
+
+	// Surface output/format errors (e.g. --output sarif without --output-file)
+	// here rather than later at reporter construction.
+	if err := config.Validate(); err != nil {
+		return err
+	}
 
 	// Enable verbose logging if requested
 	log.SetVerbose(config.Verbose)

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -238,33 +238,24 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 
 	reportAuthConfigsLoaded(config.Auth, config.Roles, authConfig, rolesConfig, authConfigs, config.Verbose)
 
-	// Pre-load + compile templates for SARIF rule enrichment. runTemplateTests
-	// loads templates again on its own; double-loading is cheap and avoids
-	// reshaping the existing call structure. The directory is resolved the same
-	// way runTemplateTests resolves it (via getTemplateDir), so a default-dir
-	// `--output sarif` run still produces enriched SARIF rules.
-	var sarifTemplates []*templates.CompiledTemplate
-	if config.Output == "sarif" {
-		sarifDir := config.TemplateDir
-		if sarifDir == "" {
-			sarifDir = getTemplateDir("./templates/graphql")
-		}
-		raw, lerr := loadGraphQLTemplates(sarifDir)
-		if lerr != nil {
-			log.Warn("SARIF: failed to load templates from %s: %v — rules will use wiki fallback metadata", sarifDir, lerr)
-		}
-		for _, t := range raw {
-			c, cerr := templates.Compile(t)
-			if cerr != nil {
-				log.Warn("SARIF: failed to compile template %s: %v", t.ID, cerr)
-				continue
-			}
-			sarifTemplates = append(sarifTemplates, c)
-		}
+	// Load + compile GraphQL templates once and feed the same slice to both
+	// the reporter (for SARIF rule enrichment) and the test executor. Avoids
+	// the previous double-load and guarantees the SARIF rules section matches
+	// the templates actually exercised at runtime.
+	gqlTemplateDir := config.TemplateDir
+	if gqlTemplateDir == "" {
+		gqlTemplateDir = getTemplateDir("./templates/graphql")
+	}
+	compiledTemplates, lerr := loadAndCompileGraphQLTemplates(gqlTemplateDir, config.Templates)
+	if lerr != nil {
+		// Treat as non-fatal: the GraphQL command runs scanner-based checks
+		// even when no templates are available. Surface so the operator can
+		// see why the SARIF rules section is empty.
+		log.Warn("GraphQL: failed to load templates from %s: %v", gqlTemplateDir, lerr)
 	}
 
 	// Create reporter based on output format (using REST reporter pattern)
-	reporter, err := createReporter(config.Output, config.OutputFile, config.RequestIDsLimit, sarifTemplates)
+	reporter, err := createReporter(config.Output, config.OutputFile, config.RequestIDsLimit, compiledTemplates)
 	if err != nil {
 		return fmt.Errorf("failed to create reporter: %w", err)
 	}
@@ -272,7 +263,7 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 
 	// Run security checks with rate-limited client
 	endpoint := config.Target + config.Endpoint
-	modelFindings, templatesLoaded := runSecurityChecks(ctx, schema, rateLimitedClient, endpoint, config, authConfigs, reporter, customHeaders)
+	modelFindings, templatesLoaded := runSecurityChecks(ctx, schema, rateLimitedClient, endpoint, config, authConfigs, reporter, customHeaders, compiledTemplates)
 
 	// Compute unified LLM-enabled flag (same logic as REST command)
 	graphqlLLMEnabled := hasLLMConfig() || (config.LLMProvider != "" && config.LLMProvider != "ollama") || config.LLMHost != "" || config.LLMModel != "" || config.LLMTriageClient != nil

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -192,6 +192,7 @@ func loadGraphQLTemplates(dir string) ([]*templates.Template, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse template %s: %w", name, err)
 		}
+		tmpl.FilePath = filePath
 
 		tmplList = append(tmplList, tmpl)
 	}

--- a/pkg/runner/graphql.go
+++ b/pkg/runner/graphql.go
@@ -118,7 +118,7 @@ func newTestGraphQLCmd() *cobra.Command {
 	cmd.Flags().IntVar(&config.Timeout, "timeout", 30, "Request timeout in seconds")
 
 	// Output options
-	cmd.Flags().StringVar(&config.Output, "output", "terminal", "Output format: terminal, json, markdown")
+	cmd.Flags().StringVar(&config.Output, "output", "terminal", "Output format: terminal, json, markdown, sarif")
 	cmd.Flags().StringVar(&config.OutputFile, "output-file", "", "Output file path")
 	cmd.Flags().IntVar(&config.RequestIDsLimit, "request-ids-limit", 1, "Limit request IDs in output (0 = show all)")
 	cmd.Flags().BoolVar(&config.Verbose, "verbose", false, "Verbose output")
@@ -238,8 +238,22 @@ func runGraphQLTest(ctx context.Context, config GraphQLConfig) error {
 
 	reportAuthConfigsLoaded(config.Auth, config.Roles, authConfig, rolesConfig, authConfigs, config.Verbose)
 
+	// Pre-load + compile templates for SARIF rule enrichment. runTemplateTests
+	// loads templates again on its own; double-loading is cheap and avoids
+	// reshaping the existing call structure.
+	var sarifTemplates []*templates.CompiledTemplate
+	if config.Output == "sarif" && config.TemplateDir != "" {
+		if raw, lerr := loadGraphQLTemplates(config.TemplateDir); lerr == nil {
+			for _, t := range raw {
+				if c, cerr := templates.Compile(t); cerr == nil {
+					sarifTemplates = append(sarifTemplates, c)
+				}
+			}
+		}
+	}
+
 	// Create reporter based on output format (using REST reporter pattern)
-	reporter, err := createReporter(config.Output, config.OutputFile, config.RequestIDsLimit)
+	reporter, err := createReporter(config.Output, config.OutputFile, config.RequestIDsLimit, sarifTemplates)
 	if err != nil {
 		return fmt.Errorf("failed to create reporter: %w", err)
 	}

--- a/pkg/runner/graphql_helpers.go
+++ b/pkg/runner/graphql_helpers.go
@@ -190,7 +190,6 @@ func reportFindings(findings []*model.Finding) {
 	}
 }
 
-// runSecurityChecks executes scanner checks and template tests, returning all findings and template count
 // runSecurityChecks runs scanner-based checks plus template-driven tests. When
 // `preloaded` is non-nil, runTemplateTests uses it directly and skips its
 // internal load+filter+compile path. This is how the SARIF reporter and the
@@ -293,7 +292,6 @@ func filterGraphQLTemplatesByID(tmpls []*templates.Template, filters []string) [
 	return filtered
 }
 
-// runTemplateTests executes GraphQL templates and returns findings and template count
 // runTemplateTests executes GraphQL templates and returns findings and template
 // count. When `preloaded` is non-nil it is used as the canonical compiled set;
 // when nil the function falls back to its legacy load+filter+compile path so

--- a/pkg/runner/graphql_helpers.go
+++ b/pkg/runner/graphql_helpers.go
@@ -191,7 +191,11 @@ func reportFindings(findings []*model.Finding) {
 }
 
 // runSecurityChecks executes scanner checks and template tests, returning all findings and template count
-func runSecurityChecks(ctx context.Context, schema *graphql.Schema, httpClient templates.HTTPClient, endpoint string, config GraphQLConfig, authConfigs map[string]*graphql.AuthInfo, reporter Reporter, customHeaders map[string]string) ([]*model.Finding, int) {
+// runSecurityChecks runs scanner-based checks plus template-driven tests. When
+// `preloaded` is non-nil, runTemplateTests uses it directly and skips its
+// internal load+filter+compile path. This is how the SARIF reporter and the
+// runtime test pass share one view of which templates exist.
+func runSecurityChecks(ctx context.Context, schema *graphql.Schema, httpClient templates.HTTPClient, endpoint string, config GraphQLConfig, authConfigs map[string]*graphql.AuthInfo, reporter Reporter, customHeaders map[string]string, preloaded []*templates.CompiledTemplate) ([]*model.Finding, int) {
 	var findings []*model.Finding
 
 	// Run built-in security checks unless skip flag is set
@@ -239,12 +243,36 @@ func runSecurityChecks(ctx context.Context, schema *graphql.Schema, httpClient t
 		}
 	} else {
 		config.TemplateDir = templateDir
-		templateFindings, count := runTemplateTests(ctx, config, endpoint, httpClient, authConfigs, reporter, customHeaders)
+		templateFindings, count := runTemplateTests(ctx, config, endpoint, httpClient, authConfigs, reporter, customHeaders, preloaded)
 		findings = append(findings, templateFindings...)
 		templateCount = count
 	}
 
 	return findings, templateCount
+}
+
+// loadAndCompileGraphQLTemplates loads templates from `dir`, applies the
+// `filters` allowlist (empty = no filtering), and returns the compiled set.
+// Compile failures are logged and skipped — they are author bugs in the
+// template, not callable errors. The function is the single template-load site
+// for the graphql command; both the SARIF rule preload and the runtime
+// execution path consume its output to keep the two views in lockstep.
+func loadAndCompileGraphQLTemplates(dir string, filters []string) ([]*templates.CompiledTemplate, error) {
+	raw, err := loadGraphQLTemplates(dir)
+	if err != nil {
+		return nil, err
+	}
+	raw = filterGraphQLTemplatesByID(raw, filters)
+	out := make([]*templates.CompiledTemplate, 0, len(raw))
+	for _, t := range raw {
+		c, cerr := templates.Compile(t)
+		if cerr != nil {
+			log.Warn("Failed to compile GraphQL template %s: %v", t.ID, cerr)
+			continue
+		}
+		out = append(out, c)
+	}
+	return out, nil
 }
 
 // filterGraphQLTemplatesByID filters GraphQL templates by ID patterns
@@ -266,25 +294,34 @@ func filterGraphQLTemplatesByID(tmpls []*templates.Template, filters []string) [
 }
 
 // runTemplateTests executes GraphQL templates and returns findings and template count
-func runTemplateTests(ctx context.Context, config GraphQLConfig, endpoint string, httpClient templates.HTTPClient, authConfigs map[string]*graphql.AuthInfo, reporter Reporter, customHeaders map[string]string) ([]*model.Finding, int) {
+// runTemplateTests executes GraphQL templates and returns findings and template
+// count. When `preloaded` is non-nil it is used as the canonical compiled set;
+// when nil the function falls back to its legacy load+filter+compile path so
+// existing callers (tests, alternate entry points) keep working unchanged.
+func runTemplateTests(ctx context.Context, config GraphQLConfig, endpoint string, httpClient templates.HTTPClient, authConfigs map[string]*graphql.AuthInfo, reporter Reporter, customHeaders map[string]string, preloaded []*templates.CompiledTemplate) ([]*model.Finding, int) {
 	graphqlVerboseLog(config.Verbose, "\n=== Running GraphQL Templates ===")
 
-	// Load templates
-	tmplFiles, err := loadGraphQLTemplates(config.TemplateDir)
-	if err != nil {
-		fmt.Printf("Error loading templates: %v\n", err)
-		return nil, 0
+	var compiledTmpls []*templates.CompiledTemplate
+	if preloaded != nil {
+		compiledTmpls = preloaded
+		graphqlVerboseLog(config.Verbose, "Using %d preloaded template(s)", len(compiledTmpls))
+	} else {
+		// Legacy path: load + filter + compile internally. Kept so existing
+		// tests and any other caller that doesn't share runGraphQLTest's
+		// preload work unchanged.
+		var lerr error
+		compiledTmpls, lerr = loadAndCompileGraphQLTemplates(config.TemplateDir, config.Templates)
+		if lerr != nil {
+			fmt.Printf("Error loading templates: %v\n", lerr)
+			return nil, 0
+		}
+		graphqlVerboseLog(config.Verbose, "Loaded %d template(s) from: %s", len(compiledTmpls), config.TemplateDir)
+		if len(config.Templates) > 0 {
+			graphqlVerboseLog(config.Verbose, "Filtered by templates: %v", config.Templates)
+		}
 	}
 
-	// Apply filters
-	tmplFiles = filterGraphQLTemplatesByID(tmplFiles, config.Templates)
-
-	templateCount := len(tmplFiles)
-	graphqlVerboseLog(config.Verbose, "Loaded %d template(s) from: %s", templateCount, config.TemplateDir)
-
-	if len(config.Templates) > 0 {
-		graphqlVerboseLog(config.Verbose, "Filtered by templates: %v", config.Templates)
-	}
+	templateCount := len(compiledTmpls)
 
 	// Create template executor
 	tmplExecutor := templates.NewExecutor(httpClient, customHeaders)
@@ -292,14 +329,8 @@ func runTemplateTests(ctx context.Context, config GraphQLConfig, endpoint string
 	var findings []*model.Finding
 
 	// Execute each template
-	for _, tmpl := range tmplFiles {
-		// Compile template
-		compiled, err := templates.Compile(tmpl)
-		if err != nil {
-			// Use log.Warn for consistent warning output
-			log.Warn("Failed to compile GraphQL template %s: %v", tmpl.ID, err)
-			continue
-		}
+	for _, compiled := range compiledTmpls {
+		tmpl := compiled.Template
 
 		// Convert authConfigs to templates.AuthInfo map
 		var tmplAuthInfos map[string]*templates.AuthInfo

--- a/pkg/runner/graphql_helpers.go
+++ b/pkg/runner/graphql_helpers.go
@@ -269,6 +269,10 @@ func loadAndCompileGraphQLTemplates(dir string, filters []string) ([]*templates.
 			log.Warn("Failed to compile GraphQL template %s: %v", t.ID, cerr)
 			continue
 		}
+		// Mirror the REST/gRPC loaders: carry the source path onto the compiled
+		// template so helpUri resolves to the GitHub blob for built-in templates
+		// and duplicate-id warnings name real files.
+		c.FilePath = t.FilePath
 		out = append(out, c)
 	}
 	warnDuplicateTemplateIDs(out)

--- a/pkg/runner/graphql_helpers.go
+++ b/pkg/runner/graphql_helpers.go
@@ -271,6 +271,7 @@ func loadAndCompileGraphQLTemplates(dir string, filters []string) ([]*templates.
 		}
 		out = append(out, c)
 	}
+	warnDuplicateTemplateIDs(out)
 	return out, nil
 }
 

--- a/pkg/runner/graphql_helpers.go
+++ b/pkg/runner/graphql_helpers.go
@@ -351,6 +351,7 @@ func runTemplateTests(ctx context.Context, config GraphQLConfig, endpoint string
 			// Create model.Finding using template ID as the name
 			finding := &model.Finding{
 				ID:              generateGraphQLID(),
+				TemplateID:      tmpl.ID,
 				Category:        tmpl.Info.Category,
 				Name:            tmpl.ID,
 				Description:     description,

--- a/pkg/runner/graphql_helpers_test.go
+++ b/pkg/runner/graphql_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/praetorian-inc/hadrian/pkg/auth"
 	"github.com/praetorian-inc/hadrian/pkg/graphql"
 	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/templates"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -495,4 +496,138 @@ func TestMapTemplateSeverity(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// writeTemplateFile writes a YAML template file to the given dir. Used by
+// the loadAndCompileGraphQLTemplates tests below to construct hermetic
+// fixtures so the tests don't depend on the canonical templates/graphql/
+// tree.
+func writeTemplateFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0644))
+}
+
+// TestLoadAndCompileGraphQLTemplates exercises the helper that backs both the
+// SARIF rule enrichment preload (graphql.go) and the runtime template
+// executor's legacy fallback (runTemplateTests). It owns three independently
+// testable behaviors — load propagation, filter semantics, and compile-failure
+// handling — and previously had no direct test.
+func TestLoadAndCompileGraphQLTemplates(t *testing.T) {
+	minimal := `id: t-one
+info:
+  name: "One"
+  category: "API1:2023"
+  severity: "MEDIUM"
+graphql:
+  - query: |
+      query Q { __typename }
+    matchers:
+      - type: status
+        status: [200]
+`
+	second := `id: t-two
+info:
+  name: "Two"
+  category: "API2:2023"
+  severity: "HIGH"
+graphql:
+  - query: |
+      query Q { __typename }
+    matchers:
+      - type: status
+        status: [200]
+`
+	t.Run("empty filters returns full compiled set", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTemplateFile(t, dir, "one.yaml", minimal)
+		writeTemplateFile(t, dir, "two.yaml", second)
+
+		got, err := loadAndCompileGraphQLTemplates(dir, nil)
+		require.NoError(t, err)
+		require.Len(t, got, 2, "empty filter must keep every template")
+		ids := []string{got[0].ID, got[1].ID}
+		assert.ElementsMatch(t, []string{"t-one", "t-two"}, ids)
+	})
+
+	t.Run("filter narrows the set", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTemplateFile(t, dir, "one.yaml", minimal)
+		writeTemplateFile(t, dir, "two.yaml", second)
+
+		got, err := loadAndCompileGraphQLTemplates(dir, []string{"t-two"})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "t-two", got[0].ID)
+	})
+
+	t.Run("non-matching filter returns empty without error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTemplateFile(t, dir, "one.yaml", minimal)
+
+		got, err := loadAndCompileGraphQLTemplates(dir, []string{"no-such-id"})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("missing directory returns error", func(t *testing.T) {
+		_, err := loadAndCompileGraphQLTemplates(filepath.Join(t.TempDir(), "does-not-exist"), nil)
+		assert.Error(t, err, "missing template dir should surface as an error to the caller")
+	})
+}
+
+// TestRunTemplateTests_UsesPreloadedSlice verifies the entire point of the
+// Pass-2 refactor: when callers pass a preloaded []*CompiledTemplate, the
+// internal load+filter+compile is skipped. We point config.TemplateDir at a
+// directory that does NOT exist — if a regression re-enabled the internal
+// load this test would fail trying to read the bogus directory.
+func TestRunTemplateTests_UsesPreloadedSlice(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer server.Close()
+
+	// Compile a real template in-memory so executor.ExecuteGraphQL has a
+	// well-formed input. The matchers won't fire against the empty server
+	// response — that's fine; the test asserts the LOAD path was skipped,
+	// not that findings are produced.
+	parsed, err := templates.ParseYAML([]byte(`id: preloaded-only
+info:
+  name: "Preloaded Only"
+  category: "API1:2023"
+  severity: "MEDIUM"
+graphql:
+  - query: |
+      query Q { __typename }
+    matchers:
+      - type: status
+        status: [418]
+`))
+	require.NoError(t, err)
+	compiled, err := templates.Compile(parsed)
+	require.NoError(t, err)
+
+	bogusDir := filepath.Join(t.TempDir(), "definitely-not-a-templates-dir")
+	config := GraphQLConfig{
+		TemplateDir: bogusDir, // would fail if the internal load ran
+		Timeout:     30,
+	}
+
+	_, count := runTemplateTests(
+		context.Background(),
+		config,
+		server.URL,
+		server.Client(),
+		nil, // no auth
+		nil, // no reporter
+		nil, // no headers
+		[]*templates.CompiledTemplate{compiled},
+	)
+
+	// templateCount == len(preloaded) is the proof the internal load was
+	// skipped — if a regression re-enabled it the bogus TemplateDir would
+	// have caused loadAndCompileGraphQLTemplates to return an error and
+	// runTemplateTests would return (nil, 0).
+	assert.Equal(t, 1, count, "templateCount must reflect preloaded slice length, proving internal load was skipped")
 }

--- a/pkg/runner/graphql_helpers_test.go
+++ b/pkg/runner/graphql_helpers_test.go
@@ -384,6 +384,7 @@ func TestRunTemplateTests_PopulatesTemplateID(t *testing.T) {
 		nil, // no auth needed for this template
 		nil, // reporter
 		nil, // customHeaders
+		nil, // preloaded — fall back to internal load+filter+compile
 	)
 
 	require.NotEmpty(t, findings, "matching server should yield at least one finding")
@@ -418,6 +419,7 @@ func TestRunTemplateTests_ReturnsTemplateCount(t *testing.T) {
 		nil,
 		nil, // reporter
 		nil, // customHeaders
+		nil, // preloaded — fall back to internal load
 	)
 
 	// Verify findings are returned (may be 0 if no templates match)
@@ -463,6 +465,7 @@ func TestRunSecurityChecks_NoTemplates(t *testing.T) {
 		nil,
 		nil, // No reporter for this test
 		nil, // customHeaders
+		nil, // preloaded
 	)
 
 	// Verify findings are returned

--- a/pkg/runner/graphql_helpers_test.go
+++ b/pkg/runner/graphql_helpers_test.go
@@ -547,6 +547,14 @@ graphql:
 		require.Len(t, got, 2, "empty filter must keep every template")
 		ids := []string{got[0].ID, got[1].ID}
 		assert.ElementsMatch(t, []string{"t-one", "t-two"}, ids)
+		// The loader must propagate the source path onto the compiled template
+		// (so helpUri resolves to the GitHub blob and duplicate-id warnings name
+		// real files). A regression dropping `c.FilePath = t.FilePath` would
+		// leave these empty.
+		paths := []string{got[0].FilePath, got[1].FilePath}
+		assert.ElementsMatch(t,
+			[]string{filepath.Join(dir, "one.yaml"), filepath.Join(dir, "two.yaml")},
+			paths, "compiled templates must carry their source FilePath")
 	})
 
 	t.Run("filter narrows the set", func(t *testing.T) {

--- a/pkg/runner/graphql_helpers_test.go
+++ b/pkg/runner/graphql_helpers_test.go
@@ -353,6 +353,46 @@ func TestReportFindings_WithFindings(t *testing.T) {
 	reportFindings(findings)
 }
 
+// TestRunTemplateTests_PopulatesTemplateID drives runTemplateTests against a
+// server that matches the no-auth Broken Authentication template (status 200
+// + body containing "data" and "users") and asserts every produced finding
+// carries Finding.TemplateID = tmpl.ID. SARIF rule dedup depends on this.
+func TestRunTemplateTests_PopulatesTemplateID(t *testing.T) {
+	// Server returns a body that satisfies both matchers in
+	// 02-api2-broken-authentication.yaml ("data" + "users" + status 200).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":"1","username":"u","email":"e@x.test"}]}}`))
+	}))
+	defer server.Close()
+
+	// Filter to a single no-auth template so the test is deterministic and
+	// fast; this is the one that does NOT need auth + role config.
+	config := GraphQLConfig{
+		TemplateDir: "../../templates/graphql",
+		Templates:   []string{"graphql-broken-authentication"},
+		Timeout:     30,
+		Verbose:     false,
+	}
+
+	findings, _ := runTemplateTests(
+		context.Background(),
+		config,
+		server.URL,
+		server.Client(),
+		nil, // no auth needed for this template
+		nil, // reporter
+		nil, // customHeaders
+	)
+
+	require.NotEmpty(t, findings, "matching server should yield at least one finding")
+	for _, f := range findings {
+		assert.Equal(t, "graphql-broken-authentication", f.TemplateID,
+			"TemplateID must propagate from the matched template (regression risk: SARIF dedup collapses to hadrian.unknown)")
+	}
+}
+
 // TestRunTemplateTests_ReturnsTemplateCount tests that runTemplateTests returns the count of loaded templates
 func TestRunTemplateTests_ReturnsTemplateCount(t *testing.T) {
 	// Create a test server that returns a simple GraphQL response

--- a/pkg/runner/graphql_validate_test.go
+++ b/pkg/runner/graphql_validate_test.go
@@ -1,0 +1,39 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGraphQLConfigValidate pins the GraphQL output-format / SARIF-pairing
+// validation, keeping the three protocols' SARIF behavior symmetric (REST and
+// gRPC have equivalent tests). Without this, the GraphQL command was the only
+// protocol with no test exercising its sarif output path.
+func TestGraphQLConfigValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    GraphQLConfig
+		wantError bool
+		errorMsg  string
+	}{
+		{name: "default terminal", config: GraphQLConfig{Output: "terminal"}, wantError: false},
+		{name: "empty output tolerated", config: GraphQLConfig{Output: ""}, wantError: false},
+		{name: "json", config: GraphQLConfig{Output: "json"}, wantError: false},
+		{name: "invalid format", config: GraphQLConfig{Output: "xml"}, wantError: true, errorMsg: "invalid output format"},
+		{name: "sarif without output-file", config: GraphQLConfig{Output: "sarif"}, wantError: true, errorMsg: "--output sarif requires --output-file"},
+		{name: "sarif with output-file", config: GraphQLConfig{Output: "sarif", OutputFile: "report.sarif"}, wantError: false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/runner/grpc.go
+++ b/pkg/runner/grpc.go
@@ -72,9 +72,11 @@ func (c *GRPCConfig) Validate() error {
 		return fmt.Errorf("--rate-limit must be positive (got %f)", c.RateLimit)
 	}
 
-	// Output format must be supported, and SARIF requires a file target. This
-	// mirrors REST Config.Validate so the error surfaces here rather than later
-	// at reporter construction.
+	// Output format must be supported, and SARIF requires a file target, so the
+	// error surfaces here rather than later at reporter construction. An empty
+	// Output is tolerated: REST's Config.Validate defaults "" → "json" via
+	// setDefaults before this check, so tolerating "" here (the CLI always
+	// supplies "terminal") keeps gRPC consistent with REST rather than stricter.
 	validFormats := map[string]bool{"terminal": true, "json": true, "markdown": true, "sarif": true}
 	if c.Output != "" && !validFormats[c.Output] {
 		return fmt.Errorf("invalid output format: %s (valid: terminal, json, markdown, sarif)", c.Output)

--- a/pkg/runner/grpc.go
+++ b/pkg/runner/grpc.go
@@ -308,7 +308,7 @@ func runGRPCTest(ctx context.Context, config GRPCConfig) error {
 
 	// When emitting SARIF without any compiled templates, warn that rules will
 	// degrade to wiki-fallback metadata; this matches the GraphQL behavior.
-	if config.Output == "sarif" && len(templateFiles) == 0 {
+	if sarifLacksTemplates(config.Output, len(templateFiles)) {
 		log.Warn("SARIF: no templates loaded from %s — rules will use wiki fallback metadata", templateDir)
 	}
 

--- a/pkg/runner/grpc.go
+++ b/pkg/runner/grpc.go
@@ -293,6 +293,12 @@ func runGRPCTest(ctx context.Context, config GRPCConfig) error {
 		mutationExecutor = orchestrator.NewGRPCMutationExecutor(adapter)
 	}
 
+	// When emitting SARIF without any compiled templates, warn that rules will
+	// degrade to wiki-fallback metadata; this matches the GraphQL behavior.
+	if config.Output == "sarif" && len(templateFiles) == 0 {
+		log.Warn("SARIF: no templates loaded from %s — rules will use wiki fallback metadata", templateDir)
+	}
+
 	// Create reporter based on output format
 	rep, err := createReporter(config.Output, config.OutputFile, 0, templateFiles)
 	if err != nil {

--- a/pkg/runner/grpc.go
+++ b/pkg/runner/grpc.go
@@ -72,6 +72,17 @@ func (c *GRPCConfig) Validate() error {
 		return fmt.Errorf("--rate-limit must be positive (got %f)", c.RateLimit)
 	}
 
+	// Output format must be supported, and SARIF requires a file target. This
+	// mirrors REST Config.Validate so the error surfaces here rather than later
+	// at reporter construction.
+	validFormats := map[string]bool{"terminal": true, "json": true, "markdown": true, "sarif": true}
+	if c.Output != "" && !validFormats[c.Output] {
+		return fmt.Errorf("invalid output format: %s (valid: terminal, json, markdown, sarif)", c.Output)
+	}
+	if c.Output == "sarif" && c.OutputFile == "" {
+		return fmt.Errorf("--output sarif requires --output-file")
+	}
+
 	// Validate custom headers format
 	if len(c.Headers) > 0 {
 		if _, err := ParseCustomHeaders(c.Headers); err != nil {

--- a/pkg/runner/grpc.go
+++ b/pkg/runner/grpc.go
@@ -694,6 +694,8 @@ func loadGRPCTemplates(dir string) ([]*templates.CompiledTemplate, error) {
 		return nil, err
 	}
 
+	warnDuplicateTemplateIDs(result)
+
 	return result, nil
 }
 

--- a/pkg/runner/grpc.go
+++ b/pkg/runner/grpc.go
@@ -122,7 +122,7 @@ func newTestGRPCCmd() *cobra.Command {
 	cmd.Flags().IntVar(&config.Timeout, "timeout", 30, "Request timeout in seconds")
 
 	// Output options
-	cmd.Flags().StringVar(&config.Output, "output", "terminal", "Output format: terminal, json, markdown")
+	cmd.Flags().StringVar(&config.Output, "output", "terminal", "Output format: terminal, json, markdown, sarif")
 	cmd.Flags().StringVar(&config.OutputFile, "output-file", "", "Output file path")
 	cmd.Flags().BoolVar(&config.Verbose, "verbose", false, "Verbose output")
 	cmd.Flags().BoolVar(&config.DryRun, "dry-run", false, "Dry run (don't execute tests)")
@@ -294,7 +294,7 @@ func runGRPCTest(ctx context.Context, config GRPCConfig) error {
 	}
 
 	// Create reporter based on output format
-	rep, err := createReporter(config.Output, config.OutputFile, 0)
+	rep, err := createReporter(config.Output, config.OutputFile, 0, templateFiles)
 	if err != nil {
 		return fmt.Errorf("failed to create reporter: %w", err)
 	}
@@ -470,6 +470,7 @@ func buildGRPCFinding(tmpl *templates.CompiledTemplate, op *model.Operation, att
 
 	return &model.Finding{
 		ID:              tmpl.ID,
+		TemplateID:      tmpl.ID,
 		Category:        category,
 		Name:            tmpl.ID,
 		Severity:        severity,

--- a/pkg/runner/grpc_test.go
+++ b/pkg/runner/grpc_test.go
@@ -743,6 +743,42 @@ func TestGRPCConfigValidate(t *testing.T) {
 			wantError: true,
 			errorMsg:  "rate-limit must be positive",
 		},
+		{
+			name: "invalid output format",
+			config: GRPCConfig{
+				Target:    "localhost:50051",
+				Proto:     "test.proto",
+				Timeout:   30,
+				RateLimit: 5.0,
+				Output:    "xml",
+			},
+			wantError: true,
+			errorMsg:  "invalid output format",
+		},
+		{
+			name: "sarif without output-file",
+			config: GRPCConfig{
+				Target:    "localhost:50051",
+				Proto:     "test.proto",
+				Timeout:   30,
+				RateLimit: 5.0,
+				Output:    "sarif",
+			},
+			wantError: true,
+			errorMsg:  "--output sarif requires --output-file",
+		},
+		{
+			name: "sarif with output-file",
+			config: GRPCConfig{
+				Target:     "localhost:50051",
+				Proto:      "test.proto",
+				Timeout:    30,
+				RateLimit:  5.0,
+				Output:     "sarif",
+				OutputFile: "report.sarif",
+			},
+			wantError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/runner/grpc_test.go
+++ b/pkg/runner/grpc_test.go
@@ -436,6 +436,7 @@ func TestBuildGRPCFinding(t *testing.T) {
 		finding := buildGRPCFinding(tmpl, op, "attacker", "victim")
 
 		assert.Equal(t, "test-template-id", finding.ID)
+		assert.Equal(t, "test-template-id", finding.TemplateID, "TemplateID is the stable SARIF ruleId — regression would silently collapse all gRPC findings to hadrian.unknown in SARIF")
 		assert.Equal(t, "BOLA", finding.Category)
 		assert.Equal(t, "test-template-id", finding.Name)
 		assert.Equal(t, model.Severity("HIGH"), finding.Severity)
@@ -461,6 +462,7 @@ func TestBuildGRPCFinding(t *testing.T) {
 		finding := buildGRPCFinding(tmpl, op, "user1", "user2")
 
 		assert.Equal(t, "default-template", finding.ID)
+		assert.Equal(t, "default-template", finding.TemplateID, "TemplateID must propagate even when template lacks an info.category")
 		assert.Equal(t, "default-template", finding.Category) // Uses ID as category
 		assert.Equal(t, model.Severity("MEDIUM"), finding.Severity)
 		assert.Equal(t, "user1", finding.AttackerRole)

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -26,6 +26,14 @@ import (
 // PUBLIC API (Helper functions for CLI workflow)
 // =============================================================================
 
+// sarifLacksTemplates reports whether a SARIF run will fall back to wiki
+// metadata because no templates were loaded — the condition the gRPC/GraphQL
+// runners warn the operator about. Pure predicate so the branch is testable
+// without standing up a full protocol run.
+func sarifLacksTemplates(output string, templateCount int) bool {
+	return output == "sarif" && templateCount == 0
+}
+
 // warnDuplicateTemplateIDs logs a warning for each template id declared by more
 // than one file in a loaded set. Two templates sharing an id collapse to a
 // single SARIF rule (buildRules keeps the first seen) and, when they match the

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/praetorian-inc/hadrian/pkg/plugins/rest"    // Register REST plugin
 	"github.com/praetorian-inc/hadrian/pkg/reporter"
 	"github.com/praetorian-inc/hadrian/pkg/roles"
+	"github.com/praetorian-inc/hadrian/pkg/templates"
 )
 
 // =============================================================================
@@ -77,8 +78,13 @@ type Stats struct {
 	TemplatesLoaded int           `json:"templates_loaded"`
 }
 
-// createReporter creates appropriate reporter based on output format
-func createReporter(format, outputFile string, requestIDsLimit int) (Reporter, error) {
+// createReporter creates appropriate reporter based on output format.
+//
+// tmpls is consulted only by the SARIF reporter (to enrich the rules section
+// with descriptions, tags, and helpUri). Other formats ignore it. Pass nil if
+// no templates are available — SARIF will still emit minimal rules derived
+// from each finding's own metadata.
+func createReporter(format, outputFile string, requestIDsLimit int, tmpls []*templates.CompiledTemplate) (Reporter, error) {
 	switch format {
 	case "terminal":
 		return NewTerminalReporter(os.Stdout, requestIDsLimit), nil
@@ -86,6 +92,8 @@ func createReporter(format, outputFile string, requestIDsLimit int) (Reporter, e
 		return NewJSONReporter(outputFile, requestIDsLimit)
 	case "markdown":
 		return NewMarkdownReporter(outputFile, requestIDsLimit)
+	case "sarif":
+		return NewSARIFReporter(outputFile, tmpls)
 	default:
 		return nil, fmt.Errorf("unsupported output format: %s", format)
 	}

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -36,7 +36,9 @@ import (
 func warnDuplicateTemplateIDs(tmpls []*templates.CompiledTemplate) {
 	seen := make(map[string]string, len(tmpls))
 	for _, t := range tmpls {
-		if t == nil || t.ID == "" {
+		// t.ID reads through the embedded *Template, so guard the nil embedded
+		// pointer too — a directly-constructed CompiledTemplate{} would panic.
+		if t == nil || t.Template == nil || t.ID == "" {
 			continue
 		}
 		if first, ok := seen[t.ID]; ok {

--- a/pkg/runner/helpers.go
+++ b/pkg/runner/helpers.go
@@ -26,6 +26,27 @@ import (
 // PUBLIC API (Helper functions for CLI workflow)
 // =============================================================================
 
+// warnDuplicateTemplateIDs logs a warning for each template id declared by more
+// than one file in a loaded set. Two templates sharing an id collapse to a
+// single SARIF rule (buildRules keeps the first seen) and, when they match the
+// same operation+role pair, to a single partialFingerprint — silently hiding
+// the second finding. This only happens with a misconfigured template set, so
+// it is a warning (surfacing the conflict) rather than a hard load failure.
+// It is shared by the rest, graphql, and grpc loaders.
+func warnDuplicateTemplateIDs(tmpls []*templates.CompiledTemplate) {
+	seen := make(map[string]string, len(tmpls))
+	for _, t := range tmpls {
+		if t == nil || t.ID == "" {
+			continue
+		}
+		if first, ok := seen[t.ID]; ok {
+			log.Warn("Duplicate template id %q: %q and %q declare the same id; only the first surfaces in SARIF rules and fingerprints", t.ID, first, t.FilePath)
+			continue
+		}
+		seen[t.ID] = t.FilePath
+	}
+}
+
 // parseAPISpec parses API specification using registered plugins
 func parseAPISpec(path string) (*model.APISpec, error) {
 	data, err := os.ReadFile(path)

--- a/pkg/runner/helpers_test.go
+++ b/pkg/runner/helpers_test.go
@@ -123,30 +123,44 @@ func TestCreateHTTPClient_WithInsecure(t *testing.T) {
 // =============================================================================
 
 func TestCreateReporter_Terminal(t *testing.T) {
-	rep, err := createReporter("terminal", "", 1)
+	rep, err := createReporter("terminal", "", 1, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, rep)
 	assert.NoError(t, rep.Close())
 }
 
 func TestCreateReporter_JSON(t *testing.T) {
-	rep, err := createReporter("json", "", 1)
+	rep, err := createReporter("json", "", 1, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, rep)
 	assert.NoError(t, rep.Close())
 }
 
 func TestCreateReporter_Markdown(t *testing.T) {
-	rep, err := createReporter("markdown", "", 1)
+	rep, err := createReporter("markdown", "", 1, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, rep)
 	assert.NoError(t, rep.Close())
 }
 
 func TestCreateReporter_InvalidFormat(t *testing.T) {
-	_, err := createReporter("invalid", "", 1)
+	_, err := createReporter("invalid", "", 1, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported output format")
+}
+
+func TestCreateReporter_SARIF(t *testing.T) {
+	dir := t.TempDir()
+	rep, err := createReporter("sarif", filepath.Join(dir, "out.sarif"), 1, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, rep)
+	assert.NoError(t, rep.Close())
+}
+
+func TestCreateReporter_SARIF_RequiresOutputFile(t *testing.T) {
+	_, err := createReporter("sarif", "", 1, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--output-file")
 }
 
 // =============================================================================

--- a/pkg/runner/helpers_test.go
+++ b/pkg/runner/helpers_test.go
@@ -153,7 +153,10 @@ func TestCreateReporter_SARIF(t *testing.T) {
 	dir := t.TempDir()
 	rep, err := createReporter("sarif", filepath.Join(dir, "out.sarif"), 1, nil)
 	require.NoError(t, err)
-	assert.NotNil(t, rep)
+	// Type-assert the concrete reporter; a regression returning a different
+	// implementation for "sarif" would otherwise still pass.
+	_, ok := rep.(*SARIFReporter)
+	require.True(t, ok, "createReporter(sarif) must return *SARIFReporter, got %T", rep)
 	assert.NoError(t, rep.Close())
 }
 

--- a/pkg/runner/rest.go
+++ b/pkg/runner/rest.go
@@ -261,6 +261,8 @@ func loadTemplateFiles(dir string, categories []string) ([]*templates.CompiledTe
 		return result[i].FilePath < result[j].FilePath
 	})
 
+	warnDuplicateTemplateIDs(result)
+
 	return result, nil
 }
 

--- a/pkg/runner/rest.go
+++ b/pkg/runner/rest.go
@@ -87,7 +87,7 @@ func newTestRestCmd() *cobra.Command {
 	cmd.Flags().IntVar(&config.RateLimitMaxRetries, "rate-limit-max-retries", 5, "Maximum retry attempts on rate limit response")
 	cmd.Flags().IntSliceVar(&config.RateLimitStatusCodes, "rate-limit-status-codes", []int{429, 503}, "Status codes that trigger rate limit retry")
 	cmd.Flags().IntVar(&config.Timeout, "timeout", 30, "Request timeout (seconds)")
-	cmd.Flags().StringVar(&config.Output, "output", "terminal", "Output format: terminal, json, markdown")
+	cmd.Flags().StringVar(&config.Output, "output", "terminal", "Output format: terminal, json, markdown, sarif")
 	cmd.Flags().StringVar(&config.OutputFile, "output-file", "", "Write findings to file")
 	cmd.Flags().StringSliceVar(&config.Categories, "category", []string{"owasp"}, "Filter by template metadata — exact match against info.category and info.tags (case-insensitive, default: owasp)")
 	cmd.Flags().StringVar(&config.TemplateDir, "template-dir", "", "Directory containing test templates (default: $HADRIAN_TEMPLATES or ./templates/rest)")
@@ -136,7 +136,7 @@ func runTest(ctx context.Context, config Config) error {
 	rolesCfg := inputs.rolesCfg
 	tmplFiles := inputs.tmplFiles
 
-	rep, err := createReporter(config.Output, config.OutputFile, config.RequestIDsLimit)
+	rep, err := createReporter(config.Output, config.OutputFile, config.RequestIDsLimit, tmplFiles)
 	if err != nil {
 		return fmt.Errorf("failed to create reporter: %w", err)
 	}

--- a/pkg/runner/sarif.go
+++ b/pkg/runner/sarif.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/praetorian-inc/hadrian/pkg/log"
 	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/praetorian-inc/hadrian/pkg/reporter"
 	"github.com/praetorian-inc/hadrian/pkg/templates"
@@ -202,9 +203,12 @@ func (r *SARIFReporter) build(findings []*model.Finding) SARIFReport {
 		}
 		idx, ok := ruleIndex[ruleID]
 		if !ok {
-			// Should not happen — buildRules covers every TemplateID present
-			// in findings — but guard against panics.
-			idx = 0
+			// buildRules walks the same finding set, so this branch indicates
+			// an invariant violation (refactor regression, future loader bug,
+			// concurrent mutation). Surface it rather than silently emitting a
+			// SARIF result that points at the wrong rule.
+			log.Warn("SARIF: dropping finding with ruleID %q — no matching entry in driver.rules (invariant violation)", ruleID)
+			continue
 		}
 		results = append(results, SARIFResult{
 			RuleID:              ruleID,
@@ -279,7 +283,10 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 	if tmpl, ok := r.templates[id]; ok {
 		rule.ShortDescription = &SARIFMessage{Text: tmpl.Info.Name}
 		if tmpl.Info.Description != "" {
-			rule.FullDescription = &SARIFMessage{Text: tmpl.Info.Description}
+			// Built-in template descriptions are author-controlled YAML, so
+			// PII contamination is unlikely — but the redactor is cheap and
+			// keeps the rule-description path symmetric with the result path.
+			rule.FullDescription = &SARIFMessage{Text: r.redactor.Redact(tmpl.Info.Description)}
 		}
 		rule.HelpURI = templateHelpURI(tmpl.FilePath)
 		rule.DefaultConfiguration = &SARIFConfiguration{
@@ -305,7 +312,12 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 			rule.ShortDescription = &SARIFMessage{Text: sample.Name}
 		}
 		if sample.Description != "" {
-			rule.FullDescription = &SARIFMessage{Text: sample.Description}
+			// Fallback rule path is the one the GraphQL non-template scanner
+			// hits (TemplateIDs like "bola"/"bfla"/"introspection-disclosure"
+			// have no compiled-template entry). CheckBOLA et al. embed
+			// response-derived victim IDs in Description, so redaction here
+			// is the actual leak fix — not just defense-in-depth.
+			rule.FullDescription = &SARIFMessage{Text: r.redactor.Redact(sample.Description)}
 		}
 		rule.HelpURI = templateWikiURL
 		rule.DefaultConfiguration = &SARIFConfiguration{

--- a/pkg/runner/sarif.go
+++ b/pkg/runner/sarif.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/reporter"
 	"github.com/praetorian-inc/hadrian/pkg/templates"
 )
 
@@ -24,11 +25,26 @@ import (
 // Code Scanning uses these to deduplicate alerts across runs.
 
 const (
-	sarifVersion          = "2.1.0"
-	sarifSchema           = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+	sarifVersion = "2.1.0"
+	// sarifSchema points at the canonical SARIF v2.1.0 JSON Schema on the
+	// oasis-tcs/sarif-spec main branch — the old master/Schemata URL returns 404.
+	sarifSchema           = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json"
 	hadrianInformationURI = "https://github.com/praetorian-inc/hadrian"
 	templateBaseURL       = "https://github.com/praetorian-inc/hadrian/blob/main/"
 	templateWikiURL       = "https://github.com/praetorian-inc/hadrian/wiki/Template-System"
+
+	// builtInTemplatePrefix gates templateHelpURI: only paths rooted at
+	// "templates/" map to the hadrian GitHub blob URL. A custom template at
+	// /home/user/my-templates/foo.yaml would otherwise match a naive substring
+	// search and produce a broken URL.
+	builtInTemplatePrefix = "templates/"
+
+	// fingerprintFieldSep separates identity fields when computing
+	// partialFingerprints. NUL is used because it cannot legitimately appear in
+	// any of the inputs (template IDs, HTTP methods, paths, role names) — joining
+	// with a printable delimiter risks collisions if a user-supplied field
+	// contains the delimiter.
+	fingerprintFieldSep = "\x00"
 )
 
 // SARIFReport is the top-level SARIF v2.1.0 document.
@@ -122,9 +138,15 @@ type SARIFLogicalLocation struct {
 // Templates passed at construction time are used to enrich the rules section
 // (full description, helpUri, tags). They are optional: if absent, rules are
 // derived from the findings themselves.
+//
+// Free-text content (Finding.Description, embedded response excerpts) is
+// passed through reporter.Redactor before being written so that tokens and
+// PII the scanned API returned cannot leak into a SARIF document that the
+// PR documents as upload-ready to GitHub Code Scanning.
 type SARIFReporter struct {
 	outputFile string
 	templates  map[string]*templates.CompiledTemplate
+	redactor   *reporter.Redactor
 }
 
 // NewSARIFReporter constructs a SARIFReporter. `tmpls` may be nil for callers
@@ -144,6 +166,7 @@ func NewSARIFReporter(outputFile string, tmpls []*templates.CompiledTemplate) (*
 	return &SARIFReporter{
 		outputFile: outputFile,
 		templates:  idx,
+		redactor:   reporter.NewRedactor(),
 	}, nil
 }
 
@@ -187,7 +210,7 @@ func (r *SARIFReporter) build(findings []*model.Finding) SARIFReport {
 			RuleID:              ruleID,
 			RuleIndex:           idx,
 			Level:               severityToSARIFLevel(f.Severity),
-			Message:             SARIFMessage{Text: buildResultMessage(f)},
+			Message:             SARIFMessage{Text: r.redactor.Redact(buildResultMessage(f))},
 			Locations:           buildLocations(f),
 			PartialFingerprints: buildPartialFingerprints(f),
 			Properties:          buildResultProperties(f),
@@ -268,8 +291,11 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 		}
 		tags = append(tags, tmpl.Info.Tags...)
 		rule.Properties = &SARIFRuleProperties{
-			Tags:      dedupeStrings(tags),
-			Precision: "high",
+			Tags: dedupeStrings(tags),
+			// Hadrian templates don't carry a per-rule precision signal today;
+			// "medium" is a conservative default that avoids overstating
+			// confidence to SARIF consumers (GitHub UI, Code Scanning APIs).
+			Precision: "medium",
 		}
 		return rule
 	}
@@ -290,8 +316,11 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 			tags = append(tags, sample.Category)
 		}
 		rule.Properties = &SARIFRuleProperties{
-			Tags:      dedupeStrings(tags),
-			Precision: "high",
+			Tags: dedupeStrings(tags),
+			// Hadrian templates don't carry a per-rule precision signal today;
+			// "medium" is a conservative default that avoids overstating
+			// confidence to SARIF consumers (GitHub UI, Code Scanning APIs).
+			Precision: "medium",
 		}
 	} else {
 		rule.HelpURI = templateWikiURL
@@ -299,17 +328,22 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 	return rule
 }
 
-// templateHelpURI returns a stable GitHub URL for built-in templates
-// (paths starting with "templates/"), and a fallback wiki URL otherwise.
+// templateHelpURI returns a stable GitHub URL for built-in templates and a
+// fallback wiki URL otherwise.
+//
+// A built-in template is identified by a FilePath rooted at "templates/"
+// (optionally prefixed with "./"). Earlier versions of this function matched
+// the substring "templates/" anywhere in the path, which produced broken URLs
+// for legitimate custom layouts like /home/user/my-templates/foo.yaml.
 func templateHelpURI(filePath string) string {
 	if filePath == "" {
 		return templateWikiURL
 	}
-	// Built-in templates ship under templates/{rest,graphql,grpc}/...
-	// Normalize Windows separators just in case.
-	normalized := strings.ReplaceAll(filePath, "\\", "/")
-	if i := strings.Index(normalized, "templates/"); i >= 0 {
-		return templateBaseURL + normalized[i:]
+	// Normalize Windows separators and strip a leading "./" so a built-in
+	// template loaded via the default relative path still matches.
+	normalized := strings.TrimPrefix(strings.ReplaceAll(filePath, "\\", "/"), "./")
+	if strings.HasPrefix(normalized, builtInTemplatePrefix) {
+		return templateBaseURL + normalized
 	}
 	return templateWikiURL
 }
@@ -358,6 +392,10 @@ func buildLocations(f *model.Finding) []SARIFLocation {
 //
 // Inputs are intentionally limited to stable identity fields. We deliberately
 // exclude timestamps, request IDs, response bodies, and LLM analysis output.
+//
+// Fields are joined with NUL (\x00) so that no user-controllable value can
+// shift the boundary between fields and produce a collision with a different
+// (template, endpoint, role) tuple.
 func buildPartialFingerprints(f *model.Finding) map[string]string {
 	parts := []string{
 		f.TemplateID,
@@ -366,7 +404,7 @@ func buildPartialFingerprints(f *model.Finding) map[string]string {
 		f.AttackerRole,
 		f.VictimRole,
 	}
-	h := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	h := sha256.Sum256([]byte(strings.Join(parts, fingerprintFieldSep)))
 	return map[string]string{
 		"primaryLocationHash/v1": hex.EncodeToString(h[:]),
 	}

--- a/pkg/runner/sarif.go
+++ b/pkg/runner/sarif.go
@@ -34,12 +34,6 @@ const (
 	templateBaseURL       = "https://github.com/praetorian-inc/hadrian/blob/main/"
 	templateWikiURL       = "https://github.com/praetorian-inc/hadrian/wiki/Template-System"
 
-	// builtInTemplatePrefix gates templateHelpURI: only paths rooted at
-	// "templates/" map to the hadrian GitHub blob URL. A custom template at
-	// /home/user/my-templates/foo.yaml would otherwise match a naive substring
-	// search and produce a broken URL.
-	builtInTemplatePrefix = "templates/"
-
 	// fingerprintFieldSep separates identity fields when computing
 	// partialFingerprints. NUL is used because it cannot legitimately appear in
 	// any of the inputs (template IDs, HTTP methods, paths, role names) — joining
@@ -353,13 +347,26 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 	return rule
 }
 
+// builtInTemplateDirs are the canonical subdirectories of Hadrian's built-in
+// template tree. A FilePath that contains one of these as a path segment is
+// linked to its GitHub blob, regardless of how the loader reached it.
+var builtInTemplateDirs = []string{"templates/rest/", "templates/graphql/", "templates/grpc/"}
+
 // templateHelpURI returns a stable GitHub URL for built-in templates and a
 // fallback wiki URL otherwise.
 //
-// A built-in template is identified by a FilePath rooted at "templates/"
-// (optionally prefixed with "./"). Earlier versions of this function matched
-// the substring "templates/" anywhere in the path, which produced broken URLs
-// for legitimate custom layouts like /home/user/my-templates/foo.yaml.
+// A built-in template is identified by a FilePath that contains one of
+// builtInTemplateDirs as a path segment. Anchoring on the
+// templates/{rest,graphql,grpc}/ segment (rather than a leading "templates/"
+// prefix) is what lets the canonical blob URL resolve no matter how the loader
+// reached the file: the relative default ("templates/rest/x.yaml"), an absolute
+// --template-dir ("/opt/hadrian/templates/grpc/x.yaml"), $HADRIAN_TEMPLATES, or
+// a "../../templates/rest/x.yaml" relative path all map to the same blob.
+//
+// The segment must sit on a path boundary (string start or after a "/"), so
+// custom layouts like /home/user/my-templates/foo.yaml or
+// /opt/work/sub-templates/api.yaml still fall through to the wiki URL instead
+// of producing a broken blob link.
 func templateHelpURI(filePath string) string {
 	if filePath == "" {
 		return templateWikiURL
@@ -367,8 +374,11 @@ func templateHelpURI(filePath string) string {
 	// Normalize Windows separators and strip a leading "./" so a built-in
 	// template loaded via the default relative path still matches.
 	normalized := strings.TrimPrefix(strings.ReplaceAll(filePath, "\\", "/"), "./")
-	if strings.HasPrefix(normalized, builtInTemplatePrefix) {
-		return templateBaseURL + normalized
+	for _, seg := range builtInTemplateDirs {
+		i := strings.LastIndex(normalized, seg)
+		if i == 0 || (i > 0 && normalized[i-1] == '/') {
+			return templateBaseURL + normalized[i:]
+		}
 	}
 	return templateWikiURL
 }
@@ -421,6 +431,16 @@ func buildLocations(f *model.Finding) []SARIFLocation {
 // Fields are joined with NUL (\x00) so that no user-controllable value can
 // shift the boundary between fields and produce a collision with a different
 // (template, endpoint, role) tuple.
+//
+// INVARIANT: one (TemplateID, Method, Endpoint, AttackerRole, VictimRole) tuple
+// must map to at most one finding. Category and Severity are deliberately NOT
+// part of the hash — today that tuple uniquely identifies a finding, so adding
+// them would only churn fingerprints (and reopen GitHub Code Scanning alerts)
+// without improving uniqueness. If a future change ever lets the same tuple
+// emit two findings that differ only by Category or Severity, they will collide
+// to a single alert and one will be hidden; at that point Category/Severity
+// must be folded into the hash here (a new "/v2" key, leaving v1 intact so
+// existing alerts are not orphaned).
 func buildPartialFingerprints(f *model.Finding) map[string]string {
 	parts := []string{
 		f.TemplateID,

--- a/pkg/runner/sarif.go
+++ b/pkg/runner/sarif.go
@@ -1,0 +1,446 @@
+package runner
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/templates"
+)
+
+// SARIF v2.1.0 output (https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html).
+//
+// Hadrian emits one SARIF "run" containing:
+//   - tool.driver.rules[] — one rule per unique TemplateID that produced a finding
+//   - results[] — one entry per Finding
+//
+// Each result carries a stable partialFingerprints["primaryLocationHash/v1"]
+// derived from (TemplateID, Method, Endpoint, AttackerRole, VictimRole). GitHub
+// Code Scanning uses these to deduplicate alerts across runs.
+
+const (
+	sarifVersion          = "2.1.0"
+	sarifSchema           = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+	hadrianInformationURI = "https://github.com/praetorian-inc/hadrian"
+	templateBaseURL       = "https://github.com/praetorian-inc/hadrian/blob/main/"
+	templateWikiURL       = "https://github.com/praetorian-inc/hadrian/wiki/Template-System"
+)
+
+// SARIFReport is the top-level SARIF v2.1.0 document.
+type SARIFReport struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []SARIFRun `json:"runs"`
+}
+
+type SARIFRun struct {
+	Tool              SARIFTool           `json:"tool"`
+	Results           []SARIFResult       `json:"results"`
+	AutomationDetails *SARIFRunAutomation `json:"automationDetails,omitempty"`
+	ColumnKind        string              `json:"columnKind,omitempty"`
+}
+
+type SARIFRunAutomation struct {
+	ID string `json:"id"`
+}
+
+type SARIFTool struct {
+	Driver SARIFDriver `json:"driver"`
+}
+
+type SARIFDriver struct {
+	Name           string      `json:"name"`
+	InformationURI string      `json:"informationUri"`
+	Version        string      `json:"version"`
+	Rules          []SARIFRule `json:"rules"`
+}
+
+type SARIFRule struct {
+	ID                   string               `json:"id"`
+	Name                 string               `json:"name,omitempty"`
+	ShortDescription     *SARIFMessage        `json:"shortDescription,omitempty"`
+	FullDescription      *SARIFMessage        `json:"fullDescription,omitempty"`
+	HelpURI              string               `json:"helpUri,omitempty"`
+	DefaultConfiguration *SARIFConfiguration  `json:"defaultConfiguration,omitempty"`
+	Properties           *SARIFRuleProperties `json:"properties,omitempty"`
+}
+
+type SARIFConfiguration struct {
+	Level string `json:"level"`
+}
+
+type SARIFRuleProperties struct {
+	Tags      []string `json:"tags,omitempty"`
+	Precision string   `json:"precision,omitempty"`
+}
+
+type SARIFMessage struct {
+	Text string `json:"text"`
+}
+
+type SARIFResult struct {
+	RuleID              string            `json:"ruleId"`
+	RuleIndex           int               `json:"ruleIndex"`
+	Level               string            `json:"level"`
+	Message             SARIFMessage      `json:"message"`
+	Locations           []SARIFLocation   `json:"locations"`
+	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
+	Properties          map[string]any    `json:"properties,omitempty"`
+}
+
+type SARIFLocation struct {
+	PhysicalLocation *SARIFPhysicalLocation `json:"physicalLocation,omitempty"`
+	LogicalLocations []SARIFLogicalLocation `json:"logicalLocations,omitempty"`
+}
+
+type SARIFPhysicalLocation struct {
+	ArtifactLocation SARIFArtifactLocation `json:"artifactLocation"`
+	Region           *SARIFRegion          `json:"region,omitempty"`
+}
+
+type SARIFArtifactLocation struct {
+	URI       string `json:"uri"`
+	URIBaseID string `json:"uriBaseId,omitempty"`
+}
+
+type SARIFRegion struct {
+	StartLine int `json:"startLine"`
+}
+
+type SARIFLogicalLocation struct {
+	Name string `json:"name,omitempty"`
+	Kind string `json:"kind,omitempty"`
+}
+
+// SARIFReporter writes findings as a SARIF v2.1.0 document.
+//
+// Templates passed at construction time are used to enrich the rules section
+// (full description, helpUri, tags). They are optional: if absent, rules are
+// derived from the findings themselves.
+type SARIFReporter struct {
+	outputFile string
+	templates  map[string]*templates.CompiledTemplate
+}
+
+// NewSARIFReporter constructs a SARIFReporter. `tmpls` may be nil for callers
+// (notably the GraphQL non-template scanner path) that produce findings without
+// matching CompiledTemplate metadata.
+func NewSARIFReporter(outputFile string, tmpls []*templates.CompiledTemplate) (*SARIFReporter, error) {
+	if outputFile == "" {
+		return nil, fmt.Errorf("sarif output requires --output-file")
+	}
+	idx := make(map[string]*templates.CompiledTemplate, len(tmpls))
+	for _, t := range tmpls {
+		if t == nil {
+			continue
+		}
+		idx[t.ID] = t
+	}
+	return &SARIFReporter{
+		outputFile: outputFile,
+		templates:  idx,
+	}, nil
+}
+
+// ReportFinding is a no-op; SARIF output is batched in GenerateReport.
+func (r *SARIFReporter) ReportFinding(_ *model.Finding) {}
+
+// GenerateReport writes the SARIF document to outputFile.
+func (r *SARIFReporter) GenerateReport(findings []*model.Finding, _ *Stats) error {
+	report := r.build(findings)
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal SARIF report: %w", err)
+	}
+
+	if err := os.WriteFile(r.outputFile, data, 0600); err != nil {
+		return fmt.Errorf("failed to write SARIF report: %w", err)
+	}
+	return nil
+}
+
+// Close is a no-op for SARIFReporter (no resources held).
+func (r *SARIFReporter) Close() error { return nil }
+
+// build assembles the SARIF document from findings.
+func (r *SARIFReporter) build(findings []*model.Finding) SARIFReport {
+	rules, ruleIndex := r.buildRules(findings)
+	results := make([]SARIFResult, 0, len(findings))
+	for _, f := range findings {
+		ruleID := f.TemplateID
+		if ruleID == "" {
+			ruleID = "hadrian.unknown"
+		}
+		idx, ok := ruleIndex[ruleID]
+		if !ok {
+			// Should not happen — buildRules covers every TemplateID present
+			// in findings — but guard against panics.
+			idx = 0
+		}
+		results = append(results, SARIFResult{
+			RuleID:              ruleID,
+			RuleIndex:           idx,
+			Level:               severityToSARIFLevel(f.Severity),
+			Message:             SARIFMessage{Text: buildResultMessage(f)},
+			Locations:           buildLocations(f),
+			PartialFingerprints: buildPartialFingerprints(f),
+			Properties:          buildResultProperties(f),
+		})
+	}
+
+	return SARIFReport{
+		Schema:  sarifSchema,
+		Version: sarifVersion,
+		Runs: []SARIFRun{{
+			Tool: SARIFTool{
+				Driver: SARIFDriver{
+					Name:           "Hadrian",
+					InformationURI: hadrianInformationURI,
+					Version:        Version,
+					Rules:          rules,
+				},
+			},
+			Results: results,
+			AutomationDetails: &SARIFRunAutomation{
+				ID: "hadrian",
+			},
+			ColumnKind: "utf16CodeUnits",
+		}},
+	}
+}
+
+// buildRules emits one SARIFRule per unique TemplateID found in `findings`.
+// Returns the slice in deterministic order plus a TemplateID->index map.
+func (r *SARIFReporter) buildRules(findings []*model.Finding) ([]SARIFRule, map[string]int) {
+	type seen struct {
+		first *model.Finding
+	}
+	uniq := map[string]seen{}
+	order := []string{}
+	for _, f := range findings {
+		id := f.TemplateID
+		if id == "" {
+			id = "hadrian.unknown"
+		}
+		if _, ok := uniq[id]; !ok {
+			uniq[id] = seen{first: f}
+			order = append(order, id)
+		}
+	}
+	sort.Strings(order)
+
+	rules := make([]SARIFRule, 0, len(order))
+	idx := make(map[string]int, len(order))
+	for i, id := range order {
+		rules = append(rules, r.ruleFor(id, uniq[id].first))
+		idx[id] = i
+	}
+	return rules, idx
+}
+
+// ruleFor builds a SARIFRule for a TemplateID. When a matching CompiledTemplate
+// is registered it provides richer metadata (description, helpUri, tags);
+// otherwise we synthesize a minimal rule from a sample finding.
+func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
+	rule := SARIFRule{
+		ID:   id,
+		Name: id,
+	}
+
+	if tmpl, ok := r.templates[id]; ok {
+		rule.ShortDescription = &SARIFMessage{Text: tmpl.Info.Name}
+		if tmpl.Info.Description != "" {
+			rule.FullDescription = &SARIFMessage{Text: tmpl.Info.Description}
+		}
+		rule.HelpURI = templateHelpURI(tmpl.FilePath)
+		rule.DefaultConfiguration = &SARIFConfiguration{
+			Level: severityToSARIFLevel(model.Severity(tmpl.Info.Severity)),
+		}
+		tags := []string{"security"}
+		if tmpl.Info.Category != "" {
+			tags = append(tags, tmpl.Info.Category)
+		}
+		tags = append(tags, tmpl.Info.Tags...)
+		rule.Properties = &SARIFRuleProperties{
+			Tags:      dedupeStrings(tags),
+			Precision: "high",
+		}
+		return rule
+	}
+
+	if sample != nil {
+		if sample.Name != "" {
+			rule.ShortDescription = &SARIFMessage{Text: sample.Name}
+		}
+		if sample.Description != "" {
+			rule.FullDescription = &SARIFMessage{Text: sample.Description}
+		}
+		rule.HelpURI = templateWikiURL
+		rule.DefaultConfiguration = &SARIFConfiguration{
+			Level: severityToSARIFLevel(sample.Severity),
+		}
+		tags := []string{"security"}
+		if sample.Category != "" {
+			tags = append(tags, sample.Category)
+		}
+		rule.Properties = &SARIFRuleProperties{
+			Tags:      dedupeStrings(tags),
+			Precision: "high",
+		}
+	} else {
+		rule.HelpURI = templateWikiURL
+	}
+	return rule
+}
+
+// templateHelpURI returns a stable GitHub URL for built-in templates
+// (paths starting with "templates/"), and a fallback wiki URL otherwise.
+func templateHelpURI(filePath string) string {
+	if filePath == "" {
+		return templateWikiURL
+	}
+	// Built-in templates ship under templates/{rest,graphql,grpc}/...
+	// Normalize Windows separators just in case.
+	normalized := strings.ReplaceAll(filePath, "\\", "/")
+	if i := strings.Index(normalized, "templates/"); i >= 0 {
+		return templateBaseURL + normalized[i:]
+	}
+	return templateWikiURL
+}
+
+// severityToSARIFLevel maps Hadrian severities to SARIF's notification levels.
+// SARIF values: "error", "warning", "note", "none".
+func severityToSARIFLevel(s model.Severity) string {
+	switch s {
+	case model.SeverityCritical, model.SeverityHigh:
+		return "error"
+	case model.SeverityMedium:
+		return "warning"
+	case model.SeverityLow, model.SeverityInfo:
+		return "note"
+	default:
+		return "warning"
+	}
+}
+
+// buildLocations renders a SARIF location pair (physical + logical) describing
+// the API endpoint that produced the finding. SARIF requires a physical
+// location for results that participate in code scanning, so we synthesize one
+// from the operation's METHOD + PATH.
+func buildLocations(f *model.Finding) []SARIFLocation {
+	uri := f.Endpoint
+	if uri == "" {
+		uri = "unknown"
+	}
+	logical := strings.TrimSpace(strings.ToUpper(f.Method) + " " + f.Endpoint)
+	return []SARIFLocation{{
+		PhysicalLocation: &SARIFPhysicalLocation{
+			ArtifactLocation: SARIFArtifactLocation{
+				URI: uri,
+			},
+			Region: &SARIFRegion{StartLine: 1},
+		},
+		LogicalLocations: []SARIFLogicalLocation{{
+			Name: logical,
+			Kind: "function",
+		}},
+	}}
+}
+
+// buildPartialFingerprints emits a stable fingerprint GitHub Code Scanning
+// uses to deduplicate alerts across runs.
+//
+// Inputs are intentionally limited to stable identity fields. We deliberately
+// exclude timestamps, request IDs, response bodies, and LLM analysis output.
+func buildPartialFingerprints(f *model.Finding) map[string]string {
+	parts := []string{
+		f.TemplateID,
+		strings.ToUpper(f.Method),
+		f.Endpoint,
+		f.AttackerRole,
+		f.VictimRole,
+	}
+	h := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return map[string]string{
+		"primaryLocationHash/v1": hex.EncodeToString(h[:]),
+	}
+}
+
+// buildResultMessage renders the human-readable message for a SARIF result.
+func buildResultMessage(f *model.Finding) string {
+	header := f.Name
+	if header == "" {
+		header = f.TemplateID
+	}
+	if header == "" {
+		header = "Security finding"
+	}
+
+	var b strings.Builder
+	b.WriteString(header)
+	if f.Method != "" || f.Endpoint != "" {
+		b.WriteString(" on ")
+		b.WriteString(strings.TrimSpace(strings.ToUpper(f.Method) + " " + f.Endpoint))
+	}
+	if f.AttackerRole != "" {
+		b.WriteString(" (attacker=")
+		b.WriteString(f.AttackerRole)
+		if f.VictimRole != "" {
+			b.WriteString(", victim=")
+			b.WriteString(f.VictimRole)
+		}
+		b.WriteString(")")
+	}
+	if f.Description != "" {
+		b.WriteString(". ")
+		b.WriteString(f.Description)
+	}
+	return b.String()
+}
+
+// buildResultProperties carries Hadrian-specific metadata that SARIF consumers
+// (e.g., GitHub Code Scanning UI) display under "Properties".
+func buildResultProperties(f *model.Finding) map[string]any {
+	props := map[string]any{
+		"category":        f.Category,
+		"isVulnerability": f.IsVulnerability,
+	}
+	if f.AttackerRole != "" {
+		props["attackerRole"] = f.AttackerRole
+	}
+	if f.VictimRole != "" {
+		props["victimRole"] = f.VictimRole
+	}
+	if f.Confidence > 0 {
+		props["confidence"] = f.Confidence
+	}
+	if f.LLMAnalysis != nil {
+		props["llmConfidence"] = f.LLMAnalysis.Confidence
+		props["llmProvider"] = f.LLMAnalysis.Provider
+	}
+	return props
+}
+
+// dedupeStrings returns the input slice with empty values removed and
+// duplicates collapsed, preserving first-seen order.
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/pkg/runner/sarif.go
+++ b/pkg/runner/sarif.go
@@ -204,12 +204,29 @@ func (r *SARIFReporter) build(findings []*model.Finding) SARIFReport {
 				},
 			},
 			Results: results,
+			// Static run id. GitHub Code Scanning separates runs by the
+			// upload-sarif `category` parameter (see the example workflow), not
+			// by automationDetails.id, so a constant value is intentional here —
+			// it is not a per-run unique identifier.
 			AutomationDetails: &SARIFRunAutomation{
 				ID: "hadrian",
 			},
 			ColumnKind: "utf16CodeUnits",
 		}},
 	}
+}
+
+// ruleID returns the SARIF rule identifier for a finding: its TemplateID, or
+// the "hadrian.unknown" sentinel when the finding carries no template ID.
+// buildRules, buildResults, and buildPartialFingerprints all route through this
+// so a result's ruleId and its partialFingerprint can never derive from
+// different values (an empty TemplateID would otherwise hash "" while the rule
+// is named "hadrian.unknown").
+func ruleID(f *model.Finding) string {
+	if f.TemplateID == "" {
+		return "hadrian.unknown"
+	}
+	return f.TemplateID
 }
 
 // buildResults maps findings to SARIF results given a TemplateID→index map.
@@ -223,21 +240,18 @@ func (r *SARIFReporter) build(findings []*model.Finding) SARIFReport {
 func (r *SARIFReporter) buildResults(findings []*model.Finding, ruleIndex map[string]int) []SARIFResult {
 	results := make([]SARIFResult, 0, len(findings))
 	for _, f := range findings {
-		ruleID := f.TemplateID
-		if ruleID == "" {
-			ruleID = "hadrian.unknown"
-		}
-		idx, ok := ruleIndex[ruleID]
+		rid := ruleID(f)
+		idx, ok := ruleIndex[rid]
 		if !ok {
 			// buildRules walks the same finding set, so this branch indicates
 			// an invariant violation (refactor regression, future loader bug,
 			// concurrent mutation). Surface it rather than silently emitting a
 			// SARIF result that points at the wrong rule.
-			log.Warn("SARIF: dropping finding with ruleID %q — no matching entry in driver.rules (invariant violation)", ruleID)
+			log.Warn("SARIF: dropping finding with ruleID %q — no matching entry in driver.rules (invariant violation)", rid)
 			continue
 		}
 		results = append(results, SARIFResult{
-			RuleID:              ruleID,
+			RuleID:              rid,
 			RuleIndex:           idx,
 			Level:               severityToSARIFLevel(f.Severity),
 			Message:             SARIFMessage{Text: r.redactor.Redact(buildResultMessage(f))},
@@ -258,10 +272,7 @@ func (r *SARIFReporter) buildRules(findings []*model.Finding) ([]SARIFRule, map[
 	uniq := map[string]seen{}
 	order := []string{}
 	for _, f := range findings {
-		id := f.TemplateID
-		if id == "" {
-			id = "hadrian.unknown"
-		}
+		id := ruleID(f)
 		if _, ok := uniq[id]; !ok {
 			uniq[id] = seen{first: f}
 			order = append(order, id)
@@ -287,6 +298,8 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 		Name: id,
 	}
 
+	// Template-enriched path: a CompiledTemplate is registered for this id, so
+	// description/helpUri/tags/severity come from its author-controlled metadata.
 	if tmpl, ok := r.templates[id]; ok {
 		rule.ShortDescription = &SARIFMessage{Text: tmpl.Info.Name}
 		if tmpl.Info.Description != "" {
@@ -314,6 +327,9 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 		return rule
 	}
 
+	// Finding-derived fallback: no template registered (e.g. the GraphQL
+	// non-template scanner), so synthesize a minimal rule from a sample finding
+	// and point helpUri at the wiki.
 	if sample != nil {
 		if sample.Name != "" {
 			rule.ShortDescription = &SARIFMessage{Text: sample.Name}
@@ -447,7 +463,10 @@ func buildLocations(f *model.Finding) []SARIFLocation {
 // existing alerts are not orphaned).
 func buildPartialFingerprints(f *model.Finding) map[string]string {
 	parts := []string{
-		f.TemplateID,
+		// Use the normalized rule id (not the raw TemplateID) so the fingerprint
+		// matches the ruleId emitted in the same SARIFResult — an empty
+		// TemplateID must hash "hadrian.unknown", not "".
+		ruleID(f),
 		strings.ToUpper(f.Method),
 		f.Endpoint,
 		f.AttackerRole,

--- a/pkg/runner/sarif.go
+++ b/pkg/runner/sarif.go
@@ -34,6 +34,12 @@ const (
 	templateBaseURL       = "https://github.com/praetorian-inc/hadrian/blob/main/"
 	templateWikiURL       = "https://github.com/praetorian-inc/hadrian/wiki/Template-System"
 
+	// defaultPrecision is the SARIF rule precision Hadrian reports. Hadrian
+	// templates don't carry a per-rule precision signal today, so "medium" is a
+	// conservative default that avoids overstating confidence to SARIF consumers
+	// (GitHub UI, Code Scanning APIs).
+	defaultPrecision = "medium"
+
 	// fingerprintFieldSep separates identity fields when computing
 	// partialFingerprints. NUL is used because it cannot legitimately appear in
 	// any of the inputs (template IDs, HTTP methods, paths, role names) — joining
@@ -318,11 +324,8 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 		}
 		tags = append(tags, tmpl.Info.Tags...)
 		rule.Properties = &SARIFRuleProperties{
-			Tags: dedupeStrings(tags),
-			// Hadrian templates don't carry a per-rule precision signal today;
-			// "medium" is a conservative default that avoids overstating
-			// confidence to SARIF consumers (GitHub UI, Code Scanning APIs).
-			Precision: "medium",
+			Tags:      dedupeStrings(tags),
+			Precision: defaultPrecision,
 		}
 		return rule
 	}
@@ -351,11 +354,8 @@ func (r *SARIFReporter) ruleFor(id string, sample *model.Finding) SARIFRule {
 			tags = append(tags, sample.Category)
 		}
 		rule.Properties = &SARIFRuleProperties{
-			Tags: dedupeStrings(tags),
-			// Hadrian templates don't carry a per-rule precision signal today;
-			// "medium" is a conservative default that avoids overstating
-			// confidence to SARIF consumers (GitHub UI, Code Scanning APIs).
-			Precision: "medium",
+			Tags:      dedupeStrings(tags),
+			Precision: defaultPrecision,
 		}
 	} else {
 		rule.HelpURI = templateWikiURL

--- a/pkg/runner/sarif.go
+++ b/pkg/runner/sarif.go
@@ -195,6 +195,38 @@ func (r *SARIFReporter) Close() error { return nil }
 // build assembles the SARIF document from findings.
 func (r *SARIFReporter) build(findings []*model.Finding) SARIFReport {
 	rules, ruleIndex := r.buildRules(findings)
+	results := r.buildResults(findings, ruleIndex)
+
+	return SARIFReport{
+		Schema:  sarifSchema,
+		Version: sarifVersion,
+		Runs: []SARIFRun{{
+			Tool: SARIFTool{
+				Driver: SARIFDriver{
+					Name:           "Hadrian",
+					InformationURI: hadrianInformationURI,
+					Version:        Version,
+					Rules:          rules,
+				},
+			},
+			Results: results,
+			AutomationDetails: &SARIFRunAutomation{
+				ID: "hadrian",
+			},
+			ColumnKind: "utf16CodeUnits",
+		}},
+	}
+}
+
+// buildResults maps findings to SARIF results given a TemplateID→index map.
+//
+// Extracted from build() so the invariant-violation branch (a finding whose
+// ruleID is not in ruleIndex) is unit-testable. In normal flow buildRules
+// produces ruleIndex from the same finding set, so the !ok case should never
+// fire — but the defensive log.Warn+skip exists to surface future refactor
+// regressions, and a regression test for it must be able to inject an
+// inconsistent ruleIndex.
+func (r *SARIFReporter) buildResults(findings []*model.Finding, ruleIndex map[string]int) []SARIFResult {
 	results := make([]SARIFResult, 0, len(findings))
 	for _, f := range findings {
 		ruleID := f.TemplateID
@@ -220,26 +252,7 @@ func (r *SARIFReporter) build(findings []*model.Finding) SARIFReport {
 			Properties:          buildResultProperties(f),
 		})
 	}
-
-	return SARIFReport{
-		Schema:  sarifSchema,
-		Version: sarifVersion,
-		Runs: []SARIFRun{{
-			Tool: SARIFTool{
-				Driver: SARIFDriver{
-					Name:           "Hadrian",
-					InformationURI: hadrianInformationURI,
-					Version:        Version,
-					Rules:          rules,
-				},
-			},
-			Results: results,
-			AutomationDetails: &SARIFRunAutomation{
-				ID: "hadrian",
-			},
-			ColumnKind: "utf16CodeUnits",
-		}},
-	}
+	return results
 }
 
 // buildRules emits one SARIFRule per unique TemplateID found in `findings`.

--- a/pkg/runner/sarif.go
+++ b/pkg/runner/sarif.go
@@ -407,7 +407,11 @@ func buildLocations(f *model.Finding) []SARIFLocation {
 	if uri == "" {
 		uri = "unknown"
 	}
-	logical := strings.TrimSpace(strings.ToUpper(f.Method) + " " + f.Endpoint)
+	logical := formatMethodEndpoint(f)
+	if logical == "" {
+		// Mirror the physical URI fallback so the logical name is never blank.
+		logical = "unknown"
+	}
 	return []SARIFLocation{{
 		PhysicalLocation: &SARIFPhysicalLocation{
 			ArtifactLocation: SARIFArtifactLocation{
@@ -455,6 +459,13 @@ func buildPartialFingerprints(f *model.Finding) map[string]string {
 	}
 }
 
+// formatMethodEndpoint renders a finding's operation as "METHOD /path" (method
+// upper-cased, surrounding whitespace trimmed). Returns "" when both fields are
+// empty. Shared by buildLocations (logical-location name) and buildResultMessage.
+func formatMethodEndpoint(f *model.Finding) string {
+	return strings.TrimSpace(strings.ToUpper(f.Method) + " " + f.Endpoint)
+}
+
 // buildResultMessage renders the human-readable message for a SARIF result.
 func buildResultMessage(f *model.Finding) string {
 	header := f.Name
@@ -469,7 +480,7 @@ func buildResultMessage(f *model.Finding) string {
 	b.WriteString(header)
 	if f.Method != "" || f.Endpoint != "" {
 		b.WriteString(" on ")
-		b.WriteString(strings.TrimSpace(strings.ToUpper(f.Method) + " " + f.Endpoint))
+		b.WriteString(formatMethodEndpoint(f))
 	}
 	if f.AttackerRole != "" {
 		b.WriteString(" (attacker=")
@@ -491,8 +502,10 @@ func buildResultMessage(f *model.Finding) string {
 // (e.g., GitHub Code Scanning UI) display under "Properties".
 func buildResultProperties(f *model.Finding) map[string]any {
 	props := map[string]any{
-		"category":        f.Category,
 		"isVulnerability": f.IsVulnerability,
+	}
+	if f.Category != "" {
+		props["category"] = f.Category
 	}
 	if f.AttackerRole != "" {
 		props["attackerRole"] = f.AttackerRole

--- a/pkg/runner/sarif_schema_test.go
+++ b/pkg/runner/sarif_schema_test.go
@@ -1,0 +1,95 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/templates"
+)
+
+// loadSARIFSchema compiles the SARIF v2.1.0 JSON Schema bundled in testdata.
+// The file is a verbatim copy of https://json.schemastore.org/sarif-2.1.0.json
+// — refreshing it from upstream is the only maintenance burden.
+func loadSARIFSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	path := filepath.Join("testdata", "sarif-2.1.0.json")
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var schemaDoc any
+	require.NoError(t, json.Unmarshal(raw, &schemaDoc))
+
+	c := jsonschema.NewCompiler()
+	require.NoError(t, c.AddResource("sarif-2.1.0.json", schemaDoc))
+	schema, err := c.Compile("sarif-2.1.0.json")
+	require.NoError(t, err)
+	return schema
+}
+
+// validateAgainstSARIFSchema parses the file at `path` and validates it against
+// the SARIF v2.1.0 schema. Fails the test with a readable error on mismatch.
+func validateAgainstSARIFSchema(t *testing.T, schema *jsonschema.Schema, path string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var doc any
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	if err := schema.Validate(doc); err != nil {
+		t.Fatalf("SARIF document at %s does not validate against schema:\n%s", path, err)
+	}
+}
+
+// TestSARIFReporter_ValidatesAgainstSchema is the load-bearing acceptance test
+// for LAB-2747: the file must validate against the canonical SARIF v2.1.0
+// schema, which is exactly what GitHub Code Scanning enforces on upload.
+func TestSARIFReporter_ValidatesAgainstSchema(t *testing.T) {
+	schema := loadSARIFSchema(t)
+
+	out := filepath.Join(t.TempDir(), "report.sarif")
+	tmpl := sampleTemplate("01-api1-bola-read")
+	rep, err := NewSARIFReporter(out, []*templates.CompiledTemplate{tmpl})
+	require.NoError(t, err)
+
+	findings := []*model.Finding{
+		sampleFinding(),
+		{
+			ID:           "02-api2-broken-auth-1",
+			TemplateID:   "04-api2-broken-auth-no-token",
+			Category:     "API2:2023",
+			Name:         "Missing authentication",
+			Description:  "Endpoint accepts requests without a token",
+			Severity:     model.SeverityCritical,
+			Method:       "GET",
+			Endpoint:     "/api/admin/users",
+			AttackerRole: "anonymous",
+		},
+		{
+			ID:         "graphql-introspection-1",
+			TemplateID: "introspection-disclosure",
+			Category:   "API8:2023 Security Misconfiguration",
+			Name:       "introspection-disclosure",
+			Severity:   model.SeverityMedium,
+			Method:     "POST",
+			Endpoint:   "/graphql",
+		},
+	}
+
+	require.NoError(t, rep.GenerateReport(findings, &Stats{}))
+	validateAgainstSARIFSchema(t, schema, out)
+}
+
+func TestSARIFReporter_ValidatesAgainstSchema_Empty(t *testing.T) {
+	// Empty result set is also valid SARIF (a scan that found nothing).
+	schema := loadSARIFSchema(t)
+	out := filepath.Join(t.TempDir(), "empty.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	require.NoError(t, rep.GenerateReport(nil, &Stats{}))
+	validateAgainstSARIFSchema(t, schema, out)
+}

--- a/pkg/runner/sarif_schema_test.go
+++ b/pkg/runner/sarif_schema_test.go
@@ -93,3 +93,29 @@ func TestSARIFReporter_ValidatesAgainstSchema_Empty(t *testing.T) {
 	require.NoError(t, rep.GenerateReport(nil, &Stats{}))
 	validateAgainstSARIFSchema(t, schema, out)
 }
+
+// TestSARIFSchema_RejectsInvalidDocuments proves the schema validator is not a
+// no-op: documents that violate the SARIF v2.1.0 schema must fail validation.
+// Without this, a regression that loaded an empty/permissive schema would let
+// TestSARIFReporter_ValidatesAgainstSchema pass against anything.
+func TestSARIFSchema_RejectsInvalidDocuments(t *testing.T) {
+	schema := loadSARIFSchema(t)
+	cases := []struct {
+		name string
+		doc  string
+	}{
+		{"missing required runs", `{"version": "2.1.0"}`},
+		{"runs is wrong type", `{"version": "2.1.0", "runs": "not-an-array"}`},
+		{"missing version", `{"runs": []}`},
+		{"empty object", `{}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var doc any
+			require.NoError(t, json.Unmarshal([]byte(tc.doc), &doc))
+			require.Error(t, schema.Validate(doc),
+				"expected schema to reject invalid SARIF document %q", tc.doc)
+		})
+	}
+}

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -585,6 +585,10 @@ func TestSARIFReporter_ResultProperties_CategoryOmittedWhenEmpty(t *testing.T) {
 		props := readSARIF(t, out).Runs[0].Results[0].Properties
 		assert.Equal(t, "API1:2023", props["category"])
 		assert.Equal(t, true, props["isVulnerability"])
+		// Role/confidence properties (sampleFinding sets attacker/victim and 0.9).
+		assert.Equal(t, "attacker", props["attackerRole"])
+		assert.Equal(t, "victim", props["victimRole"])
+		assert.InDelta(t, 0.9, props["confidence"], 1e-9)
 	})
 
 	t.Run("category omitted when empty", func(t *testing.T) {
@@ -598,6 +602,36 @@ func TestSARIFReporter_ResultProperties_CategoryOmittedWhenEmpty(t *testing.T) {
 		assert.NotContains(t, props, "category")
 		assert.Equal(t, true, props["isVulnerability"], "non-optional props still present")
 	})
+}
+
+// The fingerprint upper-cases Method so a scan emitting "get" and a later scan
+// emitting "GET" for the same operation dedupe to one GitHub alert. A dropped
+// ToUpper would silently reopen alerts; this pins the normalization.
+func TestSARIFReporter_PartialFingerprints_MethodCaseInsensitive(t *testing.T) {
+	lower := sampleFinding()
+	lower.Method = "get"
+	upper := sampleFinding()
+	upper.Method = "GET"
+	assert.Equal(t,
+		buildPartialFingerprints(upper)["primaryLocationHash/v1"],
+		buildPartialFingerprints(lower)["primaryLocationHash/v1"],
+		"method case must not change the fingerprint")
+}
+
+// Run-level metadata (columnKind, automationDetails.id) and the rule precision
+// are schema-optional, so the schema test won't catch their removal. Pin them.
+func TestSARIFReporter_RunLevelMetadata(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "meta.sarif")
+	tmpl := sampleTemplate("01-api1-bola-read")
+	rep, err := NewSARIFReporter(out, []*templates.CompiledTemplate{tmpl})
+	require.NoError(t, err)
+	require.NoError(t, rep.GenerateReport([]*model.Finding{sampleFinding()}, &Stats{}))
+	run := readSARIF(t, out).Runs[0]
+	assert.Equal(t, "utf16CodeUnits", run.ColumnKind)
+	require.NotNil(t, run.AutomationDetails)
+	assert.Equal(t, "hadrian", run.AutomationDetails.ID)
+	require.NotNil(t, run.Tool.Driver.Rules[0].Properties)
+	assert.Equal(t, "medium", run.Tool.Driver.Rules[0].Properties.Precision)
 }
 
 // ruleFor has conditional branches for missing template description / sample

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -198,6 +198,34 @@ func TestSARIFReporter_PartialFingerprintsDifferWhenIdentityChanges(t *testing.T
 	}
 }
 
+// QUAL-006 / SEC-BE-002 regression test: two findings whose identity fields
+// would collide under a printable delimiter (e.g. "|") must still produce
+// distinct fingerprints. The NUL separator guarantees this.
+func TestSARIFReporter_PartialFingerprintsResistDelimiterCollision(t *testing.T) {
+	// Without NUL separation, both joins would collapse to:
+	//   "tpl|GET|/foo|attacker|"
+	// Two distinct (TemplateID, Endpoint) tuples can shift the boundary so
+	// joined strings match; assert their hashes differ regardless.
+	a := &model.Finding{
+		TemplateID:   "tpl",
+		Method:       "GET",
+		Endpoint:     "/foo|attacker|",
+		AttackerRole: "",
+		VictimRole:   "",
+	}
+	b := &model.Finding{
+		TemplateID:   "tpl",
+		Method:       "GET",
+		Endpoint:     "/foo",
+		AttackerRole: "attacker",
+		VictimRole:   "",
+	}
+	assert.NotEqual(t,
+		buildPartialFingerprints(a)["primaryLocationHash/v1"],
+		buildPartialFingerprints(b)["primaryLocationHash/v1"],
+		"delimiter-collision-resistant fingerprinting expected")
+}
+
 func TestSeverityToSARIFLevel(t *testing.T) {
 	cases := map[model.Severity]string{
 		model.SeverityCritical: "error",
@@ -214,18 +242,27 @@ func TestSeverityToSARIFLevel(t *testing.T) {
 
 func TestTemplateHelpURI(t *testing.T) {
 	cases := []struct {
+		name     string
 		filePath string
 		want     string
 	}{
-		{"", templateWikiURL},
-		{"templates/rest/01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
-		{"./templates/graphql/foo.yaml", templateBaseURL + "templates/graphql/foo.yaml"},
-		{"/abs/path/templates/grpc/bar.yaml", templateBaseURL + "templates/grpc/bar.yaml"},
-		{"/some/custom/path/my-template.yaml", templateWikiURL},
-		{"templates\\rest\\01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
+		{"empty path", "", templateWikiURL},
+		{"built-in rest", "templates/rest/01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
+		{"built-in graphql with leading ./", "./templates/graphql/foo.yaml", templateBaseURL + "templates/graphql/foo.yaml"},
+		{"built-in grpc with Windows separators", "templates\\rest\\01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
+		// QUAL-005 fix: absolute paths that contain "templates/" as a non-prefix
+		// segment must NOT be mapped to hadrian's GitHub blob — they are custom
+		// templates that live outside the built-in tree.
+		{"custom abs path with templates/ as a non-prefix segment", "/abs/path/templates/grpc/bar.yaml", templateWikiURL},
+		{"custom path with sub-templates dir", "/opt/work/sub-templates/api.yaml", templateWikiURL},
+		{"custom path with my-templates dir", "/home/user/my-templates/foo.yaml", templateWikiURL},
+		{"completely custom path", "/some/custom/path/my-template.yaml", templateWikiURL},
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.want, templateHelpURI(tc.filePath), "filePath=%q", tc.filePath)
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, templateHelpURI(tc.filePath))
+		})
 	}
 }
 
@@ -369,6 +406,80 @@ func TestSARIFReporter_ReportFindingIsNoOp(t *testing.T) {
 	require.NoError(t, rep.GenerateReport(nil, &Stats{}))
 	doc := readSARIF(t, out)
 	assert.Empty(t, doc.Runs[0].Results, "ReportFinding must not mutate state")
+}
+
+// SARIF documents are documented as upload-ready to GitHub Code Scanning, so
+// any tokens / PII the scanned API returned in a Finding.Description must be
+// redacted before they reach the SARIF document. Counterpart to SEC-BE-001.
+func TestSARIFReporter_RedactsTokensInResultMessage(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "redacted.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	leaky := sampleFinding()
+	leaky.Description = "response carried bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def and an email user@example.com"
+	require.NoError(t, rep.GenerateReport([]*model.Finding{leaky}, &Stats{}))
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Results, 1)
+	msg := doc.Runs[0].Results[0].Message.Text
+	assert.NotContains(t, msg, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def", "JWT must be redacted")
+	assert.NotContains(t, msg, "user@example.com", "email must be redacted")
+}
+
+// QUAL-005 / SEC-BE: SARIF files may carry sensitive content, so the file
+// must be written with owner-only (0600) permissions.
+func TestSARIFReporter_WritesFileWith0600Mode(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "mode.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	require.NoError(t, rep.GenerateReport([]*model.Finding{sampleFinding()}, &Stats{}))
+	info, err := os.Stat(out)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+// Findings with no endpoint must still produce a syntactically valid SARIF
+// location — the spec requires an artifactLocation.uri.
+func TestSARIFReporter_HandlesEmptyEndpoint(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "noendpoint.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	f := sampleFinding()
+	f.Endpoint = ""
+	require.NoError(t, rep.GenerateReport([]*model.Finding{f}, &Stats{}))
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Results, 1)
+	require.Len(t, doc.Runs[0].Results[0].Locations, 1)
+	assert.Equal(t, "unknown", doc.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
+}
+
+// ruleFor has conditional branches for missing template description / sample
+// name. Both should emit a valid (if minimal) rule object.
+func TestSARIFReporter_RuleForEmptyBranches(t *testing.T) {
+	t.Run("template with empty description", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "tmpl-emptydesc.sarif")
+		tmpl := sampleTemplate("01-api1-bola-read")
+		tmpl.Info.Description = ""
+		rep, err := NewSARIFReporter(out, []*templates.CompiledTemplate{tmpl})
+		require.NoError(t, err)
+		require.NoError(t, rep.GenerateReport([]*model.Finding{sampleFinding()}, &Stats{}))
+		doc := readSARIF(t, out)
+		require.Len(t, doc.Runs[0].Tool.Driver.Rules, 1)
+		assert.Nil(t, doc.Runs[0].Tool.Driver.Rules[0].FullDescription, "empty template description should omit FullDescription")
+	})
+
+	t.Run("finding with empty Name and no template", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "nomatch.sarif")
+		rep, err := NewSARIFReporter(out, nil)
+		require.NoError(t, err)
+		f := sampleFinding()
+		f.Name = ""
+		f.Description = ""
+		require.NoError(t, rep.GenerateReport([]*model.Finding{f}, &Stats{}))
+		doc := readSARIF(t, out)
+		require.Len(t, doc.Runs[0].Tool.Driver.Rules, 1)
+		assert.Nil(t, doc.Runs[0].Tool.Driver.Rules[0].ShortDescription, "empty finding name should omit ShortDescription")
+		assert.Nil(t, doc.Runs[0].Tool.Driver.Rules[0].FullDescription, "empty finding description should omit FullDescription")
+	})
 }
 
 // readSARIF reads and parses a SARIF document, failing the test on any error.

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -198,6 +198,43 @@ func TestSARIFReporter_PartialFingerprintsDifferWhenIdentityChanges(t *testing.T
 	}
 }
 
+// TestSARIFReporter_BuildResults_DropsFindingWhenRuleIDMissing exercises the
+// invariant-violation branch in buildResults: when a finding's ruleID is not
+// in the supplied ruleIndex, the result is dropped (log.Warn + skip). In
+// normal flow buildRules produces ruleIndex from the same finding set, so the
+// branch is impossible to reach via build(); the regression test injects an
+// inconsistent ruleIndex directly to prove the defensive fallback fires.
+func TestSARIFReporter_BuildResults_DropsFindingWhenRuleIDMissing(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "missing-rule.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+
+	f := sampleFinding()
+	f.TemplateID = "absent-from-index"
+
+	// Empty ruleIndex simulates the invariant violation. buildResults must
+	// drop the finding rather than emit a SARIF result pointing at index 0.
+	results := rep.buildResults([]*model.Finding{f}, map[string]int{})
+
+	assert.Empty(t, results, "finding with missing ruleID must be dropped, not emitted with wrong index")
+}
+
+// Companion: when ruleIndex contains the ruleID, buildResults emits the result
+// with the correct index. Prevents an over-zealous regression that drops every
+// finding.
+func TestSARIFReporter_BuildResults_EmitsWhenRuleIDPresent(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "present-rule.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+
+	f := sampleFinding()
+	results := rep.buildResults([]*model.Finding{f}, map[string]int{f.TemplateID: 7})
+
+	require.Len(t, results, 1)
+	assert.Equal(t, f.TemplateID, results[0].RuleID)
+	assert.Equal(t, 7, results[0].RuleIndex)
+}
+
 // QUAL-006 / SEC-BE-002 regression test: two findings whose identity fields
 // would collide under a printable delimiter (e.g. "|") must still produce
 // distinct fingerprints. The NUL separator guarantees this.

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -549,6 +549,32 @@ func TestSARIFReporter_LogicalNameFallsBackWhenMethodAndEndpointEmpty(t *testing
 	assert.Equal(t, "unknown", loc.LogicalLocations[0].Name)
 }
 
+// buildResultProperties emits "category" only when non-empty (consistent with
+// the other optional properties). Both branches are pinned here.
+func TestSARIFReporter_ResultProperties_CategoryOmittedWhenEmpty(t *testing.T) {
+	t.Run("category present when set", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "cat.sarif")
+		rep, err := NewSARIFReporter(out, nil)
+		require.NoError(t, err)
+		require.NoError(t, rep.GenerateReport([]*model.Finding{sampleFinding()}, &Stats{}))
+		props := readSARIF(t, out).Runs[0].Results[0].Properties
+		assert.Equal(t, "API1:2023", props["category"])
+		assert.Equal(t, true, props["isVulnerability"])
+	})
+
+	t.Run("category omitted when empty", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "nocat.sarif")
+		rep, err := NewSARIFReporter(out, nil)
+		require.NoError(t, err)
+		f := sampleFinding()
+		f.Category = ""
+		require.NoError(t, rep.GenerateReport([]*model.Finding{f}, &Stats{}))
+		props := readSARIF(t, out).Runs[0].Results[0].Properties
+		assert.NotContains(t, props, "category")
+		assert.Equal(t, true, props["isVulnerability"], "non-optional props still present")
+	})
+}
+
 // ruleFor has conditional branches for missing template description / sample
 // name. Both should emit a valid (if minimal) rule object.
 func TestSARIFReporter_RuleForEmptyBranches(t *testing.T) {

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -287,12 +287,18 @@ func TestTemplateHelpURI(t *testing.T) {
 		{"built-in rest", "templates/rest/01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
 		{"built-in graphql with leading ./", "./templates/graphql/foo.yaml", templateBaseURL + "templates/graphql/foo.yaml"},
 		{"built-in grpc with Windows separators", "templates\\rest\\01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
-		// QUAL-005 fix: absolute paths that contain "templates/" as a non-prefix
-		// segment must NOT be mapped to hadrian's GitHub blob — they are custom
-		// templates that live outside the built-in tree.
-		{"custom abs path with templates/ as a non-prefix segment", "/abs/path/templates/grpc/bar.yaml", templateWikiURL},
+		// N1 fix: the canonical blob URL must resolve for built-in templates no
+		// matter how the loader reached them — anchoring on the
+		// templates/{rest,graphql,grpc}/ segment (not a leading prefix) covers
+		// absolute --template-dir, $HADRIAN_TEMPLATES, and ../../ relative paths.
+		{"built-in via absolute --template-dir", "/opt/hadrian/templates/grpc/bar.yaml", templateBaseURL + "templates/grpc/bar.yaml"},
+		{"built-in via ../../ relative path", "../../templates/rest/01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
+		// Custom layouts whose path merely contains "templates" as a fragment of
+		// another directory name must still fall back to the wiki — the segment
+		// only matches on a path boundary (start of string or after "/").
 		{"custom path with sub-templates dir", "/opt/work/sub-templates/api.yaml", templateWikiURL},
 		{"custom path with my-templates dir", "/home/user/my-templates/foo.yaml", templateWikiURL},
+		{"custom path with my-templates/rest dir", "/home/user/my-templates/rest/foo.yaml", templateWikiURL},
 		{"completely custom path", "/some/custom/path/my-template.yaml", templateWikiURL},
 	}
 	for _, tc := range cases {

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -174,6 +174,31 @@ func TestSARIFReporter_PartialFingerprintsAreStable(t *testing.T) {
 		"fingerprints should not depend on transient state")
 }
 
+// A finding with no TemplateID is emitted with ruleId "hadrian.unknown"; its
+// fingerprint must hash that same normalized id (not the raw empty string), so
+// the ruleId in the SARIFResult and the value the fingerprint derives from stay
+// consistent. Pins the buildResults/buildPartialFingerprints normalization.
+func TestSARIFReporter_PartialFingerprints_NormalizeMissingTemplateID(t *testing.T) {
+	empty := sampleFinding()
+	empty.TemplateID = ""
+
+	named := sampleFinding()
+	named.TemplateID = "hadrian.unknown"
+
+	assert.Equal(t,
+		buildPartialFingerprints(named)["primaryLocationHash/v1"],
+		buildPartialFingerprints(empty)["primaryLocationHash/v1"],
+		"empty TemplateID must fingerprint as the normalized 'hadrian.unknown' rule id")
+
+	// And it must NOT collide with the literal empty-string hash that the old
+	// (raw f.TemplateID) behavior produced.
+	rawEmpty := sampleFinding()
+	rawEmpty.TemplateID = "\x00sentinel-not-equal" // any value != hadrian.unknown
+	assert.NotEqual(t,
+		buildPartialFingerprints(empty)["primaryLocationHash/v1"],
+		buildPartialFingerprints(rawEmpty)["primaryLocationHash/v1"])
+}
+
 func TestSARIFReporter_PartialFingerprintsDifferWhenIdentityChanges(t *testing.T) {
 	base := sampleFinding()
 	cases := []struct {

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -533,6 +533,22 @@ func TestSARIFReporter_HandlesEmptyEndpoint(t *testing.T) {
 	assert.Equal(t, "unknown", doc.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
 }
 
+// When both Method and Endpoint are empty, the logical-location name must fall
+// back to "unknown" rather than the empty string, mirroring the physical URI.
+func TestSARIFReporter_LogicalNameFallsBackWhenMethodAndEndpointEmpty(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "noop.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	f := sampleFinding()
+	f.Method = ""
+	f.Endpoint = ""
+	require.NoError(t, rep.GenerateReport([]*model.Finding{f}, &Stats{}))
+	doc := readSARIF(t, out)
+	loc := doc.Runs[0].Results[0].Locations[0]
+	assert.Equal(t, "unknown", loc.PhysicalLocation.ArtifactLocation.URI)
+	assert.Equal(t, "unknown", loc.LogicalLocations[0].Name)
+}
+
 // ruleFor has conditional branches for missing template description / sample
 // name. Both should emit a valid (if minimal) rule object.
 func TestSARIFReporter_RuleForEmptyBranches(t *testing.T) {

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -416,13 +416,51 @@ func TestSARIFReporter_RedactsTokensInResultMessage(t *testing.T) {
 	rep, err := NewSARIFReporter(out, nil)
 	require.NoError(t, err)
 	leaky := sampleFinding()
-	leaky.Description = "response carried bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def and an email user@example.com"
+	leaky.Description = "response carried bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.abc and an email user@example.com"
 	require.NoError(t, rep.GenerateReport([]*model.Finding{leaky}, &Stats{}))
 	doc := readSARIF(t, out)
 	require.Len(t, doc.Runs[0].Results, 1)
 	msg := doc.Runs[0].Results[0].Message.Text
-	assert.NotContains(t, msg, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def", "JWT must be redacted")
+	assert.NotContains(t, msg, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.abc", "JWT must be redacted")
 	assert.NotContains(t, msg, "user@example.com", "email must be redacted")
+}
+
+// SEC-BE: the rule fallback path (ruleFor when no compiled template matches —
+// hit by every GraphQL non-template finding) also writes Finding.Description
+// into rule.FullDescription. Without redaction there, the result-message
+// redaction would be bypassed for any consumer that inspects rule metadata.
+func TestSARIFReporter_RedactsTokensInRuleFullDescription_Fallback(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "rule-redact.sarif")
+	rep, err := NewSARIFReporter(out, nil) // no compiled templates → fallback branch
+	require.NoError(t, err)
+	leaky := sampleFinding()
+	leaky.TemplateID = "bola" // matches GraphQL non-template scanner shape
+	leaky.Description = "BOLA detected: victim id user@example.com via token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.abc"
+	require.NoError(t, rep.GenerateReport([]*model.Finding{leaky}, &Stats{}))
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Tool.Driver.Rules, 1)
+	require.NotNil(t, doc.Runs[0].Tool.Driver.Rules[0].FullDescription, "fallback rule should still emit FullDescription")
+	rdesc := doc.Runs[0].Tool.Driver.Rules[0].FullDescription.Text
+	assert.NotContains(t, rdesc, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.abc", "JWT in fallback rule FullDescription must be redacted")
+	assert.NotContains(t, rdesc, "user@example.com", "email in fallback rule FullDescription must be redacted")
+}
+
+// Same redaction guarantee on the template-known path. Less critical because
+// template descriptions are author-controlled YAML, but a regression that
+// reintroduces a raw assignment should still fail.
+func TestSARIFReporter_RedactsTokensInRuleFullDescription_TemplatePath(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "tmpl-rule-redact.sarif")
+	tmpl := sampleTemplate("01-api1-bola-read")
+	tmpl.Info.Description = "Tests for bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.abc leakage to user@example.com"
+	rep, err := NewSARIFReporter(out, []*templates.CompiledTemplate{tmpl})
+	require.NoError(t, err)
+	require.NoError(t, rep.GenerateReport([]*model.Finding{sampleFinding()}, &Stats{}))
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Tool.Driver.Rules, 1)
+	require.NotNil(t, doc.Runs[0].Tool.Driver.Rules[0].FullDescription)
+	rdesc := doc.Runs[0].Tool.Driver.Rules[0].FullDescription.Text
+	assert.NotContains(t, rdesc, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.abc")
+	assert.NotContains(t, rdesc, "user@example.com")
 }
 
 // QUAL-005 / SEC-BE: SARIF files may carry sensitive content, so the file

--- a/pkg/runner/sarif_test.go
+++ b/pkg/runner/sarif_test.go
@@ -1,0 +1,385 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/hadrian/pkg/model"
+	"github.com/praetorian-inc/hadrian/pkg/templates"
+)
+
+func sampleFinding() *model.Finding {
+	return &model.Finding{
+		ID:              "01-api1-bola-read-GET-/api/users/{id}-attacker-victim",
+		TemplateID:      "01-api1-bola-read",
+		Category:        "API1:2023",
+		Name:            "BOLA - Cross-User Resource Access (Read)",
+		Description:     "Lower-privileged attacker read victim's resource",
+		Severity:        model.SeverityHigh,
+		Endpoint:        "/api/users/{id}",
+		Method:          "GET",
+		AttackerRole:    "attacker",
+		VictimRole:      "victim",
+		IsVulnerability: true,
+		Confidence:      0.9,
+		Timestamp:       time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func sampleTemplate(id string) *templates.CompiledTemplate {
+	return &templates.CompiledTemplate{
+		Template: &templates.Template{
+			ID: id,
+			Info: templates.TemplateInfo{
+				Name:        "BOLA - Cross-User Resource Access (Read)",
+				Category:    "API1:2023",
+				Severity:    "HIGH",
+				Description: "Tests GET endpoints for unauthorized cross-user resource access",
+				Tags:        []string{"bola", "owasp"},
+			},
+		},
+		FilePath: "templates/rest/01-api1-bola-read.yaml",
+	}
+}
+
+func TestNewSARIFReporter_RequiresOutputFile(t *testing.T) {
+	_, err := NewSARIFReporter("", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--output-file")
+}
+
+func TestSARIFReporter_GenerateReport_Empty(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "empty.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	require.NoError(t, rep.GenerateReport(nil, &Stats{}))
+
+	doc := readSARIF(t, out)
+	assert.Equal(t, "2.1.0", doc.Version)
+	assert.Equal(t, sarifSchema, doc.Schema)
+	require.Len(t, doc.Runs, 1)
+	assert.Equal(t, "Hadrian", doc.Runs[0].Tool.Driver.Name)
+	assert.Empty(t, doc.Runs[0].Tool.Driver.Rules)
+	assert.Empty(t, doc.Runs[0].Results)
+}
+
+func TestSARIFReporter_GenerateReport_SingleFinding(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "single.sarif")
+	tmpl := sampleTemplate("01-api1-bola-read")
+	rep, err := NewSARIFReporter(out, []*templates.CompiledTemplate{tmpl})
+	require.NoError(t, err)
+
+	f := sampleFinding()
+	require.NoError(t, rep.GenerateReport([]*model.Finding{f}, &Stats{}))
+
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs, 1)
+	run := doc.Runs[0]
+
+	// Rule
+	require.Len(t, run.Tool.Driver.Rules, 1)
+	rule := run.Tool.Driver.Rules[0]
+	assert.Equal(t, "01-api1-bola-read", rule.ID)
+	assert.Equal(t, "BOLA - Cross-User Resource Access (Read)", rule.ShortDescription.Text)
+	assert.Equal(t, "Tests GET endpoints for unauthorized cross-user resource access", rule.FullDescription.Text)
+	assert.Equal(t, "https://github.com/praetorian-inc/hadrian/blob/main/templates/rest/01-api1-bola-read.yaml", rule.HelpURI)
+	require.NotNil(t, rule.DefaultConfiguration)
+	assert.Equal(t, "error", rule.DefaultConfiguration.Level)
+	require.NotNil(t, rule.Properties)
+	assert.Contains(t, rule.Properties.Tags, "API1:2023")
+	assert.Contains(t, rule.Properties.Tags, "bola")
+	assert.Contains(t, rule.Properties.Tags, "security")
+
+	// Result
+	require.Len(t, run.Results, 1)
+	res := run.Results[0]
+	assert.Equal(t, "01-api1-bola-read", res.RuleID)
+	assert.Equal(t, 0, res.RuleIndex)
+	assert.Equal(t, "error", res.Level)
+	assert.Contains(t, res.Message.Text, "BOLA")
+	assert.Contains(t, res.Message.Text, "attacker")
+	assert.Contains(t, res.Message.Text, "victim")
+	require.Len(t, res.Locations, 1)
+	assert.Equal(t, "/api/users/{id}", res.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+	assert.Equal(t, "GET /api/users/{id}", res.Locations[0].LogicalLocations[0].Name)
+	require.Contains(t, res.PartialFingerprints, "primaryLocationHash/v1")
+	assert.Len(t, res.PartialFingerprints["primaryLocationHash/v1"], 64, "expected sha256 hex digest")
+}
+
+func TestSARIFReporter_GenerateReport_DeduplicatesRulesByTemplateID(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "dupes.sarif")
+	rep, err := NewSARIFReporter(out, []*templates.CompiledTemplate{sampleTemplate("01-api1-bola-read")})
+	require.NoError(t, err)
+
+	a := sampleFinding()
+	b := sampleFinding()
+	b.AttackerRole = "guest"
+	c := sampleFinding()
+	c.Endpoint = "/api/orders/{id}"
+
+	require.NoError(t, rep.GenerateReport([]*model.Finding{a, b, c}, &Stats{}))
+
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Tool.Driver.Rules, 1, "same TemplateID should collapse to a single rule")
+	require.Len(t, doc.Runs[0].Results, 3)
+	for _, r := range doc.Runs[0].Results {
+		assert.Equal(t, "01-api1-bola-read", r.RuleID)
+		assert.Equal(t, 0, r.RuleIndex)
+	}
+}
+
+func TestSARIFReporter_GenerateReport_RulesAreDeterministicallyOrdered(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "ordered.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+
+	a := sampleFinding()
+	a.TemplateID = "zz-last"
+	b := sampleFinding()
+	b.TemplateID = "aa-first"
+	c := sampleFinding()
+	c.TemplateID = "mm-middle"
+
+	require.NoError(t, rep.GenerateReport([]*model.Finding{a, b, c}, &Stats{}))
+
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Tool.Driver.Rules, 3)
+	ids := []string{doc.Runs[0].Tool.Driver.Rules[0].ID, doc.Runs[0].Tool.Driver.Rules[1].ID, doc.Runs[0].Tool.Driver.Rules[2].ID}
+	assert.Equal(t, []string{"aa-first", "mm-middle", "zz-last"}, ids)
+}
+
+func TestSARIFReporter_PartialFingerprintsAreStable(t *testing.T) {
+	// Identical identity fields with different transient state must hash to the
+	// same value — that is what makes GitHub Code Scanning treat two runs as
+	// referring to the same alert.
+	a := sampleFinding()
+	a.Timestamp = time.Now()
+	a.RequestIDs = []string{"req-1"}
+	a.Evidence = model.Evidence{Response: model.HTTPResponse{Body: "first run"}}
+
+	b := sampleFinding()
+	b.Timestamp = time.Now().Add(1 * time.Hour)
+	b.RequestIDs = []string{"req-different"}
+	b.Evidence = model.Evidence{Response: model.HTTPResponse{Body: "second run"}}
+	b.LLMAnalysis = &model.LLMTriage{Provider: "openai", Confidence: 0.95}
+
+	assert.Equal(t, buildPartialFingerprints(a), buildPartialFingerprints(b),
+		"fingerprints should not depend on transient state")
+}
+
+func TestSARIFReporter_PartialFingerprintsDifferWhenIdentityChanges(t *testing.T) {
+	base := sampleFinding()
+	cases := []struct {
+		name   string
+		mutate func(f *model.Finding)
+	}{
+		{"TemplateID", func(f *model.Finding) { f.TemplateID = "different-rule" }},
+		{"Method", func(f *model.Finding) { f.Method = "POST" }},
+		{"Endpoint", func(f *model.Finding) { f.Endpoint = "/different/path" }},
+		{"AttackerRole", func(f *model.Finding) { f.AttackerRole = "different-attacker" }},
+		{"VictimRole", func(f *model.Finding) { f.VictimRole = "different-victim" }},
+	}
+	baseFP := buildPartialFingerprints(base)["primaryLocationHash/v1"]
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := sampleFinding()
+			tc.mutate(mutated)
+			assert.NotEqual(t, baseFP, buildPartialFingerprints(mutated)["primaryLocationHash/v1"],
+				"%s change should produce a different fingerprint", tc.name)
+		})
+	}
+}
+
+func TestSeverityToSARIFLevel(t *testing.T) {
+	cases := map[model.Severity]string{
+		model.SeverityCritical: "error",
+		model.SeverityHigh:     "error",
+		model.SeverityMedium:   "warning",
+		model.SeverityLow:      "note",
+		model.SeverityInfo:     "note",
+		model.Severity(""):     "warning",
+	}
+	for sev, expected := range cases {
+		assert.Equal(t, expected, severityToSARIFLevel(sev), "severity %q", sev)
+	}
+}
+
+func TestTemplateHelpURI(t *testing.T) {
+	cases := []struct {
+		filePath string
+		want     string
+	}{
+		{"", templateWikiURL},
+		{"templates/rest/01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
+		{"./templates/graphql/foo.yaml", templateBaseURL + "templates/graphql/foo.yaml"},
+		{"/abs/path/templates/grpc/bar.yaml", templateBaseURL + "templates/grpc/bar.yaml"},
+		{"/some/custom/path/my-template.yaml", templateWikiURL},
+		{"templates\\rest\\01-api1-bola-read.yaml", templateBaseURL + "templates/rest/01-api1-bola-read.yaml"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, templateHelpURI(tc.filePath), "filePath=%q", tc.filePath)
+	}
+}
+
+func TestSARIFReporter_FallsBackWhenNoTemplate(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "no-tmpl.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	require.NoError(t, rep.GenerateReport([]*model.Finding{sampleFinding()}, &Stats{}))
+
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Tool.Driver.Rules, 1)
+	rule := doc.Runs[0].Tool.Driver.Rules[0]
+	assert.Equal(t, templateWikiURL, rule.HelpURI, "expected wiki fallback when no template registered")
+	assert.Equal(t, "BOLA - Cross-User Resource Access (Read)", rule.ShortDescription.Text,
+		"rule short description should come from the finding when no template is registered")
+}
+
+func TestSARIFReporter_HandlesMissingTemplateID(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "missing-id.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+
+	orphan := sampleFinding()
+	orphan.TemplateID = ""
+
+	require.NoError(t, rep.GenerateReport([]*model.Finding{orphan}, &Stats{}))
+
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Tool.Driver.Rules, 1)
+	assert.Equal(t, "hadrian.unknown", doc.Runs[0].Tool.Driver.Rules[0].ID)
+	require.Len(t, doc.Runs[0].Results, 1)
+	assert.Equal(t, "hadrian.unknown", doc.Runs[0].Results[0].RuleID)
+}
+
+func TestSARIFReporter_OutputValidatesAsSchemaShape(t *testing.T) {
+	// Light shape check — verifies the produced document contains every
+	// required SARIF v2.1.0 top-level/run-level field that GitHub Code
+	// Scanning rejects when missing. Full JSON-Schema validation is exercised
+	// in the integration test that downloads the official schema.
+	out := filepath.Join(t.TempDir(), "shape.sarif")
+	rep, err := NewSARIFReporter(out, []*templates.CompiledTemplate{sampleTemplate("01-api1-bola-read")})
+	require.NoError(t, err)
+	require.NoError(t, rep.GenerateReport([]*model.Finding{sampleFinding()}, &Stats{}))
+
+	raw, err := os.ReadFile(out)
+	require.NoError(t, err)
+	var v map[string]any
+	require.NoError(t, json.Unmarshal(raw, &v))
+	assert.Equal(t, "2.1.0", v["version"])
+	assert.NotEmpty(t, v["$schema"])
+	runs, ok := v["runs"].([]any)
+	require.True(t, ok)
+	require.Len(t, runs, 1)
+	run := runs[0].(map[string]any)
+	assert.Contains(t, run, "tool")
+	assert.Contains(t, run, "results")
+	tool := run["tool"].(map[string]any)
+	driver := tool["driver"].(map[string]any)
+	assert.Equal(t, "Hadrian", driver["name"])
+	assert.NotEmpty(t, driver["version"])
+	assert.NotEmpty(t, driver["informationUri"])
+}
+
+func TestBuildResultMessage(t *testing.T) {
+	cases := []struct {
+		name     string
+		f        *model.Finding
+		contains []string
+	}{
+		{
+			name:     "complete",
+			f:        sampleFinding(),
+			contains: []string{"BOLA", "GET /api/users/{id}", "attacker=attacker", "victim=victim", "victim's resource"},
+		},
+		{
+			name: "no roles",
+			f: &model.Finding{
+				TemplateID: "x",
+				Name:       "X",
+				Method:     "POST",
+				Endpoint:   "/a",
+			},
+			contains: []string{"X", "POST /a"},
+		},
+		{
+			name:     "fallback name",
+			f:        &model.Finding{TemplateID: "anon"},
+			contains: []string{"anon"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			msg := buildResultMessage(tc.f)
+			for _, want := range tc.contains {
+				assert.Contains(t, msg, want)
+			}
+		})
+	}
+}
+
+func TestDedupeStrings(t *testing.T) {
+	got := dedupeStrings([]string{"a", "", "b", "a", "c", "b", ""})
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}
+
+// LLM-triaged findings should surface llmConfidence and llmProvider in the
+// result properties so downstream consumers (and the GitHub UI) see the AI
+// signal alongside the raw detection metadata.
+func TestSARIFReporter_LLMPropertiesAreCarriedThrough(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "llm.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	f := sampleFinding()
+	f.LLMAnalysis = &model.LLMTriage{
+		Provider:        "anthropic",
+		Confidence:      0.92,
+		IsVulnerability: true,
+		Reasoning:       "endpoint returned victim's data",
+	}
+	require.NoError(t, rep.GenerateReport([]*model.Finding{f}, &Stats{}))
+
+	doc := readSARIF(t, out)
+	require.Len(t, doc.Runs[0].Results, 1)
+	props := doc.Runs[0].Results[0].Properties
+	require.NotNil(t, props)
+	assert.Equal(t, "anthropic", props["llmProvider"])
+	assert.InDelta(t, 0.92, props["llmConfidence"], 1e-9)
+}
+
+// ReportFinding is a no-op so SARIF stays a batched format. The contract test
+// just confirms it doesn't panic and doesn't mutate state — anything else
+// would surprise callers iterating findings during LLM triage.
+func TestSARIFReporter_ReportFindingIsNoOp(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "noop.sarif")
+	rep, err := NewSARIFReporter(out, nil)
+	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		rep.ReportFinding(sampleFinding())
+	}
+	require.NoError(t, rep.GenerateReport(nil, &Stats{}))
+	doc := readSARIF(t, out)
+	assert.Empty(t, doc.Runs[0].Results, "ReportFinding must not mutate state")
+}
+
+// readSARIF reads and parses a SARIF document, failing the test on any error.
+func readSARIF(t *testing.T, path string) SARIFReport {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var doc SARIFReport
+	require.NoError(t, json.Unmarshal(data, &doc))
+	// Sanity: the produced JSON should round-trip without losing the schema
+	// declaration (we hard-fail here so accidental removals show up).
+	require.True(t, strings.HasPrefix(doc.Schema, "https://"), "schema must be a URL")
+	return doc
+}

--- a/pkg/runner/testdata/sarif-2.1.0.json
+++ b/pkg/runner/testdata/sarif-2.1.0.json
@@ -1,0 +1,2882 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "additionalProperties": false,
+  "definitions": {
+    "address": {
+      "description": "A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "absoluteAddress": {
+          "description": "The address expressed as a byte offset from the start of the addressable region.",
+          "type": "integer",
+          "minimum": -1,
+          "default": -1
+        },
+        "relativeAddress": {
+          "description": "The address expressed as a byte offset from the absolute address of the top-most parent object.",
+          "type": "integer"
+        },
+        "length": {
+          "description": "The number of bytes in this range of addresses.",
+          "type": "integer"
+        },
+        "kind": {
+          "description": "An open-ended string that identifies the address kind. 'data', 'function', 'header','instruction', 'module', 'page', 'section', 'segment', 'stack', 'stackFrame', 'table' are well-known values.",
+          "type": "string"
+        },
+        "name": {
+          "description": "A name that is associated with the address, e.g., '.text'.",
+          "type": "string"
+        },
+        "fullyQualifiedName": {
+          "description": "A human-readable fully qualified name that is associated with the address.",
+          "type": "string"
+        },
+        "offsetFromParent": {
+          "description": "The byte offset of this address from the absolute or relative address of the parent object.",
+          "type": "integer"
+        },
+        "index": {
+          "description": "The index within run.addresses of the cached object for this address.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "parentIndex": {
+          "description": "The index within run.addresses of the parent object.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the address."
+        }
+      }
+    },
+    "artifact": {
+      "description": "A single artifact. In some cases, this artifact might be nested within another artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the artifact."
+        },
+        "location": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact."
+        },
+        "parentIndex": {
+          "description": "Identifies the index of the immediate parent of the artifact, if this artifact is nested.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "offset": {
+          "description": "The offset in bytes of the artifact within its containing artifact.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "length": {
+          "description": "The length of the artifact in bytes.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "roles": {
+          "description": "The role or roles played by the artifact in the analysis.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "enum": [
+              "analysisTarget",
+              "attachment",
+              "responseFile",
+              "resultFile",
+              "standardStream",
+              "tracedFile",
+              "unmodified",
+              "modified",
+              "added",
+              "deleted",
+              "renamed",
+              "uncontrolled",
+              "driver",
+              "extension",
+              "translation",
+              "taxonomy",
+              "policy",
+              "referencedOnCommandLine",
+              "memoryContents",
+              "directory",
+              "userSpecifiedConfiguration",
+              "toolSpecifiedConfiguration",
+              "debugOutputFile"
+            ]
+          }
+        },
+        "mimeType": {
+          "description": "The MIME type (RFC 2045) of the artifact.",
+          "type": "string",
+          "pattern": "[^/]+/.+"
+        },
+        "contents": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The contents of the artifact."
+        },
+        "encoding": {
+          "description": "Specifies the encoding for an artifact object that refers to a text file.",
+          "type": "string"
+        },
+        "sourceLanguage": {
+          "description": "Specifies the source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+        "hashes": {
+          "description": "A dictionary, each of whose keys is the name of a hash function and each of whose values is the hashed value of the artifact produced by the specified hash function.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "lastModifiedTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the artifact was most recently modified. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact."
+        }
+      }
+    },
+    "artifactChange": {
+      "description": "A change to a single artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact to change."
+        },
+        "replacements": {
+          "description": "An array of replacement objects, each of which represents the replacement of a single region in a single artifact specified by 'artifactLocation'.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/replacement"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the change."
+        }
+      },
+      "required": ["artifactLocation", "replacements"]
+    },
+    "artifactContent": {
+      "description": "Represents the contents of an artifact.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "description": "UTF-8-encoded content from a text artifact.",
+          "type": "string"
+        },
+        "binary": {
+          "description": "MIME Base64-encoded content from a binary artifact, or from a text artifact in its original encoding.",
+          "type": "string"
+        },
+        "rendered": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "An alternate rendered representation of the artifact (e.g., a decompiled representation of a binary region)."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact content."
+        }
+      }
+    },
+    "artifactLocation": {
+      "description": "Specifies the location of an artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "uri": {
+          "description": "A string containing a valid relative or absolute URI.",
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "uriBaseId": {
+          "description": "A string which indirectly specifies the absolute URI with respect to which a relative URI in the \"uri\" property is interpreted.",
+          "type": "string"
+        },
+        "index": {
+          "description": "The index within the run artifacts array of the artifact object associated with the artifact location.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the artifact location."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact location."
+        }
+      }
+    },
+    "attachment": {
+      "description": "An artifact relevant to a result.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A message describing the role played by the attachment."
+        },
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the attachment."
+        },
+        "regions": {
+          "description": "An array of regions of interest within the attachment.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/region"
+          }
+        },
+        "rectangles": {
+          "description": "An array of rectangles specifying areas of interest within the image.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/rectangle"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the attachment."
+        }
+      },
+      "required": ["artifactLocation"]
+    },
+    "codeFlow": {
+      "description": "A set of threadFlows which together describe a pattern of code execution relevant to detecting a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the code flow."
+        },
+        "threadFlows": {
+          "description": "An array of one or more unique threadFlow objects, each of which describes the progress of a program through a thread of execution.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/threadFlow"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the code flow."
+        }
+      },
+      "required": ["threadFlows"]
+    },
+    "configurationOverride": {
+      "description": "Information about how a specific rule or notification was reconfigured at runtime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "configuration": {
+          "$ref": "#/definitions/reportingConfiguration",
+          "description": "Specifies how the rule or notification was configured during the scan."
+        },
+        "descriptor": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the descriptor whose configuration was overridden."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the configuration override."
+        }
+      },
+      "required": ["configuration", "descriptor"]
+    },
+    "conversion": {
+      "description": "Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "tool": {
+          "$ref": "#/definitions/tool",
+          "description": "A tool object that describes the converter."
+        },
+        "invocation": {
+          "$ref": "#/definitions/invocation",
+          "description": "An invocation object that describes the invocation of the converter."
+        },
+        "analysisToolLogFiles": {
+          "description": "The locations of the analysis tool's per-run log files.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the conversion."
+        }
+      },
+      "required": ["tool"]
+    },
+    "edge": {
+      "description": "Represents a directed edge in a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "A string that uniquely identifies the edge within its graph.",
+          "type": "string"
+        },
+        "label": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the edge."
+        },
+        "sourceNodeId": {
+          "description": "Identifies the source node (the node at which the edge starts).",
+          "type": "string"
+        },
+        "targetNodeId": {
+          "description": "Identifies the target node (the node at which the edge ends).",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the edge."
+        }
+      },
+      "required": ["id", "sourceNodeId", "targetNodeId"]
+    },
+    "edgeTraversal": {
+      "description": "Represents the traversal of a single edge during a graph traversal.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "edgeId": {
+          "description": "Identifies the edge being traversed.",
+          "type": "string"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message to display to the user as the edge is traversed."
+        },
+        "finalState": {
+          "description": "The values of relevant expressions after the edge has been traversed.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "stepOverEdgeCount": {
+          "description": "The number of edge traversals necessary to return from a nested graph.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the edge traversal."
+        }
+      },
+      "required": ["edgeId"]
+    },
+    "exception": {
+      "description": "Describes a runtime exception encountered during the execution of an analysis tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal."
+        },
+        "message": {
+          "description": "A message that describes the exception.",
+          "type": "string"
+        },
+        "stack": {
+          "$ref": "#/definitions/stack",
+          "description": "The sequence of function calls leading to the exception."
+        },
+        "innerExceptions": {
+          "description": "An array of exception objects each of which is considered a cause of this exception.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/exception"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the exception."
+        }
+      }
+    },
+    "externalProperties": {
+      "description": "The top-level element of an external property file.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schema": {
+          "description": "The URI of the JSON schema corresponding to the version of the external property file format.",
+          "type": "string",
+          "format": "uri"
+        },
+        "version": {
+          "description": "The SARIF format version of this external properties object.",
+          "enum": ["2.1.0"]
+        },
+        "guid": {
+          "description": "A stable, unique identifier for this external properties object, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "runGuid": {
+          "description": "A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "conversion": {
+          "$ref": "#/definitions/conversion",
+          "description": "A conversion object that will be merged with a separate run."
+        },
+        "graphs": {
+          "description": "An array of graph objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+        "externalizedProperties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information that will be merged with a separate run."
+        },
+        "artifacts": {
+          "description": "An array of artifact objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifact"
+          }
+        },
+        "invocations": {
+          "description": "Describes the invocation of the analysis tool that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/invocation"
+          }
+        },
+        "logicalLocations": {
+          "description": "An array of logical locations such as namespaces, types or functions that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+        "results": {
+          "description": "An array of result objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+        "taxonomies": {
+          "description": "Tool taxonomies that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "driver": {
+          "$ref": "#/definitions/toolComponent",
+          "description": "The analysis tool object that will be merged with a separate run."
+        },
+        "extensions": {
+          "description": "Tool extensions that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "policies": {
+          "description": "Tool policies that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "translations": {
+          "description": "Tool translations that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "addresses": {
+          "description": "Addresses that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/address"
+          }
+        },
+        "webRequests": {
+          "description": "Requests that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          }
+        },
+        "webResponses": {
+          "description": "Responses that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external properties."
+        }
+      }
+    },
+    "externalPropertyFileReference": {
+      "description": "Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the external property file."
+        },
+        "guid": {
+          "description": "A stable, unique identifier for the external property file in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "itemCount": {
+          "description": "A non-negative integer specifying the number of items contained in the external property file.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external property file."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["location"]
+        },
+        {
+          "required": ["guid"]
+        }
+      ]
+    },
+    "externalPropertyFileReferences": {
+      "description": "References to external property files that should be inlined with the content of a root log file.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "conversion": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.conversion object to be merged with the root log file."
+        },
+        "graphs": {
+          "description": "An array of external property files containing a run.graphs object to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "externalizedProperties": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.properties object to be merged with the root log file."
+        },
+        "artifacts": {
+          "description": "An array of external property files containing run.artifacts arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "invocations": {
+          "description": "An array of external property files containing run.invocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "logicalLocations": {
+          "description": "An array of external property files containing run.logicalLocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "threadFlowLocations": {
+          "description": "An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "results": {
+          "description": "An array of external property files containing run.results arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "taxonomies": {
+          "description": "An array of external property files containing run.taxonomies arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "addresses": {
+          "description": "An array of external property files containing run.addresses arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "driver": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.driver object to be merged with the root log file."
+        },
+        "extensions": {
+          "description": "An array of external property files containing run.extensions arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "policies": {
+          "description": "An array of external property files containing run.policies arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "translations": {
+          "description": "An array of external property files containing run.translations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "webRequests": {
+          "description": "An array of external property files containing run.requests arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "webResponses": {
+          "description": "An array of external property files containing run.responses arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external property files."
+        }
+      }
+    },
+    "fix": {
+      "description": "A proposed fix for the problem represented by a result object. A fix specifies a set of artifacts to modify. For each artifact, it specifies a set of bytes to remove, and provides a set of new bytes to replace them.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the proposed fix, enabling viewers to present the proposed change to an end user."
+        },
+        "artifactChanges": {
+          "description": "One or more artifact changes that comprise a fix for a result.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifactChange"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the fix."
+        }
+      },
+      "required": ["artifactChanges"]
+    },
+    "graph": {
+      "description": "A network of nodes and directed edges that describes some aspect of the structure of the code (for example, a call graph).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the graph."
+        },
+        "nodes": {
+          "description": "An array of node objects representing the nodes of the graph.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        },
+        "edges": {
+          "description": "An array of edge objects representing the edges of the graph.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/edge"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the graph."
+        }
+      }
+    },
+    "graphTraversal": {
+      "description": "Represents a path through a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runGraphIndex": {
+          "description": "The index within the run.graphs to be associated with the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "resultGraphIndex": {
+          "description": "The index within the result.graphs to be associated with the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of this graph traversal."
+        },
+        "initialState": {
+          "description": "Values of relevant expressions at the start of the graph traversal that may change during graph traversal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "immutableState": {
+          "description": "Values of relevant expressions at the start of the graph traversal that remain constant for the graph traversal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "edgeTraversals": {
+          "description": "The sequences of edges traversed by this graph traversal.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/edgeTraversal"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the graph traversal."
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["runGraphIndex"]
+        },
+        {
+          "required": ["resultGraphIndex"]
+        }
+      ]
+    },
+    "invocation": {
+      "description": "The runtime environment of the analysis tool run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "commandLine": {
+          "description": "The command line used to invoke the tool.",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "An array of strings, containing in order the command line arguments passed to the tool from the operating system.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "type": "string"
+          }
+        },
+        "responseFiles": {
+          "description": "The locations of any response files specified on the tool's command line.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+        "startTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation started. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation ended. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "exitCode": {
+          "description": "The process exit code.",
+          "type": "integer"
+        },
+        "ruleConfigurationOverrides": {
+          "description": "An array of configurationOverride objects that describe rules related runtime overrides.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          }
+        },
+        "notificationConfigurationOverrides": {
+          "description": "An array of configurationOverride objects that describe notifications related runtime overrides.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          }
+        },
+        "toolExecutionNotifications": {
+          "description": "A list of runtime conditions detected by the tool during the analysis.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/notification"
+          }
+        },
+        "toolConfigurationNotifications": {
+          "description": "A list of conditions detected by the tool that are relevant to the tool's configuration.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/notification"
+          }
+        },
+        "exitCodeDescription": {
+          "description": "The reason for the process exit.",
+          "type": "string"
+        },
+        "exitSignalName": {
+          "description": "The name of the signal that caused the process to exit.",
+          "type": "string"
+        },
+        "exitSignalNumber": {
+          "description": "The numeric value of the signal that caused the process to exit.",
+          "type": "integer"
+        },
+        "processStartFailureMessage": {
+          "description": "The reason given by the operating system that the process failed to start.",
+          "type": "string"
+        },
+        "executionSuccessful": {
+          "description": "Specifies whether the tool's execution completed successfully.",
+          "type": "boolean"
+        },
+        "machine": {
+          "description": "The machine on which the invocation occurred.",
+          "type": "string"
+        },
+        "account": {
+          "description": "The account under which the invocation occurred.",
+          "type": "string"
+        },
+        "processId": {
+          "description": "The id of the process in which the invocation occurred.",
+          "type": "integer"
+        },
+        "executableLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "An absolute URI specifying the location of the executable that was invoked."
+        },
+        "workingDirectory": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The working directory for the invocation."
+        },
+        "environmentVariables": {
+          "description": "The environment variables associated with the analysis tool process, expressed as key/value pairs.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "stdin": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard input stream to the process that was invoked."
+        },
+        "stdout": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard output stream from the process that was invoked."
+        },
+        "stderr": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard error stream from the process that was invoked."
+        },
+        "stdoutStderr": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the interleaved standard output and standard error stream from the process that was invoked."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the invocation."
+        }
+      },
+      "required": ["executionSuccessful"]
+    },
+    "location": {
+      "description": "A location within a programming artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Value that distinguishes this location from all other locations within a single result object.",
+          "type": "integer",
+          "minimum": -1,
+          "default": -1
+        },
+        "physicalLocation": {
+          "$ref": "#/definitions/physicalLocation",
+          "description": "Identifies the artifact and region."
+        },
+        "logicalLocations": {
+          "description": "The logical locations associated with the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the location."
+        },
+        "annotations": {
+          "description": "A set of regions relevant to the location.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/region"
+          }
+        },
+        "relationships": {
+          "description": "An array of objects that describe relationships between this location and others.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/locationRelationship"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the location."
+        }
+      }
+    },
+    "locationRelationship": {
+      "description": "Information about the relation of one location to another.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "description": "A reference to the related location.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "kinds": {
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'includes', 'isIncludedBy' and 'relevant'.",
+          "type": "array",
+          "default": ["relevant"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the location relationship."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the location relationship."
+        }
+      },
+      "required": ["target"]
+    },
+    "logicalLocation": {
+      "description": "A logical location of a construct that produced a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.",
+          "type": "string"
+        },
+        "index": {
+          "description": "The index within the logical locations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "fullyQualifiedName": {
+          "description": "The human-readable fully qualified name of the logical location.",
+          "type": "string"
+        },
+        "decoratedName": {
+          "description": "The machine-readable name for the logical location, such as a mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.",
+          "type": "string"
+        },
+        "parentIndex": {
+          "description": "Identifies the index of the immediate parent of the construct in which the result was detected. For example, this property might point to a logical location that represents the namespace that holds a type.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "kind": {
+          "description": "The type of construct this logical location component refers to. Should be one of 'function', 'member', 'module', 'namespace', 'parameter', 'resource', 'returnType', 'type', 'variable', 'object', 'array', 'property', 'value', 'element', 'text', 'attribute', 'comment', 'declaration', 'dtd' or 'processingInstruction', if any of those accurately describe the construct.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the logical location."
+        }
+      }
+    },
+    "message": {
+      "description": "Encapsulates a message intended to be read by the end user.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "description": "A plain text message string.",
+          "type": "string"
+        },
+        "markdown": {
+          "description": "A Markdown message string.",
+          "type": "string"
+        },
+        "id": {
+          "description": "The identifier for this message.",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "An array of strings to substitute into the message string.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the message."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["text"]
+        },
+        {
+          "required": ["id"]
+        }
+      ]
+    },
+    "multiformatMessageString": {
+      "description": "A message string or message format string rendered in multiple formats.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "description": "A plain text message string or format string.",
+          "type": "string"
+        },
+        "markdown": {
+          "description": "A Markdown message string or format string.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the message."
+        }
+      },
+      "required": ["text"]
+    },
+    "node": {
+      "description": "Represents a node in a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "A string that uniquely identifies the node within its graph.",
+          "type": "string"
+        },
+        "label": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the node."
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "A code location associated with the node."
+        },
+        "children": {
+          "description": "Array of child nodes.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the node."
+        }
+      },
+      "required": ["id"]
+    },
+    "notification": {
+      "description": "Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "locations": {
+          "description": "The locations relevant to this notification.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the condition that was encountered."
+        },
+        "level": {
+          "description": "A value specifying the severity level of the notification.",
+          "default": "warning",
+          "enum": ["none", "note", "warning", "error"]
+        },
+        "threadId": {
+          "description": "The thread identifier of the code that generated the notification.",
+          "type": "integer"
+        },
+        "timeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "exception": {
+          "$ref": "#/definitions/exception",
+          "description": "The runtime exception, if any, relevant to this notification."
+        },
+        "descriptor": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the descriptor relevant to this notification."
+        },
+        "associatedRule": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the rule descriptor associated with this notification."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the notification."
+        }
+      },
+      "required": ["message"]
+    },
+    "physicalLocation": {
+      "description": "A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address",
+          "description": "The address of the location."
+        },
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact."
+        },
+        "region": {
+          "$ref": "#/definitions/region",
+          "description": "Specifies a portion of the artifact."
+        },
+        "contextRegion": {
+          "$ref": "#/definitions/region",
+          "description": "Specifies a portion of the artifact that encloses the region. Allows a viewer to display additional context around the region."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the physical location."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["address"]
+        },
+        {
+          "required": ["artifactLocation"]
+        }
+      ]
+    },
+    "propertyBag": {
+      "description": "Key/value pairs that provide additional information about the object.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "tags": {
+          "description": "A set of distinct strings that provide additional information.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "rectangle": {
+      "description": "An area within an image.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "top": {
+          "description": "The Y coordinate of the top edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "left": {
+          "description": "The X coordinate of the left edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "bottom": {
+          "description": "The Y coordinate of the bottom edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "right": {
+          "description": "The X coordinate of the right edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the rectangle."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the rectangle."
+        }
+      }
+    },
+    "region": {
+      "description": "A region within an artifact where a result was detected.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "startLine": {
+          "description": "The line number of the first character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "startColumn": {
+          "description": "The column number of the first character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "endLine": {
+          "description": "The line number of the last character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "endColumn": {
+          "description": "The column number of the character following the end of the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "charOffset": {
+          "description": "The zero-based offset from the beginning of the artifact of the first character in the region.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "charLength": {
+          "description": "The length of the region in characters.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "byteOffset": {
+          "description": "The zero-based offset from the beginning of the artifact of the first byte in the region.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "byteLength": {
+          "description": "The length of the region in bytes.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "snippet": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The portion of the artifact contents within the specified region."
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the region."
+        },
+        "sourceLanguage": {
+          "description": "Specifies the source language, if any, of the portion of the artifact specified by the region object.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the region."
+        }
+      }
+    },
+    "replacement": {
+      "description": "The replacement of a single region of an artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "deletedRegion": {
+          "$ref": "#/definitions/region",
+          "description": "The region of the artifact to delete."
+        },
+        "insertedContent": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The content to insert at the location specified by the 'deletedRegion' property."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the replacement."
+        }
+      },
+      "required": ["deletedRegion"]
+    },
+    "reportingDescriptor": {
+      "description": "Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A stable, opaque identifier for the report.",
+          "type": "string"
+        },
+        "deprecatedIds": {
+          "description": "An array of stable, opaque identifiers by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "guid": {
+          "description": "A unique identifier for the reporting descriptor in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "deprecatedGuids": {
+          "description": "An array of unique identifies in the form of a GUID by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+          }
+        },
+        "name": {
+          "description": "A report identifier that is understandable to an end user.",
+          "type": "string"
+        },
+        "deprecatedNames": {
+          "description": "An array of readable identifiers by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A concise description of the report. Should be a single sentence that is understandable when visible space is limited to a single line of text."
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A description of the report. Should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result."
+        },
+        "messageStrings": {
+          "description": "A set of name/value pairs with arbitrary names. Each value is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "defaultConfiguration": {
+          "$ref": "#/definitions/reportingConfiguration",
+          "description": "Default reporting configuration information."
+        },
+        "helpUri": {
+          "description": "A URI where the primary documentation for the report can be found.",
+          "type": "string",
+          "format": "uri"
+        },
+        "help": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "Provides the primary documentation for the report, useful when there is no online documentation."
+        },
+        "relationships": {
+          "description": "An array of objects that describe relationships between this reporting descriptor and others.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorRelationship"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the report."
+        }
+      },
+      "required": ["id"]
+    },
+    "reportingConfiguration": {
+      "description": "Information about a rule or notification that can be configured at runtime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Specifies whether the report may be produced during the scan.",
+          "type": "boolean",
+          "default": true
+        },
+        "level": {
+          "description": "Specifies the failure level for the report.",
+          "default": "warning",
+          "enum": ["none", "note", "warning", "error"]
+        },
+        "rank": {
+          "description": "Specifies the relative priority of the report. Used for analysis output only.",
+          "type": "number",
+          "default": -1,
+          "minimum": -1,
+          "maximum": 100
+        },
+        "parameters": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Contains configuration information specific to a report."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting configuration."
+        }
+      }
+    },
+    "reportingDescriptorReference": {
+      "description": "Information about how to locate a relevant reporting descriptor.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "The id of the descriptor.",
+          "type": "string"
+        },
+        "index": {
+          "description": "The index into an array of descriptors in toolComponent.ruleDescriptors, toolComponent.notificationDescriptors, or toolComponent.taxonomyDescriptors, depending on context.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "guid": {
+          "description": "A guid that uniquely identifies the descriptor.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "toolComponent": {
+          "$ref": "#/definitions/toolComponentReference",
+          "description": "A reference used to locate the toolComponent associated with the descriptor."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["index"]
+        },
+        {
+          "required": ["guid"]
+        },
+        {
+          "required": ["id"]
+        }
+      ]
+    },
+    "reportingDescriptorRelationship": {
+      "description": "Information about the relation of one reporting descriptor to another.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference to the related reporting descriptor."
+        },
+        "kinds": {
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow', 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.",
+          "type": "array",
+          "default": ["relevant"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the reporting descriptor relationship."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference."
+        }
+      },
+      "required": ["target"]
+    },
+    "result": {
+      "description": "A result produced by an analysis tool.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "ruleId": {
+          "description": "The stable, unique identifier of the rule, if any, to which this result is relevant.",
+          "type": "string"
+        },
+        "ruleIndex": {
+          "description": "The index within the tool component rules array of the rule object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "rule": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the rule descriptor relevant to this result."
+        },
+        "kind": {
+          "description": "A value that categorizes results by evaluation state.",
+          "default": "fail",
+          "enum": [
+            "notApplicable",
+            "pass",
+            "fail",
+            "review",
+            "open",
+            "informational"
+          ]
+        },
+        "level": {
+          "description": "A value specifying the severity level of the result.",
+          "default": "warning",
+          "enum": ["none", "note", "warning", "error"]
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the result. The first sentence of the message only will be displayed when visible space is limited."
+        },
+        "analysisTarget": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "Identifies the artifact that the analysis tool was instructed to scan. This need not be the same as the artifact where the result actually occurred."
+        },
+        "locations": {
+          "description": "The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+        "guid": {
+          "description": "A stable, unique identifier for the result in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of logically identical results to which this result belongs, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "occurrenceCount": {
+          "description": "A positive integer specifying the number of times this logically unique result was observed in this run.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "partialFingerprints": {
+          "description": "A set of strings that contribute to the stable, unique identity of the result.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "fingerprints": {
+          "description": "A set of strings each of which individually defines a stable, unique identity for the result.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "stacks": {
+          "description": "An array of 'stack' objects relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/stack"
+          }
+        },
+        "codeFlows": {
+          "description": "An array of 'codeFlow' objects relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/codeFlow"
+          }
+        },
+        "graphs": {
+          "description": "An array of zero or more unique graph objects associated with the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+        "graphTraversals": {
+          "description": "An array of one or more unique 'graphTraversal' objects.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graphTraversal"
+          }
+        },
+        "relatedLocations": {
+          "description": "A set of locations relevant to this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+        "suppressions": {
+          "description": "A set of suppressions relevant to this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/suppression"
+          }
+        },
+        "baselineState": {
+          "description": "The state of a result relative to a baseline of a previous run.",
+          "enum": ["new", "unchanged", "updated", "absent"]
+        },
+        "rank": {
+          "description": "A number representing the priority or importance of the result.",
+          "type": "number",
+          "default": -1,
+          "minimum": -1,
+          "maximum": 100
+        },
+        "attachments": {
+          "description": "A set of artifacts relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/attachment"
+          }
+        },
+        "hostedViewerUri": {
+          "description": "An absolute URI at which the result can be viewed.",
+          "type": "string",
+          "format": "uri"
+        },
+        "workItemUris": {
+          "description": "The URIs of the work items associated with this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "provenance": {
+          "$ref": "#/definitions/resultProvenance",
+          "description": "Information about how and when the result was detected."
+        },
+        "fixes": {
+          "description": "An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/fix"
+          }
+        },
+        "taxa": {
+          "description": "An array of references to taxonomy reporting descriptors that are applicable to the result.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          }
+        },
+        "webRequest": {
+          "$ref": "#/definitions/webRequest",
+          "description": "A web request associated with this result."
+        },
+        "webResponse": {
+          "$ref": "#/definitions/webResponse",
+          "description": "A web response associated with this result."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the result."
+        }
+      },
+      "required": ["message"]
+    },
+    "resultProvenance": {
+      "description": "Contains information about how and when a result was detected.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "firstDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was first detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "firstDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "lastDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was most recently detected.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "invocationIndex": {
+          "description": "The index within the run.invocations array of the invocation object which describes the tool invocation that detected the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "conversionSources": {
+          "description": "An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/physicalLocation"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the result."
+        }
+      }
+    },
+    "run": {
+      "description": "Describes a single run of an analysis tool, and contains the reported output of that run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "tool": {
+          "$ref": "#/definitions/tool",
+          "description": "Information about the tool or tool pipeline that generated the results in this run. A run can only contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files."
+        },
+        "invocations": {
+          "description": "Describes the invocation of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/invocation"
+          }
+        },
+        "conversion": {
+          "$ref": "#/definitions/conversion",
+          "description": "A conversion object that describes how a converter transformed an analysis tool's native reporting format into the SARIF format."
+        },
+        "language": {
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "type": "string",
+          "default": "en-US",
+          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}?$"
+        },
+        "versionControlProvenance": {
+          "description": "Specifies the revision in version control of the artifacts that were scanned.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/versionControlDetails"
+          }
+        },
+        "originalUriBaseIds": {
+          "description": "The artifact location specified by each uriBaseId symbol on the machine where the tool originally ran.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+        "artifacts": {
+          "description": "An array of artifact objects relevant to the run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifact"
+          }
+        },
+        "logicalLocations": {
+          "description": "An array of logical locations such as namespaces, types or functions.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+        "graphs": {
+          "description": "An array of zero or more unique graph objects associated with the run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+        "results": {
+          "description": "The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+        "automationDetails": {
+          "$ref": "#/definitions/runAutomationDetails",
+          "description": "Automation details that describe this run."
+        },
+        "runAggregates": {
+          "description": "Automation details that describe the aggregate of runs to which this run belongs.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/runAutomationDetails"
+          }
+        },
+        "baselineGuid": {
+          "description": "The 'guid' property of a previous SARIF 'run' that comprises the baseline that was used to compute result 'baselineState' properties for the run.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "redactionTokens": {
+          "description": "An array of strings used to replace sensitive information in a redaction-aware property.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultEncoding": {
+          "description": "Specifies the default encoding for any artifact object that refers to a text file.",
+          "type": "string"
+        },
+        "defaultSourceLanguage": {
+          "description": "Specifies the default source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+        "newlineSequences": {
+          "description": "An ordered list of character sequences that were treated as line breaks when computing region information for the run.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "default": ["\r\n", "\n"],
+          "items": {
+            "type": "string"
+          }
+        },
+        "columnKind": {
+          "description": "Specifies the unit in which the tool measures columns.",
+          "enum": ["utf16CodeUnits", "unicodeCodePoints"]
+        },
+        "externalPropertyFileReferences": {
+          "$ref": "#/definitions/externalPropertyFileReferences",
+          "description": "References to external property files that should be inlined with the content of a root log file."
+        },
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+        "taxonomies": {
+          "description": "An array of toolComponent objects relevant to a taxonomy in which results are categorized.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "addresses": {
+          "description": "Addresses associated with this run instance, if any.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/address"
+          }
+        },
+        "translations": {
+          "description": "The set of available translations of the localized data provided by the tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "policies": {
+          "description": "Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "webRequests": {
+          "description": "An array of request objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          }
+        },
+        "webResponses": {
+          "description": "An array of response objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          }
+        },
+        "specialLocations": {
+          "$ref": "#/definitions/specialLocations",
+          "description": "A specialLocations object that defines locations of special significance to SARIF consumers."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the run."
+        }
+      },
+      "required": ["tool"]
+    },
+    "runAutomationDetails": {
+      "description": "Information that describes a run's identity and role within an engineering system process.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the identity and role played within the engineering system by this object's containing run object."
+        },
+        "id": {
+          "description": "A hierarchical string that uniquely identifies this object's containing run object.",
+          "type": "string"
+        },
+        "guid": {
+          "description": "A stable, unique identifier for this object's containing run object in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of runs to which this object's containing run object belongs in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the run automation details."
+        }
+      }
+    },
+    "specialLocations": {
+      "description": "Defines locations of special significance to SARIF consumers.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "displayBase": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "Provides a suggestion to SARIF consumers to display file paths relative to the specified location."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the special locations."
+        }
+      }
+    },
+    "stack": {
+      "description": "A call stack that is relevant to a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to this call stack."
+        },
+        "frames": {
+          "description": "An array of stack frames that represents a sequence of calls, rendered in reverse chronological order, that comprise the call stack.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/stackFrame"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the stack."
+        }
+      },
+      "required": ["frames"]
+    },
+    "stackFrame": {
+      "description": "A function call within a stack trace.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "The location to which this stack frame refers."
+        },
+        "module": {
+          "description": "The name of the module that contains the code of this stack frame.",
+          "type": "string"
+        },
+        "threadId": {
+          "description": "The thread identifier of the stack frame.",
+          "type": "integer"
+        },
+        "parameters": {
+          "description": "The parameters of the call that is executing.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "type": "string",
+            "default": []
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the stack frame."
+        }
+      }
+    },
+    "suppression": {
+      "description": "A suppression that is relevant to a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "guid": {
+          "description": "A stable, unique identifier for the suppression in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "kind": {
+          "description": "A string that indicates where the suppression is persisted.",
+          "enum": ["inSource", "external"]
+        },
+        "status": {
+          "description": "A string that indicates the review status of the suppression.",
+          "enum": ["accepted", "underReview", "rejected"]
+        },
+        "justification": {
+          "description": "A string representing the justification for the suppression.",
+          "type": "string"
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "Identifies the location associated with the suppression."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the suppression."
+        }
+      },
+      "required": ["kind"]
+    },
+    "threadFlow": {
+      "description": "Describes a sequence of code locations that specify a path through a single thread of execution such as an operating system or fiber.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "An string that uniquely identifies the threadFlow within the codeFlow in which it occurs.",
+          "type": "string"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the thread flow."
+        },
+        "initialState": {
+          "description": "Values of relevant expressions at the start of the thread flow that may change during thread flow execution.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "immutableState": {
+          "description": "Values of relevant expressions at the start of the thread flow that remain constant.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "locations": {
+          "description": "A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the tool while producing the result.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the thread flow."
+        }
+      },
+      "required": ["locations"]
+    },
+    "threadFlowLocation": {
+      "description": "A location visited by an analysis tool while simulating or monitoring the execution of a program.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "index": {
+          "description": "The index within the run threadFlowLocations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "The code location."
+        },
+        "stack": {
+          "$ref": "#/definitions/stack",
+          "description": "The call stack leading to this location."
+        },
+        "kinds": {
+          "description": "A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "taxa": {
+          "description": "An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          }
+        },
+        "module": {
+          "description": "The name of the module that contains the code that is executing.",
+          "type": "string"
+        },
+        "state": {
+          "description": "A dictionary, each of whose keys specifies a variable or expression, the associated value of which represents the variable or expression value. For an annotation of kind 'continuation', for example, this dictionary might hold the current assumed values of a set of global variables.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "nestingLevel": {
+          "description": "An integer representing a containment hierarchy within the thread flow.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "executionOrder": {
+          "description": "An integer representing the temporal order in which execution reached this location.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "executionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which this location was executed.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "importance": {
+          "description": "Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is \"essential\", \"important\", \"unimportant\". Default: \"important\".",
+          "enum": ["important", "essential", "unimportant"],
+          "default": "important"
+        },
+        "webRequest": {
+          "$ref": "#/definitions/webRequest",
+          "description": "A web request associated with this thread flow location."
+        },
+        "webResponse": {
+          "$ref": "#/definitions/webResponse",
+          "description": "A web response associated with this thread flow location."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the threadflow location."
+        }
+      }
+    },
+    "tool": {
+      "description": "The analysis tool that was run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "driver": {
+          "$ref": "#/definitions/toolComponent",
+          "description": "The analysis tool that was run."
+        },
+        "extensions": {
+          "description": "Tool extensions that contributed to or reconfigured the analysis tool that was run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the tool."
+        }
+      },
+      "required": ["driver"]
+    },
+    "toolComponent": {
+      "description": "A component, such as a plug-in or the driver, of the analysis tool that was run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "guid": {
+          "description": "A unique identifier for the tool component in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "name": {
+          "description": "The name of the tool component.",
+          "type": "string"
+        },
+        "organization": {
+          "description": "The organization or company that produced the tool component.",
+          "type": "string"
+        },
+        "product": {
+          "description": "A product suite to which the tool component belongs.",
+          "type": "string"
+        },
+        "productSuite": {
+          "description": "A localizable string containing the name of the suite of products to which the tool component belongs.",
+          "type": "string"
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A brief description of the tool component."
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A comprehensive description of the tool component."
+        },
+        "fullName": {
+          "description": "The name of the tool component along with its version and any other useful identifying information, such as its locale.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The tool component version, in whatever format the component natively provides.",
+          "type": "string"
+        },
+        "semanticVersion": {
+          "description": "The tool component version in the format specified by Semantic Versioning 2.0.",
+          "type": "string"
+        },
+        "dottedQuadFileVersion": {
+          "description": "The binary version of the tool component's primary executable file expressed as four non-negative integers separated by a period (for operating systems that express file versions in this way).",
+          "type": "string",
+          "pattern": "[0-9]+(\\.[0-9]+){3}"
+        },
+        "releaseDateUtc": {
+          "description": "A string specifying the UTC date (and optionally, the time) of the component's release.",
+          "type": "string"
+        },
+        "downloadUri": {
+          "description": "The absolute URI from which the tool component can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+        "informationUri": {
+          "description": "The absolute URI at which information about this version of the tool component can be found.",
+          "type": "string",
+          "format": "uri"
+        },
+        "globalMessageStrings": {
+          "description": "A dictionary, each of whose keys is a resource identifier and each of whose values is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "notifications": {
+          "description": "An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+        "rules": {
+          "description": "An array of reportingDescriptor objects relevant to the analysis performed by the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+        "taxa": {
+          "description": "An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+        "locations": {
+          "description": "An array of the artifactLocation objects associated with the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+        "language": {
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "type": "string",
+          "default": "en-US",
+          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}?$"
+        },
+        "contents": {
+          "description": "The kinds of data contained in this object.",
+          "type": "array",
+          "uniqueItems": true,
+          "default": ["localizedData", "nonLocalizedData"],
+          "items": {
+            "enum": ["localizedData", "nonLocalizedData"]
+          }
+        },
+        "isComprehensive": {
+          "description": "Specifies whether this object contains a complete definition of the localizable and/or non-localizable data for this component, as opposed to including only data that is relevant to the results persisted to this log file.",
+          "type": "boolean",
+          "default": false
+        },
+        "localizedDataSemanticVersion": {
+          "description": "The semantic version of the localized strings defined in this component; maintained by components that provide translations.",
+          "type": "string"
+        },
+        "minimumRequiredLocalizedDataSemanticVersion": {
+          "description": "The minimum value of localizedDataSemanticVersion required in translations consumed by this component; used by components that consume translations.",
+          "type": "string"
+        },
+        "associatedComponent": {
+          "$ref": "#/definitions/toolComponentReference",
+          "description": "The component which is strongly associated with this component. For a translation, this refers to the component which has been translated. For an extension, this is the driver that provides the extension's plugin model."
+        },
+        "translationMetadata": {
+          "$ref": "#/definitions/translationMetadata",
+          "description": "Translation metadata, required for a translation, not populated by other component types."
+        },
+        "supportedTaxonomies": {
+          "description": "An array of toolComponentReference objects to declare the taxonomies supported by the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponentReference"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the tool component."
+        }
+      },
+      "required": ["name"]
+    },
+    "toolComponentReference": {
+      "description": "Identifies a particular toolComponent object, either the driver or an extension.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The 'name' property of the referenced toolComponent.",
+          "type": "string"
+        },
+        "index": {
+          "description": "An index into the referenced toolComponent in tool.extensions.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "guid": {
+          "description": "The 'guid' property of the referenced toolComponent.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the toolComponentReference."
+        }
+      }
+    },
+    "translationMetadata": {
+      "description": "Provides additional metadata related to translation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The name associated with the translation metadata.",
+          "type": "string"
+        },
+        "fullName": {
+          "description": "The full name associated with the translation metadata.",
+          "type": "string"
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A brief description of the translation metadata."
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A comprehensive description of the translation metadata."
+        },
+        "downloadUri": {
+          "description": "The absolute URI from which the translation metadata can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+        "informationUri": {
+          "description": "The absolute URI from which information related to the translation metadata can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the translation metadata."
+        }
+      },
+      "required": ["name"]
+    },
+    "versionControlDetails": {
+      "description": "Specifies the information necessary to retrieve a desired revision from a version control system.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repositoryUri": {
+          "description": "The absolute URI of the repository.",
+          "type": "string",
+          "format": "uri"
+        },
+        "revisionId": {
+          "description": "A string that uniquely and permanently identifies the revision within the repository.",
+          "type": "string"
+        },
+        "branch": {
+          "description": "The name of a branch containing the revision.",
+          "type": "string"
+        },
+        "revisionTag": {
+          "description": "A tag that has been applied to the revision.",
+          "type": "string"
+        },
+        "asOfTimeUtc": {
+          "description": "A Coordinated Universal Time (UTC) date and time that can be used to synchronize an enlistment to the state of the repository at that time.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "mappedTo": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location in the local file system to which the root of the repository was mapped at the time of the analysis."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the version control details."
+        }
+      },
+      "required": ["repositoryUri"]
+    },
+    "webRequest": {
+      "description": "Describes an HTTP request.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "index": {
+          "description": "The index within the run.webRequests array of the request object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "protocol": {
+          "description": "The request protocol. Example: 'http'.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The request version. Example: '1.1'.",
+          "type": "string"
+        },
+        "target": {
+          "description": "The target of the request.",
+          "type": "string"
+        },
+        "method": {
+          "description": "The HTTP method. Well-known values are 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'.",
+          "type": "string"
+        },
+        "headers": {
+          "description": "The request headers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "parameters": {
+          "description": "The request parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "body": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The body of the request."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the request."
+        }
+      }
+    },
+    "webResponse": {
+      "description": "Describes the response to an HTTP request.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "index": {
+          "description": "The index within the run.webResponses array of the response object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "protocol": {
+          "description": "The response protocol. Example: 'http'.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The response version. Example: '1.1'.",
+          "type": "string"
+        },
+        "statusCode": {
+          "description": "The response status code. Example: 451.",
+          "type": "integer"
+        },
+        "reasonPhrase": {
+          "description": "The response reason. Example: 'Not found'.",
+          "type": "string"
+        },
+        "headers": {
+          "description": "The response headers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "body": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The body of the response."
+        },
+        "noResponseReceived": {
+          "description": "Specifies whether a response was received from the server.",
+          "type": "boolean",
+          "default": false
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the response."
+        }
+      }
+    }
+  },
+  "description": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.",
+  "properties": {
+    "$schema": {
+      "description": "The URI of the JSON schema corresponding to the version.",
+      "type": "string",
+      "format": "uri"
+    },
+    "version": {
+      "description": "The SARIF format version of this log file.",
+      "enum": ["2.1.0"]
+    },
+    "runs": {
+      "description": "The set of runs contained in this log file.",
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": false,
+      "items": {
+        "$ref": "#/definitions/run"
+      }
+    },
+    "inlineExternalProperties": {
+      "description": "References to external property files that share data between runs.",
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/externalProperties"
+      }
+    },
+    "properties": {
+      "$ref": "#/definitions/propertyBag",
+      "description": "Key/value pairs that provide additional information about the log file."
+    }
+  },
+  "required": ["version", "runs"],
+  "title": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema",
+  "type": "object"
+}

--- a/pkg/runner/warn_duplicate_test.go
+++ b/pkg/runner/warn_duplicate_test.go
@@ -46,10 +46,11 @@ func TestWarnDuplicateTemplateIDs(t *testing.T) {
 		assert.NotContains(t, out, "Duplicate template id")
 	})
 
-	t.Run("nil and empty-id entries are skipped without warning", func(t *testing.T) {
+	t.Run("nil, nil-embedded-Template, and empty-id entries are skipped without warning or panic", func(t *testing.T) {
 		out := captureStderr(func() {
 			warnDuplicateTemplateIDs([]*templates.CompiledTemplate{
 				nil,
+				{FilePath: "templates/rest/no-template.yaml"}, // nil embedded *Template
 				ct("", "templates/rest/empty1.yaml"),
 				ct("", "templates/rest/empty2.yaml"),
 			})

--- a/pkg/runner/warn_duplicate_test.go
+++ b/pkg/runner/warn_duplicate_test.go
@@ -71,3 +71,10 @@ func TestWarnDuplicateTemplateIDs(t *testing.T) {
 			"second and third file each warn against the first-seen path")
 	})
 }
+
+func TestSarifLacksTemplates(t *testing.T) {
+	assert.True(t, sarifLacksTemplates("sarif", 0), "sarif with no templates → warn")
+	assert.False(t, sarifLacksTemplates("sarif", 3), "sarif with templates → no warn")
+	assert.False(t, sarifLacksTemplates("json", 0), "non-sarif output → no warn regardless of count")
+	assert.False(t, sarifLacksTemplates("terminal", 0))
+}

--- a/pkg/runner/warn_duplicate_test.go
+++ b/pkg/runner/warn_duplicate_test.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/praetorian-inc/hadrian/pkg/templates"
+)
+
+func ct(id, path string) *templates.CompiledTemplate {
+	return &templates.CompiledTemplate{
+		Template: &templates.Template{ID: id},
+		FilePath: path,
+	}
+}
+
+// TestWarnDuplicateTemplateIDs covers the contract of the shared loader guard:
+// warn once per id declared by more than one file, name both paths, stay silent
+// when ids are unique, and skip nil / empty-id entries. The duplicate path is
+// the only thing standing between a misconfigured template set and a silently
+// hidden second finding (duplicate ids collapse to one SARIF rule + fingerprint),
+// so the warning content is asserted, not merely its presence.
+func TestWarnDuplicateTemplateIDs(t *testing.T) {
+	t.Run("duplicate id warns once and names both paths", func(t *testing.T) {
+		out := captureStderr(func() {
+			warnDuplicateTemplateIDs([]*templates.CompiledTemplate{
+				ct("01-api1-bola-read", "templates/rest/a.yaml"),
+				ct("01-api1-bola-read", "templates/rest/b.yaml"),
+			})
+		})
+		assert.Equal(t, 1, strings.Count(out, "Duplicate template id"), "expected exactly one warning")
+		assert.Contains(t, out, "01-api1-bola-read")
+		assert.Contains(t, out, "templates/rest/a.yaml")
+		assert.Contains(t, out, "templates/rest/b.yaml")
+	})
+
+	t.Run("all distinct ids warn nothing", func(t *testing.T) {
+		out := captureStderr(func() {
+			warnDuplicateTemplateIDs([]*templates.CompiledTemplate{
+				ct("a", "templates/rest/a.yaml"),
+				ct("b", "templates/rest/b.yaml"),
+			})
+		})
+		assert.NotContains(t, out, "Duplicate template id")
+	})
+
+	t.Run("nil and empty-id entries are skipped without warning", func(t *testing.T) {
+		out := captureStderr(func() {
+			warnDuplicateTemplateIDs([]*templates.CompiledTemplate{
+				nil,
+				ct("", "templates/rest/empty1.yaml"),
+				ct("", "templates/rest/empty2.yaml"),
+			})
+		})
+		assert.NotContains(t, out, "Duplicate template id",
+			"empty IDs must not be treated as duplicates of each other")
+	})
+
+	t.Run("three files with same id warn on each collision after the first", func(t *testing.T) {
+		out := captureStderr(func() {
+			warnDuplicateTemplateIDs([]*templates.CompiledTemplate{
+				ct("dup", "templates/rest/a.yaml"),
+				ct("dup", "templates/rest/b.yaml"),
+				ct("dup", "templates/rest/c.yaml"),
+			})
+		})
+		assert.Equal(t, 2, strings.Count(out, "Duplicate template id"),
+			"second and third file each warn against the first-seen path")
+	})
+}

--- a/pkg/templates/template.go
+++ b/pkg/templates/template.go
@@ -9,6 +9,13 @@ type Template struct {
 	ID   string       `yaml:"id"`
 	Info TemplateInfo `yaml:"info"`
 
+	// FilePath is the source path the template was loaded from. It is set by the
+	// loader (not the YAML); yaml:"-" keeps the strict decoder (KnownFields)
+	// from treating it as an input key. The GraphQL loader copies it to
+	// CompiledTemplate.FilePath so helpUri resolution and duplicate-id
+	// diagnostics work the same as for REST/gRPC.
+	FilePath string `yaml:"-"`
+
 	// Endpoint selection criteria
 	EndpointSelector EndpointSelector `yaml:"endpoint_selector"`
 


### PR DESCRIPTION
## Summary

- Adds `sarif` as a third value to `--output` alongside `terminal`, `json`, and `markdown`. Closes [LAB-2747](https://linear.app/praetorianlabs/issue/LAB-2747).
- Maps `model.Finding` → SARIF v2.1.0 runs/results with stable `partialFingerprints["primaryLocationHash/v1"]` (SHA-256 of TemplateID + Method + Endpoint + AttackerRole + VictimRole) so GitHub Code Scanning deduplicates alerts across runs.
- New `model.Finding.TemplateID` field carries the rule identifier through every protocol (REST, GraphQL, gRPC, GraphQL non-template scanner).
- `helpUri` resolves to the canonical GitHub URL for built-in templates (`templates/{rest,graphql,grpc}/*.yaml`); falls back to the Template-System wiki page for custom templates.
- Ships an example GitHub Actions workflow at `.github/workflows/example-sarif-upload.yml` showing `hadrian` → `github/codeql-action/upload-sarif@v3`.
- README, CLAUDE.md, `docs/configuration.md`, `docs/rest.md`, and `docs/graphql.md` updated.

## Acceptance criteria (LAB-2747)

- [x] `hadrian test rest ... --output sarif --output-file report.sarif` produces a valid file
- [x] File validates against [sarif-2.1.0.json](https://json.schemastore.org/sarif-2.1.0.json)  ← enforced by `TestSARIFReporter_ValidatesAgainstSchema` (schema vendored in `pkg/runner/testdata/`)
- [x] GitHub Action example in `.github/workflows/example-sarif-upload.yml`
- [x] Cross-run deduplication tested — stable `partialFingerprints` covered by both stability and identity-sensitivity unit tests

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -race ./pkg/runner/...`
- [x] `golangci-lint run ./...` — 0 issues on affected packages
- [x] Smoke run: `bin/hadrian test rest --output sarif --output-file report.sarif` against a minimal OpenAPI spec, output validates against the schema
- [ ] Upload a generated SARIF to a test repo's GitHub Code Scanning and verify it appears with no duplicate alerts after re-running (manual, can be done at review time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)