### PR TITLE
test: drop Docker dependencies from Go integration tests (LAB-2749)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ go test ./...
 # Run tests with race detection
 go test -race ./...
 
-# Run integration tests
+# Run integration tests (fully in-process via httptest fixtures — NO Docker required)
 go test -tags=integration ./...
 
 # Run tests for a specific package
@@ -31,6 +31,19 @@ go test ./pkg/runner/...
 # Run a single test
 go test -run TestFunctionName ./pkg/package/...
 ```
+
+### Integration tests (no Docker)
+
+The `integration`-tagged tests are fully in-process and require no Docker daemon
+or external target. `pkg/runner/fixtures_test.go` builds an `httptest`-backed
+vulnerable REST API (opaque static bearer tokens, no JWT) that seeds BOLA/IDOR
+(API1), broken authentication (API2), excessive data exposure / BOPLA (API3),
+and BFLA (API5). `pkg/runner/integration_test.go` runs the real `templates/rest/`
+templates against it via `runner.RunTest(...)` and asserts findings per OWASP
+category. `pkg/plugins/graphql/integration_test.go` stands up an in-process
+GraphQL service (introspection + DVGA-style queries/mutations); the gRPC
+integration tests parse local `.proto` fixtures under `test/grpc/`. The crAPI /
+DVGA Docker harnesses (below) are for optional *live* end-to-end testing only.
 
 ## Architecture
 
@@ -115,7 +128,11 @@ Built-in safeguards in `pkg/runner/ratelimit_client.go`:
 - Reactive backoff on 429/503 responses via `RateLimitingClient`
 - Audit logging to `.hadrian/audit.log`
 
-## Testing with crAPI
+## Live testing with crAPI (optional, Docker)
+
+> This is **optional** end-to-end testing against a real vulnerable target and is
+> **not** part of the Go test suite (`go test -tags=integration` needs no Docker —
+> see "Integration tests" above). Live-target harnesses are tracked separately.
 
 The `test/crapi/` directory contains a complete example for testing [OWASP crAPI](https://github.com/OWASP/crAPI), an intentionally vulnerable API. The supported flow is the wrapper scripts under `test/`:
 

--- a/README.md
+++ b/README.md
@@ -209,9 +209,15 @@ make check       # Run all checks (fmt, vet, lint, test)
 
 ```bash
 go test ./...                        # Unit tests
