### PR TITLE
ENG-7621: Pin instruction-file audit to App token

### DIFF
--- a/.github/workflows/agents-md-audit.yml
+++ b/.github/workflows/agents-md-audit.yml
@@ -7,10 +7,11 @@ concurrency:
   cancel-in-progress: true
 jobs:
   audit:
-    uses: praetorian-inc/public-workflows/.github/workflows/agents-md-audit.yml@a1c9243b3365df01b2ea64948f4327b4089455b0  # v2.19.1
+    uses: praetorian-inc/public-workflows/.github/workflows/agents-md-audit.yml@522f02d44dc72b199da3d6b8db755fe3aeabff1d  # v2.19.2
     permissions:
       contents: read
       pull-requests: write
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      RUBRIC_TOKEN: ${{ secrets.RUBRIC_TOKEN }}
+      PALATINE_SKILLS_APP_ID: ${{ secrets.PALATINE_SKILLS_APP_ID }}
+      PALATINE_SKILLS_PRIVATE_KEY: ${{ secrets.PALATINE_SKILLS_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- pin the instruction-file audit caller to public-workflows `522f02d44dc72b199da3d6b8db755fe3aeabff1d` (`v2.19.2`)
- forward `PALATINE_SKILLS_APP_ID` and `PALATINE_SKILLS_PRIVATE_KEY` instead of `RUBRIC_TOKEN`

Linear: ENG-7621