### PR TITLE
docs(agents): regenerate AGENTS.md to spec (ENG-6805)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,229 +1,62 @@
 # AGENTS.md
 
-This is the canonical agent instruction file for this repository. It provides guidance to any coding agent working with this code — Claude Code, Codex, and Gemini all load it. `CLAUDE.md` is a one-line pointer to this file, and `.gemini/settings.json` names it for Gemini.
+Canonical agent instruction file for this repository; every coding agent loads it. `CLAUDE.md` is a one-line pointer to this file and `.gemini/settings.json` names it. Reference material that used to live here is under `docs/agents/`.
 
-## Overview
+Hadrian is an API security testing framework for REST, GraphQL, and gRPC APIs: OWASP API Top 10 checks driven by role-based authorization testing and YAML templates. Architecture, package layout, and rate-limiting safeguards: `docs/agents/architecture.md`.
 
-Hadrian is an API security testing framework for REST, GraphQL, and gRPC APIs that tests for OWASP API vulnerabilities using role-based authorization testing and YAML-driven templates.
+## Config-generation skill
 
-## Claude Code Skill
-
-This repo includes a Claude Code skill at `skills/hadrian-openapi-authz/` that generates `auth.yaml` and `roles.yaml` from API specifications (OpenAPI, GraphQL SDL, gRPC proto). When loaded as a plugin (`claude --plugin-dir .`), you can ask "Generate Hadrian config from my API spec" and it will produce valid configuration files.
+`skills/hadrian-openapi-authz/SKILL.md` generates `auth.yaml` and `roles.yaml` from an API specification (OpenAPI, GraphQL SDL, gRPC proto). Loading this repo as a plugin directory so that skill is available is documented in `README.md` (plugin integration section) and `docs/configuration.md`.
 
 ## Build and Test Commands
 
 ```bash
-# Build
-go build -o hadrian ./cmd/hadrian
-
-# Run all tests
-go test ./...
-
-# Run tests with race detection
-go test -race ./...
-
-# Run integration tests (fully in-process via httptest fixtures — NO Docker required)
-go test -tags=integration ./...
-
-# Run tests for a specific package
-go test ./pkg/runner/...
-
-# Run a single test
-go test -run TestFunctionName ./pkg/package/...
+go build -o hadrian ./cmd/hadrian   # root ./hadrian (gitignored) — what the live-target scripts build and call
+make build                          # writes bin/hadrian instead; the two outputs are different paths
+go test ./...                       # unit tests
+go test -race ./...                 # same as `make test`
+go test -tags=integration ./...     # in-process integration tests — no Docker, no live target
+go test ./pkg/runner/...            # one package
+go test -run TestFunctionName ./pkg/<package>/...
+make check                          # gofmt + go vet + golangci-lint (v2 config in .golangci.yml) + race tests
 ```
+
+The PR template asks for `make test` and `make lint` to pass; `make check` covers both.
 
 ### Integration tests (no Docker)
 
-The `integration`-tagged tests are fully in-process and require no Docker daemon
-or external target. `pkg/runner/fixtures_test.go` builds an `httptest`-backed
-vulnerable REST API (opaque static bearer tokens, no JWT) that seeds BOLA/IDOR
-(API1), broken authentication (API2), excessive data exposure / BOPLA (API3),
-and BFLA (API5). `pkg/runner/integration_test.go` runs the real `templates/rest/`
-templates against it via `runner.RunTest(...)` and asserts findings per OWASP
-category. `pkg/plugins/graphql/integration_test.go` stands up an in-process
-GraphQL service (introspection + DVGA-style queries/mutations); the gRPC
-integration tests parse local `.proto` fixtures under `test/grpc/`. The crAPI /
-DVGA Docker harnesses (below) are for optional *live* end-to-end testing only.
+The `integration`-tagged tests are fully in-process and need no Docker daemon or external target. `pkg/runner/fixtures_test.go` builds an `httptest`-backed vulnerable REST API (opaque static bearer tokens, no JWT) that seeds BOLA/IDOR (API1), broken authentication (API2), excessive data exposure / BOPLA (API3), and BFLA (API5); `pkg/runner/integration_test.go` runs the real `templates/rest/` templates against it via `runner.RunTest(...)` and asserts findings per OWASP category. `pkg/plugins/graphql/integration_test.go` stands up an in-process GraphQL service (introspection + DVGA-style queries/mutations). `pkg/plugins/grpc/integration_test.go` parses the `.proto` fixtures under `test/grpc/`, and its assertions are deliberately drift-sensitive: renaming a service, method, or owner field in `test/grpc/sample.proto` or `test/grpc/complex.proto` breaks them by design. The live targets under `test/` (below) are for optional end-to-end testing only, never for the Go suite.
 