-go test -tags=integration ./...      # Integration tests
+go test -tags=integration ./...      # Integration tests (fully in-process, no Docker)
 go test -race ./...                  # Race detection
 ```
+
+> **No Docker required.** The Go integration tests stand up in-process `httptest`
+> fixtures with seeded BOLA / BFLA / BOPLA / IDOR bugs, so the full suite —
+> including `-tags=integration` — runs in a fresh devcontainer with no Docker
+> daemon. The crAPI / DVGA Docker harnesses under `test/` are for optional
+> end-to-end *live* testing only (see the wiki tutorials), not for the test suite.
 
 ## Contributing
 

--- a/pkg/plugins/graphql/integration_test.go
+++ b/pkg/plugins/graphql/integration_test.go
@@ -65,6 +65,14 @@ func newVulnerableGraphQLServer(t *testing.T) *httptest.Server {
 		case strings.Contains(req.Query, "__typename"):
 			data["__typename"] = "Query"
 		case strings.Contains(req.Query, "systemHealth"):
+			// Require the exact Authorization header that the bearer executor sets
+			// (authInfo.Value is written verbatim: "Bearer test-admin-token").
+			// This makes TestIntegration_AuthenticatedRequest meaningful: a request
+			// with no auth or a wrong token will receive 401 instead of 200.
+			if r.Header.Get("Authorization") != "Bearer test-admin-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 			data["systemHealth"] = "ok"
 		case strings.Contains(req.Query, "users"):
 			data["users"] = []map[string]interface{}{{"id": "1", "username": "admin"}}
@@ -185,6 +193,12 @@ func TestIntegration_AuthenticatedRequest(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(result.Body), &resp))
 	assert.Equal(t, "ok", resp.Data["systemHealth"])
+
+	// Negative case: no auth should yield 401, confirming the server actually
+	// enforces the auth gate and the test above is not a false positive.
+	unauthResult, err := executor.Execute(ctx, `query { systemHealth }`, nil, "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 401, unauthResult.StatusCode, "systemHealth without auth should return 401")
 }
 
 func TestIntegration_SchemaDiscovery(t *testing.T) {

--- a/pkg/plugins/graphql/integration_test.go
+++ b/pkg/plugins/graphql/integration_test.go
@@ -27,6 +27,13 @@ import (
 // mutations modeled on the Damn Vulnerable GraphQL Application (DVGA):
 // `users` / `pastes` queries, a `createPaste` mutation, and a `systemHealth`
 // query. Integration tests run real introspection + execution against it.
+//
+// SCOPE: these tests validate the GraphQL plumbing (schema introspection and
+// query execution) against an in-process target. Detection-rate regression
+// coverage for the templates/graphql/ detection templates is NOT exercised
+// here — that is covered for REST in pkg/runner/integration_test.go
+// (TestIntegration_NoRegression_AllTemplates). Running the GraphQL/gRPC
+// detection templates in-process is tracked as separate follow-up work.
 // =============================================================================
 
 // newVulnerableGraphQLServer builds and starts the in-process GraphQL service.
@@ -47,8 +54,12 @@ func newVulnerableGraphQLServer(t *testing.T) *httptest.Server {
 			return
 		}
 
-		// Regular queries → echo back data referencing the requested fields so
-		// callers can assert on the response body.
+		// Regular queries → return canned data for the requested root field.
+		// Routing is naive substring matching, which is sufficient ONLY because
+		// the fixture's known queries use non-overlapping root-field tokens.
+		// If you add a query whose text contains another branch's token as a
+		// nested selection (e.g. `pastes { author { ... } }` containing "users"),
+		// route on the GraphQL root field instead of a bare substring.
 		data := map[string]interface{}{}
 		switch {
 		case strings.Contains(req.Query, "__typename"):
@@ -143,7 +154,14 @@ func TestIntegration_QueryExecution(t *testing.T) {
 	result, err := executor.Execute(ctx, "{ __typename }", nil, "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, 200, result.StatusCode)
-	assert.Contains(t, result.Body, "__typename")
+
+	// Assert on the decoded data envelope value, not just substring presence —
+	// proves the executor returned the GraphQL `data` payload intact.
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result.Body), &resp))
+	assert.Equal(t, "Query", resp.Data["__typename"])
 }
 
 func TestIntegration_AuthenticatedRequest(t *testing.T) {
@@ -161,6 +179,12 @@ func TestIntegration_AuthenticatedRequest(t *testing.T) {
 	result, err := executor.Execute(ctx, `query { systemHealth }`, nil, "", authInfo)
 	require.NoError(t, err)
 	assert.Equal(t, 200, result.StatusCode)
+
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result.Body), &resp))
+	assert.Equal(t, "ok", resp.Data["systemHealth"])
 }
 
 func TestIntegration_SchemaDiscovery(t *testing.T) {

--- a/pkg/plugins/graphql/integration_test.go
+++ b/pkg/plugins/graphql/integration_test.go
@@ -5,8 +5,11 @@ package graphql
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
-	"os"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,29 +19,124 @@ import (
 	"github.com/praetorian-inc/hadrian/pkg/graphql"
 )
 
-func TestIntegration_IntrospectionClient(t *testing.T) {
-	endpoint := os.Getenv("DVGA_ENDPOINT")
-	if endpoint == "" {
-		t.Skip("DVGA_ENDPOINT not set, skipping integration test")
-	}
+// =============================================================================
+// In-process vulnerable GraphQL service (no Docker, no external DVGA target).
+//
+// Replaces the previous DVGA_ENDPOINT (Docker) dependency with an httptest
+// server that answers GraphQL introspection and a small set of queries /
+// mutations modeled on the Damn Vulnerable GraphQL Application (DVGA):
+// `users` / `pastes` queries, a `createPaste` mutation, and a `systemHealth`
+// query. Integration tests run real introspection + execution against it.
+// =============================================================================
 
-	client := graphql.NewIntrospectionClient(http.DefaultClient, endpoint)
+// newVulnerableGraphQLServer builds and starts the in-process GraphQL service.
+func newVulnerableGraphQLServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &req)
+
+		w.Header().Set("Content-Type", "application/json")
+
+		// Introspection request → return the schema.
+		if strings.Contains(req.Query, "__schema") || strings.Contains(req.Query, "IntrospectionQuery") {
+			_ = json.NewEncoder(w).Encode(introspectionResponse())
+			return
+		}
+
+		// Regular queries → echo back data referencing the requested fields so
+		// callers can assert on the response body.
+		data := map[string]interface{}{}
+		switch {
+		case strings.Contains(req.Query, "__typename"):
+			data["__typename"] = "Query"
+		case strings.Contains(req.Query, "systemHealth"):
+			data["systemHealth"] = "ok"
+		case strings.Contains(req.Query, "users"):
+			data["users"] = []map[string]interface{}{{"id": "1", "username": "admin"}}
+		default:
+			data["ok"] = true
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": data})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// introspectionResponse returns a minimal-but-valid introspection result with
+// the DVGA-style queries (`users`, `pastes`) and mutation (`createPaste`).
+func introspectionResponse() graphql.IntrospectionResult {
+	return graphql.IntrospectionResult{
+		Data: graphql.IntrospectionData{
+			Schema: graphql.IntrospectionSchema{
+				QueryType:    &graphql.TypeNameRef{Name: "Query"},
+				MutationType: &graphql.TypeNameRef{Name: "Mutation"},
+				Types: []graphql.IntrospectionType{
+					{
+						Kind: "OBJECT",
+						Name: "Query",
+						Fields: []graphql.IntrospectionField{
+							{Name: "users", Type: graphql.IntrospectionTypeRef{Kind: "LIST", OfType: &graphql.IntrospectionTypeRef{Kind: "OBJECT", Name: "UserObject"}}},
+							{Name: "pastes", Type: graphql.IntrospectionTypeRef{Kind: "LIST", OfType: &graphql.IntrospectionTypeRef{Kind: "OBJECT", Name: "PasteObject"}}},
+							{Name: "systemHealth", Type: graphql.IntrospectionTypeRef{Kind: "SCALAR", Name: "String"}},
+						},
+					},
+					{
+						Kind: "OBJECT",
+						Name: "Mutation",
+						Fields: []graphql.IntrospectionField{
+							{
+								Name: "createPaste",
+								Type: graphql.IntrospectionTypeRef{Kind: "OBJECT", Name: "PasteObject"},
+								Args: []graphql.IntrospectionInput{
+									{Name: "title", Type: graphql.IntrospectionTypeRef{Kind: "SCALAR", Name: "String"}},
+									{Name: "content", Type: graphql.IntrospectionTypeRef{Kind: "SCALAR", Name: "String"}},
+								},
+							},
+						},
+					},
+					{
+						Kind: "OBJECT",
+						Name: "UserObject",
+						Fields: []graphql.IntrospectionField{
+							{Name: "id", Type: graphql.IntrospectionTypeRef{Kind: "SCALAR", Name: "ID"}},
+							{Name: "username", Type: graphql.IntrospectionTypeRef{Kind: "SCALAR", Name: "String"}},
+						},
+					},
+					{
+						Kind: "OBJECT",
+						Name: "PasteObject",
+						Fields: []graphql.IntrospectionField{
+							{Name: "id", Type: graphql.IntrospectionTypeRef{Kind: "SCALAR", Name: "ID"}},
+							{Name: "content", Type: graphql.IntrospectionTypeRef{Kind: "SCALAR", Name: "String"}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestIntegration_IntrospectionClient(t *testing.T) {
+	server := newVulnerableGraphQLServer(t)
+
+	client := graphql.NewIntrospectionClient(http.DefaultClient, server.URL)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	schema, err := client.FetchSchema(ctx)
 	require.NoError(t, err)
-	assert.NotNil(t, schema)
-	assert.True(t, len(schema.Queries) > 0, "should have queries")
+	require.NotNil(t, schema)
+	assert.Greater(t, len(schema.Queries), 0, "should have queries")
 }
 
 func TestIntegration_QueryExecution(t *testing.T) {
-	endpoint := os.Getenv("DVGA_ENDPOINT")
-	if endpoint == "" {
-		t.Skip("DVGA_ENDPOINT not set, skipping integration test")
-	}
+	server := newVulnerableGraphQLServer(t)
 
-	executor := graphql.NewExecutor(http.DefaultClient, endpoint, nil)
+	executor := graphql.NewExecutor(http.DefaultClient, server.URL, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -49,45 +147,32 @@ func TestIntegration_QueryExecution(t *testing.T) {
 }
 
 func TestIntegration_AuthenticatedRequest(t *testing.T) {
-	endpoint := os.Getenv("DVGA_ENDPOINT")
-	if endpoint == "" {
-		t.Skip("DVGA_ENDPOINT not set, skipping integration test")
-	}
+	server := newVulnerableGraphQLServer(t)
 
-	token := os.Getenv("DVGA_ADMIN_TOKEN")
-	if token == "" {
-		t.Skip("DVGA_ADMIN_TOKEN not set, skipping authenticated test")
-	}
-
-	executor := graphql.NewExecutor(http.DefaultClient, endpoint, nil)
+	executor := graphql.NewExecutor(http.DefaultClient, server.URL, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	authInfo := &graphql.AuthInfo{
 		Method: "bearer",
-		Value:  "Bearer " + token,
+		Value:  "Bearer test-admin-token",
 	}
 
-	query := `query { systemHealth }`
-	result, err := executor.Execute(ctx, query, nil, "", authInfo)
+	result, err := executor.Execute(ctx, `query { systemHealth }`, nil, "", authInfo)
 	require.NoError(t, err)
 	assert.Equal(t, 200, result.StatusCode)
 }
 
 func TestIntegration_SchemaDiscovery(t *testing.T) {
-	endpoint := os.Getenv("DVGA_ENDPOINT")
-	if endpoint == "" {
-		t.Skip("DVGA_ENDPOINT not set, skipping integration test")
-	}
+	server := newVulnerableGraphQLServer(t)
 
-	client := graphql.NewIntrospectionClient(http.DefaultClient, endpoint)
+	client := graphql.NewIntrospectionClient(http.DefaultClient, server.URL)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	schema, err := client.FetchSchema(ctx)
 	require.NoError(t, err)
 
-	// Verify expected DVGA operations exist
 	hasUsersQuery := false
 	hasPastesQuery := false
 	for _, q := range schema.Queries {
@@ -98,11 +183,9 @@ func TestIntegration_SchemaDiscovery(t *testing.T) {
 			hasPastesQuery = true
 		}
 	}
-
 	assert.True(t, hasUsersQuery, "should have users query")
 	assert.True(t, hasPastesQuery, "should have pastes query")
 
-	// Verify mutations exist
 	hasCreatePaste := false
 	for _, m := range schema.Mutations {
 		if m.Name == "createPaste" {

--- a/pkg/plugins/grpc/integration_test.go
+++ b/pkg/plugins/grpc/integration_test.go
@@ -16,6 +16,13 @@ import (
 
 // These integration tests parse the local .proto fixtures under test/grpc/.
 // They require no Docker or running gRPC server — parsing happens in-process.
+//
+// SOURCE OF TRUTH: the exact-equality assertions below (operation counts,
+// method names, owner fields) are derived from test/grpc/sample.proto and
+// test/grpc/complex.proto. These assertions are intentionally drift-sensitive —
+// they verify the parser's contract and SHOULD break if a .proto changes. If
+// you edit those proto fixtures, update the expected values here in the same
+// commit.
 
 func TestIntegration_ParseSampleProto(t *testing.T) {
 	protoPath := filepath.Join("..", "..", "..", "test", "grpc", "sample.proto")

--- a/pkg/plugins/grpc/integration_test.go
+++ b/pkg/plugins/grpc/integration_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// These integration tests parse the local .proto fixtures under test/grpc/.
+// They require no Docker or running gRPC server — parsing happens in-process.
+
 func TestIntegration_ParseSampleProto(t *testing.T) {
-	// Find test fixtures relative to repo root
 	protoPath := filepath.Join("..", "..", "..", "test", "grpc", "sample.proto")
 
 	content, err := os.ReadFile(protoPath)
@@ -23,34 +25,29 @@ func TestIntegration_ParseSampleProto(t *testing.T) {
 
 	plugin := &GRPCPlugin{}
 
-	// Verify CanParse
 	assert.True(t, plugin.CanParse(content, "sample.proto"))
 
-	// Parse
 	spec, err := plugin.Parse(content)
 	require.NoError(t, err)
 	require.NotNil(t, spec)
 
-	// Verify services extracted
 	assert.Equal(t, "gRPC API", spec.Info.Title)
 
-	// Should have operations from both UserService and AdminService
-	// UserService: 5 methods, AdminService: 2 methods = 7 total
-	assert.GreaterOrEqual(t, len(spec.Operations), 7)
+	// sample.proto defines GreeterService with SayHello + GetProfile (2 methods).
+	assert.Equal(t, 2, len(spec.Operations))
 
-	// Find GetUser operation
-	var getUserOp *model.Operation
+	var getProfileOp *model.Operation
 	for _, op := range spec.Operations {
-		if strings.Contains(op.Path, "GetUser") {
-			getUserOp = op
+		if strings.Contains(op.Path, "GetProfile") {
+			getProfileOp = op
 			break
 		}
 	}
-	require.NotNil(t, getUserOp, "GetUser operation should exist")
+	require.NotNil(t, getProfileOp, "GetProfile operation should exist")
 
-	assert.Equal(t, "grpc", getUserOp.Protocol)
-	assert.Equal(t, "id", getUserOp.OwnerField)
-	assert.False(t, getUserOp.RequiresAuth, "GetUser should not require auth")
+	assert.Equal(t, "grpc", getProfileOp.Protocol)
+	// ProfileRequest has a user_id field → inferred as the owner field.
+	assert.Equal(t, "user_id", getProfileOp.OwnerField)
 }
 
 func TestIntegration_ParseComplexProto(t *testing.T) {
@@ -63,11 +60,9 @@ func TestIntegration_ParseComplexProto(t *testing.T) {
 	spec, err := plugin.Parse(content)
 	require.NoError(t, err)
 
-	// Should skip streaming method (StreamOrders)
-	// CreateOrder and GetOrder should be included = 2 operations
+	// Should skip the streaming method (StreamOrders); CreateOrder + GetOrder = 2.
 	assert.Equal(t, 2, len(spec.Operations))
 
-	// Verify CreateOrder has user_id as owner field
 	var createOrderOp *model.Operation
 	for _, op := range spec.Operations {
 		if strings.Contains(op.Path, "CreateOrder") {
@@ -77,12 +72,12 @@ func TestIntegration_ParseComplexProto(t *testing.T) {
 	}
 	require.NotNil(t, createOrderOp)
 
-	// Should have user_id as owner field
+	// CreateOrderRequest has user_id → owner field.
 	assert.Equal(t, "user_id", createOrderOp.OwnerField)
 }
 
 func TestIntegration_AuthRequirementInference(t *testing.T) {
-	protoPath := filepath.Join("..", "..", "..", "test", "grpc", "sample.proto")
+	protoPath := filepath.Join("..", "..", "..", "test", "grpc", "complex.proto")
 
 	content, err := os.ReadFile(protoPath)
 	require.NoError(t, err)
@@ -93,22 +88,14 @@ func TestIntegration_AuthRequirementInference(t *testing.T) {
 
 	authRequired := make(map[string]bool)
 	for _, op := range spec.Operations {
-		// Extract method name from path
 		parts := strings.Split(op.Path, "/")
 		methodName := parts[len(parts)-1]
 		authRequired[methodName] = op.RequiresAuth
 	}
 
-	// Read operations should not require auth
-	assert.False(t, authRequired["GetUser"])
-	assert.False(t, authRequired["ListUsers"])
-	assert.False(t, authRequired["GetSystemConfig"])
-
-	// Write operations should require auth
-	assert.True(t, authRequired["CreateUser"])
-	assert.True(t, authRequired["UpdateUser"])
-	assert.True(t, authRequired["DeleteUser"])
-	assert.True(t, authRequired["SetSystemConfig"])
+	// Read operation should not require auth; write/create operation should.
+	assert.False(t, authRequired["GetOrder"], "GetOrder (read) should not require auth")
+	assert.True(t, authRequired["CreateOrder"], "CreateOrder (write) should require auth")
 }
 
 func TestIntegration_OperationPaths(t *testing.T) {
@@ -121,14 +108,11 @@ func TestIntegration_OperationPaths(t *testing.T) {
 	spec, err := plugin.Parse(content)
 	require.NoError(t, err)
 
-	// Find specific operations and verify path format
 	pathsFound := make(map[string]bool)
 	for _, op := range spec.Operations {
 		pathsFound[op.Path] = true
 	}
 
-	// Verify expected paths exist
-	assert.True(t, pathsFound["/test.v1.UserService/GetUser"], "GetUser path")
-	assert.True(t, pathsFound["/test.v1.UserService/CreateUser"], "CreateUser path")
-	assert.True(t, pathsFound["/test.v1.AdminService/GetSystemConfig"], "GetSystemConfig path")
+	assert.True(t, pathsFound["/example.GreeterService/SayHello"], "SayHello path")
+	assert.True(t, pathsFound["/example.GreeterService/GetProfile"], "GetProfile path")
 }

--- a/pkg/plugins/grpc/integration_test.go
+++ b/pkg/plugins/grpc/integration_test.go
@@ -101,8 +101,13 @@ func TestIntegration_AuthRequirementInference(t *testing.T) {
 	}
 
 	// Read operation should not require auth; write/create operation should.
-	assert.False(t, authRequired["GetOrder"], "GetOrder (read) should not require auth")
-	assert.True(t, authRequired["CreateOrder"], "CreateOrder (write) should require auth")
+	getOrderAuth, ok := authRequired["GetOrder"]
+	require.True(t, ok, "GetOrder operation should exist")
+	assert.False(t, getOrderAuth, "GetOrder (read) should not require auth")
+
+	createOrderAuth, ok := authRequired["CreateOrder"]
+	require.True(t, ok, "CreateOrder operation should exist")
+	assert.True(t, createOrderAuth, "CreateOrder (write) should require auth")
 }
 
 func TestIntegration_OperationPaths(t *testing.T) {

--- a/pkg/runner/fixtures_test.go
+++ b/pkg/runner/fixtures_test.go
@@ -1,0 +1,259 @@
+//go:build integration
+
+package runner
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// In-process vulnerable REST fixture (no Docker, no external target)
+// =============================================================================
+//
+// This file provides an httptest-backed REST API that intentionally seeds the
+// OWASP API vulnerabilities Hadrian's templates detect — BOLA/IDOR (API1),
+// broken authentication (API2), excessive data exposure / BOPLA (API3), and
+// BFLA (API5). Integration tests run the real templates in templates/rest/
+// against this server, so detection is exercised end-to-end without launching
+// any container.
+//
+// Authentication uses opaque static bearer tokens (no JWT dependency): each
+// token simply maps to a seeded user. The vulnerabilities live in the
+// (missing) authorization checks, which is what the templates probe.
+
+// fixtureTokens maps bearer tokens to the user ID + role they authenticate as.
+// admin is the highest-privilege victim; user2 is the lowest-privilege attacker.
+var fixtureTokens = map[string]struct {
+	userID int
+	role   string
+}{
+	"admin-token": {userID: 1, role: "admin"},
+	"user1-token": {userID: 2, role: "user"},
+	"user2-token": {userID: 3, role: "user"},
+}
+
+// fixtureUser returns the user a bearer token authenticates as, or ok=false.
+func fixtureUser(r *http.Request) (userID int, role string, ok bool) {
+	authz := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authz, "Bearer ") {
+		return 0, "", false
+	}
+	u, found := fixtureTokens[strings.TrimPrefix(authz, "Bearer ")]
+	return u.userID, u.role, found
+}
+
+func fixtureJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// newVulnerableRESTServer builds the seeded vulnerable REST API and returns a
+// running httptest server. The caller is responsible for nothing — cleanup is
+// registered via t.Cleanup.
+func newVulnerableRESTServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(vulnerableRESTHandler())
+	t.Cleanup(server.Close)
+	return server
+}
+
+// vulnerableRESTHandler builds the seeded vulnerable REST API as an http.Handler
+// so callers can wrap it (e.g. to capture request headers) before serving.
+func vulnerableRESTHandler() http.Handler {
+	mux := http.NewServeMux()
+
+	// requireAuth wraps a handler so it rejects requests without a valid token.
+	// This models endpoints that DO enforce authentication but NOT authorization
+	// (the BOLA/BFLA bugs live in the handler returning data regardless of owner).
+	requireAuth := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if _, _, ok := fixtureUser(r); !ok {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next(w, r)
+		}
+	}
+
+	// API1 — BOLA/IDOR: any authenticated user can read any user record.
+	mux.HandleFunc("/api/users/", requireAuth(func(w http.ResponseWriter, r *http.Request) {
+		fixtureJSON(w, http.StatusOK, map[string]interface{}{
+			"id": pathID(r, "/api/users/"), "username": "victim", "email": "victim@example.com", "role": "admin",
+		})
+	}))
+
+	// API3 — Excessive data exposure / BOPLA: profile leaks SSN to any authed user.
+	mux.HandleFunc("/api/profiles/", requireAuth(func(w http.ResponseWriter, r *http.Request) {
+		fixtureJSON(w, http.StatusOK, map[string]interface{}{
+			"id": pathID(r, "/api/profiles/"), "user_id": 1, "full_name": "Victim User",
+			"ssn": "123-45-6789", "phone_number": "555-0001", "credit_card": "4111111111111111",
+		})
+	}))
+
+	// API1 — BOLA on orders (read/delete with no ownership check).
+	mux.HandleFunc("/api/orders/", requireAuth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		fixtureJSON(w, http.StatusOK, map[string]interface{}{
+			"id": pathID(r, "/api/orders/"), "user_id": 1, "product": "Victim Widget", "amount": 100.0,
+		})
+	}))
+
+	// API1 — BOLA on documents (read/update/delete private docs with no check).
+	mux.HandleFunc("/api/documents/", requireAuth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		fixtureJSON(w, http.StatusOK, map[string]interface{}{
+			"id": pathID(r, "/api/documents/"), "user_id": 1, "title": "Private Doc",
+			"content": "confidential", "is_private": true,
+		})
+	}))
+
+	// API5 — BFLA: admin endpoint reachable by ANY authenticated user (no role check).
+	mux.HandleFunc("/api/admin/users", requireAuth(func(w http.ResponseWriter, r *http.Request) {
+		fixtureJSON(w, http.StatusOK, []map[string]interface{}{
+			{"id": 1, "username": "admin", "role": "admin"},
+		})
+	}))
+
+	// API2 — Broken authentication: this endpoint is declared as requiring auth in
+	// the spec, but the handler serves sensitive config WITHOUT any token.
+	mux.HandleFunc("/api/internal/config", func(w http.ResponseWriter, r *http.Request) {
+		fixtureJSON(w, http.StatusOK, map[string]interface{}{
+			"database_host": "db.internal.example.com", "debug_mode": true,
+			"secret_key_ref": "vault://secrets/api-key",
+		})
+	})
+
+	return mux
+}
+
+// pathID extracts the trailing path segment (the resource id) after prefix.
+func pathID(r *http.Request, prefix string) string {
+	return strings.TrimPrefix(r.URL.Path, prefix)
+}
+
+// =============================================================================
+// Spec / roles / auth fixtures (written to a temp dir, pointed at the server)
+// =============================================================================
+
+// fixtureSpecTemplate is an OpenAPI 3.0 spec describing the seeded endpoints.
+// %s is replaced with the running server URL. Every endpoint declares bearer
+// security so the templates treat them as authenticated endpoints.
+const fixtureSpecTemplate = `openapi: "3.0.0"
+info:
+  title: Vulnerable Test API
+  version: "1.0.0"
+servers:
+  - url: "%s"
+paths:
+  /api/users/{id}:
+    get:
+      summary: Get user by ID
+      security: [{bearerAuth: []}]
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      responses: {"200": {description: OK}}
+  /api/profiles/{id}:
+    get:
+      summary: Get profile by ID
+      security: [{bearerAuth: []}]
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      responses: {"200": {description: OK}}
+  /api/orders/{id}:
+    get:
+      summary: Get order by ID
+      security: [{bearerAuth: []}]
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      responses: {"200": {description: OK}}
+    delete:
+      summary: Delete order by ID
+      security: [{bearerAuth: []}]
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      responses: {"204": {description: No Content}}
+  /api/documents/{id}:
+    get:
+      summary: Get document by ID
+      security: [{bearerAuth: []}]
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      responses: {"200": {description: OK}}
+  /api/admin/users:
+    get:
+      summary: List all users (admin only)
+      security: [{bearerAuth: []}]
+      responses: {"200": {description: OK}}
+  /api/internal/config:
+    get:
+      summary: Internal configuration (should require auth)
+      security: [{bearerAuth: []}]
+      responses: {"200": {description: OK}}
+components:
+  securitySchemes:
+    bearerAuth: {type: http, scheme: bearer}
+`
+
+// fixtureRolesConfig defines the privilege levels used to pick attacker/victim
+// roles. admin is the high-privilege victim; user2 is the low-privilege attacker.
+const fixtureRolesConfig = `roles:
+  - name: admin
+    level: 100
+    permissions: ["*:*:all"]
+  - name: user1
+    level: 50
+    permissions: ["read:users:own", "read:profiles:own", "read:orders:own", "read:documents:own"]
+  - name: user2
+    level: 5
+    permissions: ["read:users:own", "read:profiles:own", "read:orders:own", "read:documents:own"]
+objects: [users, profiles, orders, documents, admin]
+endpoints:
+  - {path: "/api/users/{id}", object: users, owner_field: id}
+  - {path: "/api/profiles/{id}", object: profiles, owner_field: user_id}
+  - {path: "/api/orders/{id}", object: orders, owner_field: user_id}
+  - {path: "/api/documents/{id}", object: documents, owner_field: user_id}
+`
+
+// fixtureAuthConfig maps each role to its static bearer token.
+const fixtureAuthConfig = `method: bearer
+roles:
+  admin:
+    token: "admin-token"
+  user1:
+    token: "user1-token"
+  user2:
+    token: "user2-token"
+`
+
+// writeFixtureConfigs writes the spec/roles/auth files into a temp dir for the
+// given server URL and returns their paths.
+func writeFixtureConfigs(t *testing.T, serverURL string) (apiPath, rolesPath, authPath string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	apiPath = filepath.Join(dir, "api.yaml")
+	if err := os.WriteFile(apiPath, []byte(strings.Replace(fixtureSpecTemplate, "%s", serverURL, 1)), 0o644); err != nil {
+		t.Fatalf("write api spec: %v", err)
+	}
+	rolesPath = filepath.Join(dir, "roles.yaml")
+	if err := os.WriteFile(rolesPath, []byte(fixtureRolesConfig), 0o644); err != nil {
+		t.Fatalf("write roles: %v", err)
+	}
+	authPath = filepath.Join(dir, "auth.yaml")
+	if err := os.WriteFile(authPath, []byte(fixtureAuthConfig), 0o644); err != nil {
+		t.Fatalf("write auth: %v", err)
+	}
+	return apiPath, rolesPath, authPath
+}
+
+// restTemplateDir is the path to the production REST templates relative to the
+// pkg/runner package directory.
+const restTemplateDir = "../../templates/rest"

--- a/pkg/runner/fixtures_test.go
+++ b/pkg/runner/fixtures_test.go
@@ -64,6 +64,25 @@ func newVulnerableRESTServer(t *testing.T) *httptest.Server {
 	return server
 }
 
+// newSecuredRESTServer is the NON-vulnerable control: it enforces authorization
+// on every endpoint the spec declares — missing token → 401, present token →
+// 403 (deny, since the attacker is never the resource owner / not admin). The
+// same templates that fire against the vulnerable fixture must produce ZERO
+// findings here, proving the detection assertions are differential rather than
+// unconditional.
+func newSecuredRESTServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, _, ok := fixtureUser(r); !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, "Forbidden", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
 // vulnerableRESTHandler builds the seeded vulnerable REST API as an http.Handler
 // so callers can wrap it (e.g. to capture request headers) before serving.
 func vulnerableRESTHandler() http.Handler {

--- a/pkg/runner/fixtures_test.go
+++ b/pkg/runner/fixtures_test.go
@@ -206,6 +206,11 @@ paths:
       security: [{bearerAuth: []}]
       parameters: [{name: id, in: path, required: true, schema: {type: string}}]
       responses: {"200": {description: OK}}
+    put:
+      summary: Update document by ID (no ownership check — BOLA write)
+      security: [{bearerAuth: []}]
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      responses: {"200": {description: OK}}
   /api/admin/users:
     get:
       summary: List all users (admin only)

--- a/pkg/runner/integration_test.go
+++ b/pkg/runner/integration_test.go
@@ -107,6 +107,33 @@ func TestIntegration_NoRegression_AllTemplates(t *testing.T) {
 	}
 }
 
+// TestIntegration_SecuredServer_NoFindings is the control case for
+// TestIntegration_NoRegression_AllTemplates: the SAME templates, run against a
+// properly-secured server (401/403 on every endpoint), must produce ZERO
+// findings. This proves the detection assertions are differential (vulnerable →
+// findings, secured → none) and guards against an over-detection regression
+// that would emit findings regardless of the response.
+func TestIntegration_SecuredServer_NoFindings(t *testing.T) {
+	server := newSecuredRESTServer(t)
+	apiPath, rolesPath, authPath := writeFixtureConfigs(t, server.URL)
+
+	config := Config{
+		API:         apiPath,
+		Roles:       rolesPath,
+		Auth:        authPath,
+		TemplateDir: restTemplateDir,
+		Categories:  []string{"all"},
+		RateLimit:   50.0,
+		Timeout:     30,
+		Output:      "json",
+	}
+
+	findings, err := RunTest(context.Background(), config)
+	require.NoError(t, err)
+	assert.Empty(t, findings,
+		"a properly-secured server (401/403) must yield no findings; got %v", findingsByCategory(findings))
+}
+
 // TestIntegration_JSONOutput verifies the CLI path (runTest) produces valid JSON
 // against the in-process fixture.
 func TestIntegration_JSONOutput(t *testing.T) {

--- a/pkg/runner/integration_test.go
+++ b/pkg/runner/integration_test.go
@@ -87,6 +87,22 @@ func TestIntegration_BFLADetection(t *testing.T) {
 		"BFLA template should detect non-admin access to /api/admin/users; got %v", counts)
 }
 
+func TestIntegration_BOLAWriteDetection(t *testing.T) {
+	// PUT to /api/documents/{id} succeeds for a non-owner → BOLA write.
+	findings := runFixtureTemplates(t, "02-api1-bola-write")
+	counts := findingsByCategory(findings)
+	assert.Positive(t, counts["API1:2023"],
+		"BOLA-write template should detect cross-user object modification; got %v", counts)
+}
+
+func TestIntegration_BOLADeleteDetection(t *testing.T) {
+	// DELETE to /api/orders/{id} succeeds for a non-owner → BOLA delete.
+	findings := runFixtureTemplates(t, "03-api1-bola-delete")
+	counts := findingsByCategory(findings)
+	assert.Positive(t, counts["API1:2023"],
+		"BOLA-delete template should detect cross-user object deletion; got %v", counts)
+}
+
 // TestIntegration_NoRegression_AllTemplates runs the full REST template suite
 // against the fixture and asserts the detection rate has not regressed: each of
 // the core OWASP categories the fixture seeds must still produce findings.

--- a/pkg/runner/integration_test.go
+++ b/pkg/runner/integration_test.go
@@ -3,397 +3,188 @@
 package runner
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/praetorian-inc/hadrian/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // =============================================================================
-// Integration Test Fixtures
+// Integration tests — in-process httptest fixtures, no Docker.
+//
+// These exercise Hadrian's real templates (templates/rest/) against the seeded
+// vulnerable API from fixtures_test.go, asserting that BOLA/IDOR, broken
+// authentication, excessive data exposure (BOPLA), and BFLA are detected
+// without launching any container.
 // =============================================================================
 
-const testOpenAPISpec = `
-openapi: "3.0.0"
-info:
-  title: Test API
-  version: "1.0.0"
-servers:
-  - url: "%s"
-paths:
-  /api/users:
-    get:
-      summary: List users
-      security:
-        - bearerAuth: []
-      responses:
-        "200":
-          description: Success
-  /api/users/{id}:
-    get:
-      summary: Get user by ID
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Success
-components:
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-`
+// runFixtureTemplates runs the given REST templates against the vulnerable
+// fixture server and returns the resulting findings.
+func runFixtureTemplates(t *testing.T, templateIDs ...string) []*model.Finding {
+	t.Helper()
+	server := newVulnerableRESTServer(t)
+	apiPath, rolesPath, authPath := writeFixtureConfigs(t, server.URL)
 
-const testRolesConfig = `
-objects:
-  - users
-roles:
-  - name: admin
-    permissions:
-      - "read:users:all"
-      - "write:users:all"
-  - name: user
-    permissions:
-      - "read:users:own"
-  - name: guest
-    permissions: []
-`
-
-const testAuthConfig = `
-auth_method: bearer_token
-roles:
-  admin:
-    token: "admin-token-12345"
-  user:
-    token: "user-token-67890"
-  guest:
-    token: "guest-token-00000"
-`
-
-// =============================================================================
-// Integration Tests
-// =============================================================================
-
-func TestIntegration_FullWorkflow(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
-	// Create mock HTTP server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"id": "123", "name": "test user"}`))
-	}))
-	defer server.Close()
-
-	// Create temp directory for test files
-	tmpDir := t.TempDir()
-
-	// Write API spec with server URL
-	apiSpecPath := filepath.Join(tmpDir, "api.yaml")
-	specContent := strings.Replace(testOpenAPISpec, "%s", server.URL, 1)
-	err := os.WriteFile(apiSpecPath, []byte(specContent), 0644)
-	require.NoError(t, err)
-
-	// Write roles config
-	rolesPath := filepath.Join(tmpDir, "roles.yaml")
-	err = os.WriteFile(rolesPath, []byte(testRolesConfig), 0644)
-	require.NoError(t, err)
-
-	// Write auth config
-	authPath := filepath.Join(tmpDir, "auth.yaml")
-	err = os.WriteFile(authPath, []byte(testAuthConfig), 0644)
-	require.NoError(t, err)
-
-	// Create templates directory with a simple template
-	templatesDir := filepath.Join(tmpDir, "templates", "rest")
-	err = os.MkdirAll(templatesDir, 0755)
-	require.NoError(t, err)
-
-	// Set HADRIAN_TEMPLATES env var
-	os.Setenv("HADRIAN_TEMPLATES", templatesDir)
-	defer os.Unsetenv("HADRIAN_TEMPLATES")
-
-	// Create config
 	config := Config{
-		API:        apiSpecPath,
-		Roles:      rolesPath,
-		Auth:       authPath,
-		RateLimit:  10.0,
-		Timeout:    30,
-		Output:     "terminal",
-		Categories: []string{"owasp"},
+		API:         apiPath,
+		Roles:       rolesPath,
+		Auth:        authPath,
+		TemplateDir: restTemplateDir,
+		Categories:  []string{"all"},
+		Templates:   templateIDs,
+		RateLimit:   50.0,
+		Timeout:     30,
+		Output:      "json",
 	}
 
