### PR TITLE
ci: stop stray review comments cancelling in-progress AI reviews

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: claude-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}  # stray review comments must not cancel an in-progress review
 
 jobs:
   claude-code-action:

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: codex-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}  # stray review comments must not cancel an in-progress review
 
 jobs:
   codex-review:

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: gemini-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}  # stray review comments must not cancel an in-progress review
 
 jobs:
   gemini-review:


### PR DESCRIPTION
## What
Changes the AI-reviewer caller concurrency from `cancel-in-progress: true` to:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why
These callers trigger on `pull_request_review_comment`, and every comment shares
the same per-PR concurrency group. Workflow-level concurrency is evaluated at run
creation — **before** the reusable's preflight `@mention` gate skips a stray
comment — so an unconditional `true` lets *any* inline review comment cancel an
in-progress review and leave the PR with none.

Gating cancellation on `pull_request` (open/ready) events means stray review
comments queue behind a running review and no-op instead of killing it, while
open/ready dedup is preserved.

Same class of bug as google-github-actions/run-gemini-cli#195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)