-## Architecture
+## Templates — non-obvious behavior
 
-### Core Flow
-
-The CLI (`cmd/hadrian`) delegates to `pkg/runner.Run()` which orchestrates:
-1. Parse OpenAPI spec → `model.Operation` list
-2. Load roles configuration → `roles.RoleConfig` with parsed permissions
-3. Load YAML templates → `templates.CompiledTemplate` list
-4. For each operation × template × role combination:
-   - Check if `EndpointSelector` matches the operation
-   - Execute HTTP test using `templates.Executor`
-   - Evaluate `Detection` rules to determine vulnerability
-5. Optionally triage findings with LLM
-6. Generate report (terminal/JSON/markdown/SARIF)
-
-### Key Packages
-
-- **pkg/runner**: CLI commands, test orchestration, rate limiting (`ratelimit.go`, `ratelimit_client.go`), and execution logic
-- **pkg/templates**: YAML template parsing (`parse.go`), compilation (`compile.go`), and HTTP execution (`execute.go`)
-- **pkg/orchestrator**: Test orchestration, endpoint/role selectors, and mutation testing
-- **pkg/roles**: Permission model with `<action>:<object>:<scope>` format and role-based filtering
-- **pkg/model**: Data structures for `Finding`, `Operation`, `Evidence`, `Severity`
-- **pkg/matchers**: Response matching (status codes, word/regex patterns)
-- **pkg/reporter**: Output formatters (terminal, JSON, markdown) with finding redaction. SARIF v2.1.0 output lives at `pkg/runner/sarif.go` (it depends on the templates list, which is only available inside `pkg/runner`).
-- **pkg/llm**: LLM triage integration (Ollama, OpenAI, Anthropic)
-
-### Template System
-
-Templates in `templates/rest/` define security tests with:
-- `endpoint_selector`: Filters which operations to test — methods, path params (`has_path_parameter`), auth requirements, and **parameter-scoped selectors** for identity carried outside the path: `has_query_parameter` / `has_body_field` (operation exposes any query param / body field) and `query_parameter_names` / `body_field_names` (narrow to identity/scope params by name, case-insensitive)
-- `role_selector`: Defines attacker/victim role combinations by permission level (lower/higher/all/none)
-- `http`: HTTP request definition with template variables (`{{operation.method}}`, `{{attacker_token}}`)
-- `detection`: Success/failure indicators to determine if vulnerability exists
-
-Templates support both simple single-phase tests and multi-phase mutation tests (setup → attack → verify).
-
-#### Multi-Phase Mutation Tests
-
-For complex vulnerability patterns like BFLA and BOPLA, templates use `test_phases`:
-
-```yaml
-test_phases:
-  setup:
-    # Single phase (backwards compatible)
-    - path: "/api/user/dashboard"
-      auth: "victim"
-      store_response_fields:
-        victim_id: "id"
-        victim_video_id: "video_id"
-    # Multiple setup phases supported (array syntax)
-    - path: "/api/user/dashboard"
-      auth: "attacker"
-      store_response_fields:
-        attacker_video_id: "video_id"
-  attack:
-    path: "/api/resource/{victim_id}"
-    auth: "attacker"
-    use_stored_field: "victim_id"
-  verify:
-    path: "/api/resource/{victim_id}"
-    auth: "victim"
-    check_field: "status"
-    expected_value: "deleted"
-```
-
-Key features:
-- **`store_response_fields`**: Map of `alias: json_path` to extract and store multiple fields from setup responses
-- **`setup` as array**: Supports multiple sequential setup phases (e.g., get attacker's data, then victim's data)
-- **Placeholder substitution**: Use `{alias}` in paths and data fields to reference stored values
-- **Phase `operation`**: Maps to an HTTP verb — `create`→POST, `update`→PUT, `patch`/`write`→PATCH, `delete`→DELETE, `read`/empty→GET
-- **Phase `body` (+ optional `content_type`)**: A raw request body supporting `{alias}` substitution (defaults to `application/json`). Substituted values are context-escaped for the content type — JSON-string-escaped for JSON, query-escaped for `x-www-form-urlencoded`, XML-escaped for XML; other content types (e.g. `multipart/form-data`, `text/html`) receive the raw value
-
-Parameter-scoped BOLA examples (query/body identity) live under `examples/param-scoped-bola/` and load via `HADRIAN_TEMPLATES` with `--category all`.
-
-### Permission Format
-
-Permissions follow `<action>:<object>:<scope>`:
-- Actions: `read`, `write`, `delete`, `execute`, `*`
-- Scopes: `public`, `own`, `org`, `all`, `*`
-
-### Rate Limiting
-
-Built-in safeguards in `pkg/runner/ratelimit_client.go`:
-- Proactive rate limiting (default 5 req/s) via `RateLimiter`
-- Reactive backoff on 429/503 responses via `RateLimitingClient`
-- Audit logging to `.hadrian/audit.log`
+- `--category` (REST subcommand only) defaults to `owasp` and matches **exactly**, case-insensitively, against a template's `info.category` and `info.tags`. The parameter-scoped BOLA examples under `examples/param-scoped-bola/` are `API1:2023` / `owasp-api-top10`, so they are not selected unless you pass `--category all` and point `HADRIAN_TEMPLATES` at that directory.
+- `--template-dir` resolves flag, then `HADRIAN_TEMPLATES`, then the per-protocol default (`templates/rest/`, `templates/graphql/`, `templates/grpc/`).
+- Template schema, endpoint/role selectors, multi-phase mutation tests, body escaping rules, and the permission format: `docs/agents/templates.md`.
 
 ## Live Test Targets
 