-	// Run the test
-	ctx := context.Background()
-	err = runTest(ctx, config)
-
-	// Should complete without error (may have no findings if no templates)
-	// The main goal is to verify the workflow executes
-	assert.NoError(t, err)
+	findings, err := RunTest(context.Background(), config)
+	require.NoError(t, err, "RunTest should not error against in-process fixture")
+	return findings
 }
 
-func TestIntegration_DryRunMode(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
+// findingsByCategory counts findings per OWASP category.
+func findingsByCategory(findings []*model.Finding) map[string]int {
+	counts := make(map[string]int)
+	for _, f := range findings {
+		counts[f.Category]++
+	}
+	return counts
+}
+
+func TestIntegration_BOLADetection(t *testing.T) {
+	findings := runFixtureTemplates(t, "01-api1-bola-read")
+	counts := findingsByCategory(findings)
+	assert.Positive(t, counts["API1:2023"],
+		"BOLA template should detect cross-user object access on the vulnerable fixture; got %v", counts)
+}
+
+func TestIntegration_BrokenAuthDetection(t *testing.T) {
+	findings := runFixtureTemplates(t, "04-api2-broken-auth-no-token")
+	counts := findingsByCategory(findings)
+	assert.Positive(t, counts["API2:2023"],
+		"broken-auth template should detect the unauthenticated /api/internal/config access; got %v", counts)
+}
+
+func TestIntegration_ExcessiveDataExposure(t *testing.T) {
+	findings := runFixtureTemplates(t, "05-api3-excessive-data-exposure")
+	counts := findingsByCategory(findings)
+	assert.Positive(t, counts["API3:2023"],
+		"excessive-data template should detect the leaked SSN/credit_card fields; got %v", counts)
+}
+
+func TestIntegration_BFLADetection(t *testing.T) {
+	findings := runFixtureTemplates(t, "06-api5-bfla-admin-access")
+	counts := findingsByCategory(findings)
+	assert.Positive(t, counts["API5:2023"],
+		"BFLA template should detect non-admin access to /api/admin/users; got %v", counts)
+}
+
+// TestIntegration_NoRegression_AllTemplates runs the full REST template suite
+// against the fixture and asserts the detection rate has not regressed: each of
+// the core OWASP categories the fixture seeds must still produce findings.
+func TestIntegration_NoRegression_AllTemplates(t *testing.T) {
+	findings := runFixtureTemplates(t) // no filter → all templates
+	require.NotEmpty(t, findings, "running all templates against the vulnerable fixture should yield findings")
+
+	counts := findingsByCategory(findings)
+	t.Logf("findings by category: %v (total=%d)", counts, len(findings))
+
+	for _, category := range []string{"API1:2023", "API2:2023", "API3:2023", "API5:2023"} {
+		assert.Positivef(t, counts[category],
+			"expected at least one %s finding against the seeded fixture (regression?); got %v", category, counts)
 	}
 
-	// Track request count
-	var requestCount int32
+	for _, f := range findings {
+		assert.True(t, f.IsVulnerability, "returned findings should be vulnerabilities")
+	}
+}
 
-	// Create mock HTTP server that tracks requests
+// TestIntegration_JSONOutput verifies the CLI path (runTest) produces valid JSON
+// against the in-process fixture.
+func TestIntegration_JSONOutput(t *testing.T) {
+	server := newVulnerableRESTServer(t)
+	apiPath, rolesPath, authPath := writeFixtureConfigs(t, server.URL)
+	outputFile := filepath.Join(t.TempDir(), "report.json")
+
+	config := Config{
+		API:         apiPath,
+		Roles:       rolesPath,
+		Auth:        authPath,
+		TemplateDir: restTemplateDir,
+		Categories:  []string{"all"},
+		RateLimit:   50.0,
+		Timeout:     30,
+		Output:      "json",
+		OutputFile:  outputFile,
+	}
+
+	require.NoError(t, runTest(context.Background(), config))
+
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	var result interface{}
+	assert.NoError(t, json.Unmarshal(data, &result), "output should be valid JSON")
+}
+
+// TestIntegration_MarkdownOutput verifies the markdown reporter path.
+func TestIntegration_MarkdownOutput(t *testing.T) {
+	server := newVulnerableRESTServer(t)
+	apiPath, rolesPath, authPath := writeFixtureConfigs(t, server.URL)
+	outputFile := filepath.Join(t.TempDir(), "report.md")
+
+	config := Config{
+		API:         apiPath,
+		Roles:       rolesPath,
+		Auth:        authPath,
+		TemplateDir: restTemplateDir,
+		Categories:  []string{"all"},
+		RateLimit:   50.0,
+		Timeout:     30,
+		Output:      "markdown",
+		OutputFile:  outputFile,
+	}
+
+	require.NoError(t, runTest(context.Background(), config))
+
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "# Hadrian Security Test Report", "markdown report should contain the report header")
+	assert.Contains(t, content, "## Summary", "markdown report should contain the summary section")
+}
+
+// TestIntegration_DryRunMode verifies dry-run sends NO requests to the target.
+func TestIntegration_DryRunMode(t *testing.T) {
+	var requestCount int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&requestCount, 1)
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"id": "123"}`))
+		vulnerableRESTHandler().ServeHTTP(w, r)
 	}))
 	defer server.Close()
 
-	// Create temp directory for test files
-	tmpDir := t.TempDir()
+	apiPath, rolesPath, authPath := writeFixtureConfigs(t, server.URL)
 
-	// Write API spec
-	apiSpecPath := filepath.Join(tmpDir, "api.yaml")
-	specContent := strings.Replace(testOpenAPISpec, "%s", server.URL, 1)
-	err := os.WriteFile(apiSpecPath, []byte(specContent), 0644)
-	require.NoError(t, err)
-
-	// Write roles config
-	rolesPath := filepath.Join(tmpDir, "roles.yaml")
-	err = os.WriteFile(rolesPath, []byte(testRolesConfig), 0644)
-	require.NoError(t, err)
-
-	// Set empty templates dir
-	templatesDir := filepath.Join(tmpDir, "templates")
-	err = os.MkdirAll(templatesDir, 0755)
-	require.NoError(t, err)
-	os.Setenv("HADRIAN_TEMPLATES", templatesDir)
-	defer os.Unsetenv("HADRIAN_TEMPLATES")
-
-	// Create config with DryRun enabled
 	config := Config{
-		API:        apiSpecPath,
-		Roles:      rolesPath,
-		RateLimit:  10.0,
-		Timeout:    30,
-		Output:     "terminal",
-		Categories: []string{"owasp"},
-		DryRun:     true, // Enable dry-run mode
+		API:         apiPath,
+		Roles:       rolesPath,
+		Auth:        authPath,
+		TemplateDir: restTemplateDir,
+		Categories:  []string{"all"},
+		RateLimit:   50.0,
+		Timeout:     30,
+		Output:      "terminal",
+		DryRun:      true,
 	}
 
-	// Run the test
-	ctx := context.Background()
-	_ = runTest(ctx, config)
-
-	// In dry-run mode, no HTTP requests should be made to the target
-	// Note: The mock server may receive 0 requests if dry-run is properly implemented
-	// This test verifies the dry-run flag is respected
+	require.NoError(t, runTest(context.Background(), config))
 	assert.Equal(t, int32(0), atomic.LoadInt32(&requestCount),
-		"dry-run mode should not make HTTP requests to target server")
-}
-
-func TestIntegration_VerboseOutput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
-	// Create mock HTTP server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	defer server.Close()
-
-	// Create temp directory for test files
-	tmpDir := t.TempDir()
-
-	// Write API spec
-	apiSpecPath := filepath.Join(tmpDir, "api.yaml")
-	specContent := strings.Replace(testOpenAPISpec, "%s", server.URL, 1)
-	err := os.WriteFile(apiSpecPath, []byte(specContent), 0644)
-	require.NoError(t, err)
-
-	// Write roles config
-	rolesPath := filepath.Join(tmpDir, "roles.yaml")
-	err = os.WriteFile(rolesPath, []byte(testRolesConfig), 0644)
-	require.NoError(t, err)
-
-	// Set empty templates dir
-	templatesDir := filepath.Join(tmpDir, "templates")
-	err = os.MkdirAll(templatesDir, 0755)
-	require.NoError(t, err)
-	os.Setenv("HADRIAN_TEMPLATES", templatesDir)
-	defer os.Unsetenv("HADRIAN_TEMPLATES")
-
-	// Capture stdout
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	// Create config with Verbose enabled
-	config := Config{
-		API:        apiSpecPath,
-		Roles:      rolesPath,
-		RateLimit:  10.0,
-		Timeout:    30,
-		Output:     "terminal",
-		Categories: []string{"owasp"},
-		Verbose:    true, // Enable verbose mode
-	}
-
-	// Run the test
-	ctx := context.Background()
-	_ = runTest(ctx, config)
-
-	// Restore stdout and read captured output
-	w.Close()
-	os.Stdout = oldStdout
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	output := buf.String()
-
-	// Verbose mode should produce output with INFO prefix
-	// Note: The actual verbose output depends on implementation
-	assert.NotEmpty(t, output, "verbose mode should produce output")
-}
-
-func TestIntegration_JSONOutput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
-	// Create mock HTTP server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	defer server.Close()
-
-	// Create temp directory for test files
-	tmpDir := t.TempDir()
-
-	// Write API spec
-	apiSpecPath := filepath.Join(tmpDir, "api.yaml")
-	specContent := strings.Replace(testOpenAPISpec, "%s", server.URL, 1)
-	err := os.WriteFile(apiSpecPath, []byte(specContent), 0644)
-	require.NoError(t, err)
-
-	// Write roles config
-	rolesPath := filepath.Join(tmpDir, "roles.yaml")
-	err = os.WriteFile(rolesPath, []byte(testRolesConfig), 0644)
-	require.NoError(t, err)
-
-	// Set empty templates dir
-	templatesDir := filepath.Join(tmpDir, "templates")
-	err = os.MkdirAll(templatesDir, 0755)
-	require.NoError(t, err)
-	os.Setenv("HADRIAN_TEMPLATES", templatesDir)
-	defer os.Unsetenv("HADRIAN_TEMPLATES")
-
-	// Create output file path
-	outputFile := filepath.Join(tmpDir, "report.json")
-
-	// Create config with JSON output
-	config := Config{
-		API:        apiSpecPath,
-		Roles:      rolesPath,
-		RateLimit:  10.0,
-		Timeout:    30,
-		Output:     "json",
-		OutputFile: outputFile,
-		Categories: []string{"owasp"},
-	}
-
-	// Run the test
-	ctx := context.Background()
-	err = runTest(ctx, config)
-	require.NoError(t, err)
-
-	// Read and verify JSON output
-	data, err := os.ReadFile(outputFile)
-	require.NoError(t, err)
-
-	// Verify it's valid JSON
-	var result interface{}
-	err = json.Unmarshal(data, &result)
-	assert.NoError(t, err, "output should be valid JSON")
-}
-
-func TestIntegration_MarkdownOutput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
-	// Create mock HTTP server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	defer server.Close()
-
-	// Create temp directory for test files
-	tmpDir := t.TempDir()
-
-	// Write API spec
-	apiSpecPath := filepath.Join(tmpDir, "api.yaml")
-	specContent := strings.Replace(testOpenAPISpec, "%s", server.URL, 1)
-	err := os.WriteFile(apiSpecPath, []byte(specContent), 0644)
-	require.NoError(t, err)
-
-	// Write roles config
-	rolesPath := filepath.Join(tmpDir, "roles.yaml")
-	err = os.WriteFile(rolesPath, []byte(testRolesConfig), 0644)
-	require.NoError(t, err)
-
-	// Set empty templates dir
-	templatesDir := filepath.Join(tmpDir, "templates")
-	err = os.MkdirAll(templatesDir, 0755)
-	require.NoError(t, err)
-	os.Setenv("HADRIAN_TEMPLATES", templatesDir)
-	defer os.Unsetenv("HADRIAN_TEMPLATES")
-
-	// Create output file path
-	outputFile := filepath.Join(tmpDir, "report.md")
-
-	// Create config with Markdown output
-	config := Config{
-		API:        apiSpecPath,
-		Roles:      rolesPath,
-		RateLimit:  10.0,
-		Timeout:    30,
-		Output:     "markdown",
-		OutputFile: outputFile,
-		Categories: []string{"owasp"},
-	}
-
-	// Run the test
-	ctx := context.Background()
-	err = runTest(ctx, config)
-	require.NoError(t, err)
-
-	// Read and verify Markdown output
-	data, err := os.ReadFile(outputFile)
-	require.NoError(t, err)
-
-	content := string(data)
-	// Verify it contains Markdown headers
-	assert.Contains(t, content, "#", "output should contain Markdown headers")
+		"dry-run mode must not send any HTTP request to the target")
 }

--- a/pkg/runner/request_id_e2e_test.go
+++ b/pkg/runner/request_id_e2e_test.go
@@ -63,12 +63,18 @@ func TestE2E_RequestIDsInTerminalOutput(t *testing.T) {
 		_ = w.Close()
 	})
 
+	var outputBuf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&outputBuf, r)
+		close(done)
+	}()
+
 	err := runTest(context.Background(), config)
 
 	_ = w.Close()
 	os.Stdout = oldStdout
-	var outputBuf bytes.Buffer
-	_, _ = io.Copy(&outputBuf, r)
+	<-done
 
 	require.NoError(t, err)
 

--- a/pkg/runner/request_id_e2e_test.go
+++ b/pkg/runner/request_id_e2e_test.go
@@ -5,188 +5,83 @@ package runner
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestE2E_RequestIDsInTerminalOutput verifies that request IDs flow
-// from template execution through to terminal reporter output
+// TestE2E_RequestIDsInTerminalOutput verifies that request IDs flow from
+// template execution through to terminal reporter output. It runs the real
+// BOLA template against the in-process vulnerable fixture (no Docker) and
+// captures the X-Hadrian-Request-Id headers the executor sends.
 func TestE2E_RequestIDsInTerminalOutput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
-	// Track request IDs received by server
+	var mu sync.Mutex
 	var capturedRequestIDs []string
 
-	// Create mock HTTP server that responds with vulnerability pattern
+	// Wrap the vulnerable fixture handler (built once) to capture request ID headers.
+	fixture := vulnerableRESTHandler()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Capture request ID header
-		requestID := r.Header.Get("X-Hadrian-Request-Id")
-		if requestID != "" {
-			capturedRequestIDs = append(capturedRequestIDs, requestID)
+		if id := r.Header.Get("X-Hadrian-Request-Id"); id != "" {
+			mu.Lock()
+			capturedRequestIDs = append(capturedRequestIDs, id)
+			mu.Unlock()
 		}
-
-		// Return vulnerable response (200 OK for anonymous access)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"id": "123", "name": "admin", "role": "administrator"}`))
+		fixture.ServeHTTP(w, r)
 	}))
 	defer server.Close()
 
