### PR TITLE
ci: pin leaderboard-metrics reusable to v2.16.3

### DIFF
--- a/.github/workflows/leaderboard-metrics.yml
+++ b/.github/workflows/leaderboard-metrics.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   metrics:
-    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml@main
+    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml@c351826e6de27cadeb5b32ce81157355b283518b # v2.16.3
     with:
       capability_map: '[{"path": ".", "name": "hadrian"}]'


### PR DESCRIPTION
## Summary
Pins the leaderboard-metrics reusable workflow reference from the mutable `@main` to the reviewed, immutable SHA `c351826e` (public-workflows v2.16.3), closing the mutable-ref exposure on this caller.

The AWS IAM trust for the metrics role now accepts the pinned SHA sub (trust migration window), so this change is zero-downtime: metrics keep flowing during and after the roll.

Part of the org-wide leaderboard Phase-2 pin rotation (~34 repos). Future reusable bumps follow the documented four-step procedure (add new sub to trust → deploy → roll caller pins → remove old sub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)