-> These are **optional** end-to-end harnesses against locally-built vulnerable
-> targets and are **not** part of the Go test suite (`go test -tags=integration`
-> needs no live targets). Do **not** wire them into CI on untrusted/fork PRs — see
-> the CI safety note in `test/README.md`.
-
-The `test/` directory ships four in-house vulnerable targets, each a self-contained
-Go binary with its own `go.mod` (no Docker daemon, image pull, or repo clone required —
-the full suite runs in a fresh devcontainer):
-
-| Target | Protocol | Replaces | Covers |
-|--------|----------|----------|--------|
-| `vulnerable-api` | REST | — | BOLA, broken auth (bearer/apikey/basic/cookie) |
-| `vulnerable-graphql` | GraphQL | DVGA (Docker) | introspection, BOLA, BFLA, alias-DoS, field-duplication, error disclosure, command injection, path traversal |
-| `grpc-server` | gRPC | — | BOLA, BFLA, metadata injection |
-| `vulnerable-rest-complex` | REST | OWASP crAPI (Docker) | cross-tenant BOLA, BFLA, mass-assignment, excessive data exposure, no-rate-limit OTP (customers/vehicles/mechanics/orders) |
-
-The supported flow is the wrapper scripts under `test/`:
+Optional end-to-end harnesses against four locally built vulnerable Go binaries under `test/` (`vulnerable-api`, `vulnerable-graphql`, `grpc-server`, `vulnerable-rest-complex`; each has its own `go.mod`, no Docker). They are **not** part of the Go test suite. **Do not wire them into CI on untrusted or fork PRs**: `vulnerable-graphql` performs real OS command execution and arbitrary file writes as the invoking user while it runs. Full CI safety note: `test/README.md`. `test/ratelimit-demo/` is a separate rate-limit demo server, not one of the four.
 
 ```bash
-# One-time setup: builds hadrian + the four Go target binaries, writes .live-test-config.
-./test/setup-live-targets.sh
-
-# Run hadrian against every target (or pass --targets to subset).
-./test/run-live-tests.sh
-
-# Stop any running target processes and remove the generated config.
-./test/setup-live-targets.sh --teardown
-
-# Optional: exercise the LLM planner / triage against vulnerable-rest-complex.
-# Standalone, LLM-gated scripts (not part of the default run); pass the provider.
-export OPENAI_API_KEY=sk-...    # set once in your shell
-./test/test-llm-planner.sh openai
+./test/setup-live-targets.sh              # builds ./hadrian + the four targets, writes test/.live-test-config
+./test/run-live-tests.sh                  # every target, or --targets a,b to subset
+./test/setup-live-targets.sh --teardown   # stop running targets, remove the generated config
+./test/test-llm-planner.sh openai         # LLM-gated, standalone (not in the default run); provider arg defaults to openai
 ./test/test-llm-triage.sh  openai
 ```
 