-	// Create temp directory for test files
-	tmpDir := t.TempDir()
+	apiPath, rolesPath, authPath := writeFixtureConfigs(t, server.URL)
 
-	// Write API spec with server URL
-	apiSpec := `
-openapi: "3.0.0"
-info:
-  title: Test API
-  version: "1.0.0"
-servers:
-  - url: "` + server.URL + `"
-paths:
-  /api/users/{id}:
-    get:
-      summary: Get user
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Success
-components:
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-`
-	apiSpecPath := filepath.Join(tmpDir, "api.yaml")
-	err := os.WriteFile(apiSpecPath, []byte(apiSpec), 0644)
-	require.NoError(t, err)
-
-	// Write roles config
-	rolesConfig := `
-objects:
-  - users
-roles:
-  - name: admin
-    permissions:
-      - "read:users:all"
-  - name: user
-    permissions:
-      - "read:users:own"
-`
-	rolesPath := filepath.Join(tmpDir, "roles.yaml")
-	err = os.WriteFile(rolesPath, []byte(rolesConfig), 0644)
-	require.NoError(t, err)
-
-	// Write auth config
-	authConfig := `
-auth_method: bearer_token
-roles:
-  admin:
-    token: "admin-token"
-  user:
-    token: "user-token"
-`
-	authPath := filepath.Join(tmpDir, "auth.yaml")
-	err = os.WriteFile(authPath, []byte(authConfig), 0644)
-	require.NoError(t, err)
-
-	// Create templates directory
-	templatesDir := filepath.Join(tmpDir, "templates", "owasp")
-	err = os.MkdirAll(templatesDir, 0755)
-	require.NoError(t, err)
-
-	// Create simple template that will match
-	template := `
-id: test-vuln
-info:
-  name: "Test Vulnerability"
-  category: "API1"
-  severity: "HIGH"
-http:
-  - method: "GET"
-    path: "` + server.URL + `/api/users/123"
-    matchers:
-      - type: status
-        status: [200]
-      - type: word
-        words: ["admin"]
-`
-	templatePath := filepath.Join(templatesDir, "test.yaml")
-	err = os.WriteFile(templatePath, []byte(template), 0644)
-	require.NoError(t, err)
-
-	// Set HADRIAN_TEMPLATES env var to parent directory
-	os.Setenv("HADRIAN_TEMPLATES", filepath.Join(tmpDir, "templates"))
-	defer os.Unsetenv("HADRIAN_TEMPLATES")
-
-	// Capture terminal output
-	var outputBuf bytes.Buffer
-
-	// Create config
 	config := Config{
-		API:        apiSpecPath,
-		Roles:      rolesPath,
-		Auth:       authPath,
-		RateLimit:  10.0,
-		Timeout:    30,
-		Output:     "terminal",
-		Categories: []string{"owasp"},
-		Verbose:    true,
+		API:         apiPath,
+		Roles:       rolesPath,
+		Auth:        authPath,
+		TemplateDir: restTemplateDir,
+		Categories:  []string{"all"},
+		Templates:   []string{"01-api1-bola-read"},
+		RateLimit:   50.0,
+		Timeout:     30,
+		Output:      "terminal",
+		Verbose:     true,
 	}
 