-Programmatic invocation (without the wrapper), e.g. the crAPI-shape REST target:
-```bash
-./hadrian test rest \
-  --api test/vulnerable-rest-complex/openapi.yaml \
-  --roles test/vulnerable-rest-complex/roles.yaml \
-  --auth test/vulnerable-rest-complex/auth-bearer.yaml \
-  --template-dir test/vulnerable-rest-complex/templates/owasp \
-  --verbose
-```
+Per-target coverage table, direct `hadrian test rest` invocation against the crAPI-shape target, port helpers, and the regression harness: `docs/agents/live-targets.md`.
 
-Generic port helpers shared by all targets live in `test/lib/port-helpers.sh`.
-A Docker-free regression harness lives at `test/regression/lab-2750-regression-tests.sh`.
+## LLM planner and triage
 
-## LLM-Assisted Planner
-
-The planner (`pkg/planner/`) uses an LLM to generate a prioritized attack plan before execution. Instead of brute-forcing every operation × template × role combination, the LLM analyzes the API spec and selects the most likely vulnerability targets.
-
-### Usage
-
-```bash
-# Plan + brute-force (recommended): LLM steps first, then remaining combos
-./hadrian test rest --api spec.json --roles roles.yaml --auth auth.yaml --planner
-
-# Plan only: run ONLY what the LLM chose (--planner-only requires --planner)
-./hadrian test rest --api spec.json --roles roles.yaml --auth auth.yaml --planner --planner-only
-
-# Steer the planner with custom context
-./hadrian test rest ... --planner --planner-context "Focus on BOLA attacks on payment endpoints"
-```
-
-### Providers
-
-Set the appropriate env var and use `--planner-provider`:
-
-| Provider | Flag | Env Var | Default Model |
-|----------|------|---------|---------------|
-| OpenAI | `--planner-provider openai` (default) | `OPENAI_API_KEY` | gpt-4o |
-| Anthropic | `--planner-provider anthropic` | `ANTHROPIC_API_KEY` | claude-sonnet-4-20250514 |
-| Ollama | `--planner-provider ollama` | `OLLAMA_HOST` (optional) | llama3.2:latest |
-
-### Programmatic Usage
-
-For platform integration, inject an `LLMClient` via `Config.PlannerLLMClient`:
-
-```go
-config := runner.Config{
-    PlannerEnabled:   true,
-    PlannerLLMClient: myPlatformLLMClient, // implements planner.LLMClient
-}
-```
+- Planner flags (`--planner`, `--planner-only` which requires `--planner`, `--planner-provider`, `--planner-context`) exist on `hadrian test rest` only. Triage (`--llm-provider`) exists on `test rest` and `test graphql`; `test grpc` has neither.
+- Defaults are asymmetric: the planner defaults to `openai`, triage defaults to `ollama`. The Anthropic default model also differs (planner `claude-sonnet-4-20250514`, triage `claude-sonnet-4-6`).
+- Planner usage, provider table, and platform injection via `Config.PlannerLLMClient`: `docs/agents/planner.md`.
 
 ## Environment Variables
 