-	// Redirect stdout to capture terminal output
+	// Capture stdout.
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	// Run the test
-	ctx := context.Background()
-	err = runTest(ctx, config)
+	err := runTest(context.Background(), config)
 
-	// Restore stdout and capture output
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
-	bytes, _ := os.ReadFile(r.Name())
-	outputBuf.Write(bytes)
+	var outputBuf bytes.Buffer
+	_, _ = io.Copy(&outputBuf, r)
 
 	require.NoError(t, err)
 
-	// Verify request IDs were sent to server
-	require.NotEmpty(t, capturedRequestIDs, "server should have received request ID headers")
+	mu.Lock()
+	ids := append([]string(nil), capturedRequestIDs...)
+	mu.Unlock()
+	require.NotEmpty(t, ids, "server should have received request ID headers")
 
-	// Verify terminal output
 	output := outputBuf.String()
-
-	// Should contain finding
-	assert.Contains(t, output, "BOLA Test", "output should contain finding name")
+	assert.Contains(t, output, "BOLA", "output should contain the BOLA finding name")
 	assert.Contains(t, output, "HIGH", "output should contain severity")
-
-	// CRITICAL: Should contain request IDs in output
 	assert.Contains(t, output, "Request IDs:", "output should label request IDs section")
 
-	// Verify at least one captured request ID appears in output
 	foundRequestID := false
-	for _, reqID := range capturedRequestIDs {
+	for _, reqID := range ids {
 		if strings.Contains(output, reqID) {
 			foundRequestID = true
 			break
 		}
 	}
-	assert.True(t, foundRequestID, "at least one request ID from server should appear in terminal output")
+	assert.True(t, foundRequestID, "at least one request ID from the server should appear in terminal output")
 }

--- a/pkg/runner/request_id_e2e_test.go
+++ b/pkg/runner/request_id_e2e_test.go
@@ -52,10 +52,16 @@ func TestE2E_RequestIDsInTerminalOutput(t *testing.T) {
 		Verbose:     true,
 	}
 
-	// Capture stdout.
+	// Capture stdout. Restore via t.Cleanup so a panic or fatal assertion in
+	// runTest cannot leave the process-global os.Stdout pointing at the pipe
+	// and corrupt the output of subsequent tests in this package.
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		_ = w.Close()
+	})
 
 	err := runTest(context.Background(), config)
 


### PR DESCRIPTION
## Summary

Replaces the Docker/live-target assumptions in the Go integration suite with **in-process `httptest` fixtures**, so the entire suite — including `-tags=integration` — runs in a fresh devcontainer with **no Docker daemon**.

Resolves [LAB-2749](https://linear.app/praetorianlabs/issue/LAB-2749/drop-docker-dependencies-from-go-integration-tests-httptest-fixtures).

> Context: the integration suite was not merely Docker-coupled — several integration tests were already **failing on `main`** (stale `auth_method:` auth fixtures; `sample.proto` fixture drift). This PR makes the whole tagged suite green and meaningful.

## Changes

- **`pkg/runner/fixtures_test.go` (new)** — an `httptest`-backed vulnerable REST API using opaque static bearer tokens (no JWT dependency) that seeds **BOLA/IDOR (API1)**, **broken authentication (API2)**, **excessive data exposure / BOPLA (API3)**, and **BFLA (API5)**, plus inline OpenAPI/roles/auth fixtures.
- **`pkg/runner/integration_test.go` (rewrite)** — runs the real `templates/rest/` templates via `runner.RunTest(...)` against the fixture and asserts findings per OWASP category, including a no-regression test across the full template suite.
- **`pkg/runner/request_id_e2e_test.go` (rewrite)** — request-ID-flow e2e rebuilt on the fixture (was failing on a stale auth fixture).
- **`pkg/plugins/graphql/integration_test.go` (rewrite)** — stands up an in-process GraphQL service (introspection + DVGA-style `users`/`pastes`/`createPaste`/`systemHealth`) instead of depending on a live `DVGA_ENDPOINT` Docker target.
- **`pkg/plugins/grpc/integration_test.go` (fix)** — expectations updated to match the current `test/grpc/*.proto` fixtures.
- **Docs** — `README.md` and `CLAUDE.md` note that Go integration tests are fully in-process; crAPI/DVGA harnesses remain optional **live-test** tutorials (per the ticket; live testing is tracked separately by NEW-52).

The crAPI/DVGA template YAMLs and `test/` live-test scripts are intentionally left untouched.

## Acceptance criteria

- [x] `make test` (`go test -race ./...`) succeeds with no Docker daemon
- [x] `go test ./... -tags=integration` exercises BOLA / BFLA / BOPLA / IDOR detection without launching any container
- [x] No regression in detection-rate of the existing REST templates against the in-process fixtures

## Verification (no Docker)

| Check | Result |
|---|---|
| `go test -race ./...` | ✅ 19 packages ok |
| `go test ./... -tags=integration` | ✅ all pass |
| `go vet ./...` / `-tags=integration` | ✅ clean |
| `golangci-lint` (integration tag) | ✅ 0 issues |

Detection against the fixture across the full REST template suite: **API1:15, API2:1, API3:18, API5:63 (97 findings)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)