-- `HADRIAN_TEMPLATES`: Custom templates directory path
-- `OLLAMA_HOST`: Ollama host for LLM triage and planner (default: http://localhost:11434)
-- `OLLAMA_MODEL`: Ollama model name (default: llama3.2:latest)
-- `OPENAI_API_KEY`: OpenAI API key for LLM triage (`--llm-provider openai`) and planner
-- `ANTHROPIC_API_KEY`: Anthropic API key for LLM triage (`--llm-provider anthropic`) and planner
+- `HADRIAN_TEMPLATES`: custom templates directory (see resolution order above)
+- `OLLAMA_HOST`: Ollama host for triage and planner (default `http://localhost:11434`)
+- `OLLAMA_MODEL`: Ollama model name (default `llama3.2:latest`)
+- `OPENAI_API_KEY`: OpenAI key for triage (`--llm-provider openai`) and planner
+- `ANTHROPIC_API_KEY`: Anthropic key for triage (`--llm-provider anthropic`) and planner

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,40 @@
+# Hadrian architecture (agent reference)
+
+Relocated from `AGENTS.md` (ENG-6805). Package-level detail also lives in `docs/architecture.md`.
+
+## Overview
+
+Hadrian is an API security testing framework for REST, GraphQL, and gRPC APIs that tests for OWASP API vulnerabilities using role-based authorization testing and YAML-driven templates.
+
+## Core Flow
+
+The CLI (`cmd/hadrian`) delegates to `pkg/runner.Run()` which orchestrates:
+1. Parse OpenAPI spec → `model.Operation` list
+2. Load roles configuration → `roles.RoleConfig` with parsed permissions
+3. Load YAML templates → `templates.CompiledTemplate` list
+4. For each operation × template × role combination:
+   - Check if `EndpointSelector` matches the operation
+   - Execute HTTP test using `templates.Executor`
+   - Evaluate `Detection` rules to determine vulnerability
+5. Optionally triage findings with LLM
+6. Generate report (terminal/JSON/markdown/SARIF)
+
+## Key Packages
+
+- **pkg/runner**: CLI commands, test orchestration, rate limiting (`ratelimit.go`, `ratelimit_client.go`), and execution logic
+- **pkg/templates**: YAML template parsing (`parse.go`), compilation (`compile.go`), and HTTP execution (`execute.go`)
+- **pkg/orchestrator**: Test orchestration, endpoint/role selectors, and mutation testing
+- **pkg/roles**: Permission model with `<action>:<object>:<scope>` format and role-based filtering
+- **pkg/model**: Data structures for `Finding`, `Operation`, `Evidence`, `Severity`
+- **pkg/matchers**: Response matching (status codes, word/regex patterns)
+- **pkg/reporter**: Output formatters (terminal, JSON, markdown) with finding redaction. SARIF v2.1.0 output lives at `pkg/runner/sarif.go` (it depends on the templates list, which is only available inside `pkg/runner`).
+- **pkg/llm**: LLM triage integration (Ollama, OpenAI, Anthropic)
+
+Also present in the tree and not described above: `pkg/auth`, `pkg/graphql`, `pkg/log`, `pkg/plugins` (REST, GraphQL, and gRPC protocol plugins), `pkg/planner` (see `docs/agents/planner.md`), `pkg/util`, and `internal/http`. This list is a partial map; the tree is authoritative.
+
+## Rate Limiting
+
+Built-in safeguards in `pkg/runner/ratelimit_client.go` and `pkg/runner/ratelimit.go`:
+- Proactive rate limiting (default 5 req/s) via `RateLimiter`
+- Reactive backoff on 429/503 responses via `RateLimitingClient` (exponential by default, 1s initial, 60s max, 5 retries)
+- Audit logging via the `--audit-log` flag on the REST subcommand (default path is a gitignored `.hadrian` file)

--- a/docs/agents/live-targets.md
+++ b/docs/agents/live-targets.md
@@ -1,0 +1,57 @@
+# Hadrian live test targets (agent reference)
+
+Relocated from `AGENTS.md` (ENG-6805). The operational guide is `test/README.md`.
+
+## Live Test Targets
+
+> These are **optional** end-to-end harnesses against locally-built vulnerable
+> targets and are **not** part of the Go test suite (`go test -tags=integration`
+> needs no live targets). Do **not** wire them into CI on untrusted/fork PRs — see
+> the CI safety note in `test/README.md`: `vulnerable-graphql` runs real OS command
+> execution and arbitrary file writes as the invoking user while it is up.
+
+The `test/` directory ships four in-house vulnerable targets, each a self-contained
+Go binary with its own `go.mod` (no Docker daemon, image pull, or repo clone required —
+the full suite runs in a fresh devcontainer). `test/ratelimit-demo/` is a fifth,
+separate rate-limit demo server that is not part of this suite.
+
+| Target | Protocol | Replaces | Covers |
+|--------|----------|----------|--------|
+| `vulnerable-api` | REST | — | BOLA, broken auth (bearer/apikey/basic/cookie) |
+| `vulnerable-graphql` | GraphQL | DVGA (Docker) | introspection, BOLA, BFLA, alias-DoS, field-duplication, error disclosure, command injection, path traversal |
+| `grpc-server` | gRPC | — | BOLA, BFLA, metadata injection |
+| `vulnerable-rest-complex` | REST | OWASP crAPI (Docker) | cross-tenant BOLA, BFLA, mass-assignment, excessive data exposure, no-rate-limit OTP (customers/vehicles/mechanics/orders) |
+
+The supported flow is the wrapper scripts under `test/`:
+
+```bash
+# One-time setup: builds ./hadrian + the four Go target binaries, writes test/.live-test-config.
+./test/setup-live-targets.sh
+
+# Run hadrian against every target (or pass --targets to subset).
+./test/run-live-tests.sh
+
+# Stop any running target processes and remove the generated config.
+./test/setup-live-targets.sh --teardown
+
+# Optional: exercise the LLM planner / triage against vulnerable-rest-complex.
+# Standalone, LLM-gated scripts (not part of the default run); pass the provider
+# (defaults to openai).
+export OPENAI_API_KEY=sk-...    # set once in your shell
+./test/test-llm-planner.sh openai
+./test/test-llm-triage.sh  openai
+```
+
+Programmatic invocation (without the wrapper), e.g. the crAPI-shape REST target:
+```bash
+./hadrian test rest \
+  --api test/vulnerable-rest-complex/openapi.yaml \
+  --roles test/vulnerable-rest-complex/roles.yaml \
+  --auth test/vulnerable-rest-complex/auth-bearer.yaml \
+  --template-dir test/vulnerable-rest-complex/templates/owasp \
+  --verbose
+```
+
+Generic port helpers shared by all targets live in `test/lib/port-helpers.sh`
+(rest-complex-specific helpers in `test/lib/rest-complex-helpers.sh`).
+A Docker-free regression harness lives at `test/regression/lab-2750-regression-tests.sh`.

--- a/docs/agents/planner.md
+++ b/docs/agents/planner.md
@@ -1,0 +1,43 @@
+# Hadrian LLM-assisted planner (agent reference)
+
+Relocated from `AGENTS.md` (ENG-6805).
+
+## LLM-Assisted Planner
+
+The planner (`pkg/planner/`) uses an LLM to generate a prioritized attack plan before execution. Instead of brute-forcing every operation × template × role combination, the LLM analyzes the API spec and selects the most likely vulnerability targets. The planner flags are registered on the REST subcommand only (`pkg/runner/rest.go`); `test graphql` and `test grpc` do not expose them.
+
+### Usage
+
+```bash
+# Plan + brute-force (recommended): LLM steps first, then remaining combos
+./hadrian test rest --api spec.json --roles roles.yaml --auth auth.yaml --planner
+
+# Plan only: run ONLY what the LLM chose (--planner-only requires --planner)
+./hadrian test rest --api spec.json --roles roles.yaml --auth auth.yaml --planner --planner-only
+
+# Steer the planner with custom context
+./hadrian test rest ... --planner --planner-context "Focus on BOLA attacks on payment endpoints"
+```
+
+### Providers
+
+Set the appropriate env var and use `--planner-provider`:
+
+| Provider | Flag | Env Var | Default Model |
+|----------|------|---------|---------------|
+| OpenAI | `--planner-provider openai` (default) | `OPENAI_API_KEY` | gpt-4o |
+| Anthropic | `--planner-provider anthropic` | `ANTHROPIC_API_KEY` | claude-sonnet-4-20250514 |
+| Ollama | `--planner-provider ollama` | `OLLAMA_HOST` (optional) | llama3.2:latest |
+
+These are the planner defaults (`pkg/planner/`). Triage (`--llm-provider`, `pkg/llm/`) defaults to `ollama`, and its Anthropic default model is `claude-sonnet-4-6`.
+
+### Programmatic Usage
+
+For platform integration, inject an `LLMClient` via `Config.PlannerLLMClient` (`pkg/runner/rest.go`; consumed in `pkg/runner/library.go`):
+
+```go
+config := runner.Config{
+    PlannerEnabled:   true,
+    PlannerLLMClient: myPlatformLLMClient, // implements planner.LLMClient
+}
+```

--- a/docs/agents/templates.md
+++ b/docs/agents/templates.md
@@ -1,0 +1,57 @@
+# Hadrian template system (agent reference)
+
+Relocated from `AGENTS.md` (ENG-6805). Struct tags for every key below are in `pkg/templates/template.go`.
+
+## Template System
+
+Templates in `templates/rest/` define security tests with:
+- `endpoint_selector`: Filters which operations to test — methods, path params (`has_path_parameter`), auth requirements, and **parameter-scoped selectors** for identity carried outside the path: `has_query_parameter` / `has_body_field` (operation exposes any query param / body field) and `query_parameter_names` / `body_field_names` (narrow to identity/scope params by name, case-insensitive)
+- `role_selector`: Defines attacker/victim role combinations by permission level (lower/higher/all/none)
+- `http`: HTTP request definition with template variables (`{{operation.method}}`, `{{attacker_token}}`)
+- `detection`: Success/failure indicators to determine if vulnerability exists
+
+Templates support both simple single-phase tests and multi-phase mutation tests (setup → attack → verify).
+
+### Multi-Phase Mutation Tests
+
+For complex vulnerability patterns like BFLA and BOPLA, templates use `test_phases`:
+
+```yaml
+test_phases:
+  setup:
+    # Single phase (backwards compatible)
+    - path: "/api/user/dashboard"
+      auth: "victim"
+      store_response_fields:
+        victim_id: "id"
+        victim_video_id: "video_id"
+    # Multiple setup phases supported (array syntax)
+    - path: "/api/user/dashboard"
+      auth: "attacker"
+      store_response_fields:
+        attacker_video_id: "video_id"
+  attack:
+    path: "/api/resource/{victim_id}"
+    auth: "attacker"
+    use_stored_field: "victim_id"
+  verify:
+    path: "/api/resource/{victim_id}"
+    auth: "victim"
+    check_field: "status"
+    expected_value: "deleted"
+```
+
+Key features:
+- **`store_response_fields`**: Map of `alias: json_path` to extract and store multiple fields from setup responses
+- **`setup` as array**: Supports multiple sequential setup phases (e.g., get attacker's data, then victim's data)
+- **Placeholder substitution**: Use `{alias}` in paths and data fields to reference stored values
+- **Phase `operation`**: Maps to an HTTP verb — `create`→POST, `update`→PUT, `patch`/`write`→PATCH, `delete`→DELETE, `read`/empty→GET (`pkg/orchestrator/mutation.go`)
+- **Phase `body` (+ optional `content_type`)**: A raw request body supporting `{alias}` substitution (defaults to JSON). Substituted values are context-escaped for the content type — JSON-string-escaped for JSON, query-escaped for form-urlencoded, XML-escaped for XML; other content types (e.g. multipart form data, HTML) receive the raw value
+
+Parameter-scoped BOLA examples (query/body identity) live under `examples/param-scoped-bola/` and load via `HADRIAN_TEMPLATES` with `--category all` (the `--category` flag defaults to `owasp` and matches exactly against `info.category` and `info.tags`).
+
+## Permission Format
+
+Permissions follow `<action>:<object>:<scope>` (validated in `pkg/roles/roles.go`):
+- Actions: `read`, `write`, `delete`, `execute`, `*`
+- Scopes: `public`, `own`, `org`, `all`, `*`


### PR DESCRIPTION
Part of [ENG-6805](https://linear.app/praetorianlabs/issue/ENG-6805/regenerate-the-18-remaining-content-carrying-nested-instruction-files).

## Sizes

| | lines | bytes |
|---|---|---|
| before | 229 | 10,809 |
| after root | 62 | 5,540 |

Root under ≤300 / ≤9,216 B. Verify: refs=59 failed=0, neutrality=45 failed=0.

Relocated Architecture/Core Flow/Key Packages/Rate Limiting → architecture.md; Template System/Multi-Phase/Permission Format → templates.md; planner Usage/Providers/Programmatic → planner.md. Live targets also relocated.

Merge = human decision.